### PR TITLE
Adjust some speed behavior in BDModulePilotAI.cs

### DIFF
--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -1133,7 +1133,7 @@ namespace BDArmory.Modules
             if (targetDot > 0)
             {
                 finalMaxSpeed = Mathf.Max((distanceToTarget - 100) / 8, 0) + (float)v.srfSpeed;
-                finalMaxSpeed = Mathf.Max(finalMaxSpeed, minSpeed + 25f);
+                finalMaxSpeed = Mathf.Max(finalMaxSpeed, minSpeed);
             }
             AdjustThrottle(finalMaxSpeed, true);
 
@@ -1245,10 +1245,9 @@ namespace BDArmory.Modules
             }
 
             //slow down for tighter turns
-            float velAngleToTarget = Vector3.Angle(targetPosition - vesselTransform.position, vessel.Velocity());
-            float normVelAngleToTarget = Mathf.Clamp(velAngleToTarget, 0, 90) / 90;
+            float velAngleToTarget = Mathf.Clamp(Vector3.Angle(targetPosition - vesselTransform.position, vessel.Velocity()), 0, 90);
             float speedReductionFactor = 1.25f;
-            float finalSpeed = Mathf.Min(speedController.targetSpeed, Mathf.Clamp(maxSpeed - (speedReductionFactor * normVelAngleToTarget), idleSpeed, maxSpeed));
+            float finalSpeed = Mathf.Min(speedController.targetSpeed, Mathf.Clamp(maxSpeed - (speedReductionFactor * velAngleToTarget), idleSpeed, maxSpeed));
             debugString.Append($"Final Target Speed: {finalSpeed}");
             debugString.Append(Environment.NewLine);
             AdjustThrottle(finalSpeed, useBrakes, useAB);
@@ -1549,6 +1548,7 @@ namespace BDArmory.Modules
 
                             debugString.Append($" from directly behind and close; breaking hard");
                             steerMode = SteerModes.Aiming;
+                            AdjustThrottle(minSpeed, true, false); // Brake to slow down and turn faster while breaking target
                         }
                     }
                     else


### PR DESCRIPTION
1. In FlyToPosition the finalSpeed variable was a function of (maxSpeed-1.25*normVelAngleToTarget), which since normVelAngleToTarget only varied between 0 and 1 this was probably not functioning as intended. Removing the normalization gives speeds between 212.5 and 325 for a default maxSpeed of 325 m/s.
2. Added an AdjustThrottle call to brake to minSpeed for evasion scenarios when the enemy is directly behind and closer than 400m.
3. Changed finalMaxSpeed = Mathf.Max(finalMaxSpeed, minSpeed + 25f); to finalMaxSpeed = Mathf.Max(finalMaxSpeed, minSpeed); for when craft is close to an enemy. The addition of +25 is unintuitive for players' understanding of what the minSpeed does.