### PR TITLE
Update Threat Vessel Checking in RadarUtils

### DIFF
--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -914,7 +914,8 @@ namespace BDArmory.Radar
                                         if (Vector3.Dot(weapon.Current.fireTransforms[0].forward, vesselDirection) > 0) continue;
 
                                         if ((Vector3.Angle(weapon.Current.fireTransforms[0].forward, -predictedRelativeDirection) < 6500 / vesselDistance)
-                                            && (!results.firingAtMe || (weapon.Current.vessel.ReferenceTransform.position - position).sqrMagnitude < (results.threatPosition - position).sqrMagnitude))
+                                            && (!results.firingAtMe || (weapon.Current.vessel.ReferenceTransform.position - position).sqrMagnitude < (results.threatPosition - position).sqrMagnitude)
+                                            && (weapon.Current.weaponManager.currentTarget.Vessel == myWpnManager.vessel))
                                         {
                                             results.firingAtMe = true;
                                             results.threatPosition = weapon.Current.vessel.transform.position;


### PR DESCRIPTION
Revisions to the segment below to make sure we're actually being targeted by the threat instead of someone else:

EXISTING:
if ((Vector3.Angle(weapon.Current.fireTransforms[0].forward, -predictedRelativeDirection) < 6500 / vesselDistance) && // Threat vessel is facing in our general direction
(!results.firingAtMe || // We haven't already picked a vessel as the threat OR
(weapon.Current.vessel.ReferenceTransform.position - position).sqrMagnitude < (results.threatPosition - position).sqrMagnitude) // New threat vessel is closer than previous threat vessel

ADD:
&& (weapon.Current.weaponManager.currentTarget.Vessel == myWpnManager.vessel)) // New threat vessel is actually targeting us and not someone else