### PR TITLE
Distance Threshold-Based Evading

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -144,6 +144,7 @@ Localization
 		#LOC_BDArmory_maxAllowedAoA = Max AoA
 		#LOC_BDArmory_ExtendMultiplier = Extend Multiplier
 		#LOC_BDArmory_EvasionMultiplier = Evasion Multiplier
+		#LOC_BDArmory_EvasionThreshold = Evasion Threshold
 		#LOC_BDArmory_Orbit = Orbit\u0020
 		#LOC_BDArmory_Orbit_enabledText = Starboard (CW)
 		#LOC_BDArmory_Orbit_disabledText = Port (CCW)

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -144,7 +144,7 @@ Localization
 		#LOC_BDArmory_maxAllowedAoA = Max AoA
 		#LOC_BDArmory_ExtendMultiplier = Extend Multiplier
 		#LOC_BDArmory_EvasionMultiplier = Evasion Multiplier
-		#LOC_BDArmory_EvasionThreshold = Evasion Threshold
+		#LOC_BDArmory_EvasionThreshold = Evasion Distance Threshold
 		#LOC_BDArmory_Orbit = Orbit\u0020
 		#LOC_BDArmory_Orbit_enabledText = Starboard (CW)
 		#LOC_BDArmory_Orbit_disabledText = Port (CCW)

--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -938,6 +938,8 @@ namespace BDArmory.Modules
 
                 // Find vertical component of aiming angle
                 float angleThreat = Mathf.Pow((1 - Mathf.Pow(targetCosAngle, 2f)), 0.5f);
+                if (float.IsNaN(angleThreat)) // Turrets will return NaN if they don't have a firing solution
+                    angleThreat = 1;
 
                 // Find distance to threat
                 threatRelativePosition = weaponManager.incomingThreatPosition - vesselTransform.position;

--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -1181,7 +1181,7 @@ namespace BDArmory.Modules
             if (targetDot > 0)
             {
                 finalMaxSpeed = Mathf.Max((distanceToTarget - 100) / 8, 0) + (float)v.srfSpeed;
-                finalMaxSpeed = Mathf.Max(finalMaxSpeed, minSpeed );
+                finalMaxSpeed = Mathf.Max(finalMaxSpeed, minSpeed);
             }
             AdjustThrottle(finalMaxSpeed, true);
 
@@ -1293,10 +1293,9 @@ namespace BDArmory.Modules
             }
 
             //slow down for tighter turns
-            float velAngleToTarget = Vector3.Angle(targetPosition - vesselTransform.position, vessel.Velocity());
-            float normVelAngleToTarget = Mathf.Clamp(velAngleToTarget, 0, 90); // This also seems wrong / 90;
+            float velAngleToTarget = Mathf.Clamp(Vector3.Angle(targetPosition - vesselTransform.position, vessel.Velocity()), 0, 90);
             float speedReductionFactor = 1.25f;
-            float finalSpeed = Mathf.Min(speedController.targetSpeed, Mathf.Clamp(maxSpeed - (speedReductionFactor * normVelAngleToTarget), idleSpeed, maxSpeed));
+            float finalSpeed = Mathf.Min(speedController.targetSpeed, Mathf.Clamp(maxSpeed - (speedReductionFactor * velAngleToTarget), idleSpeed, maxSpeed));
             debugString.Append($"Final Target Speed: {finalSpeed}");
             debugString.Append(Environment.NewLine);
             AdjustThrottle(finalSpeed, useBrakes, useAB);
@@ -1588,7 +1587,7 @@ namespace BDArmory.Modules
                             }
                         }
                         else
-                        { // This set breakTarget to the attackers position, then applies an up to 500m offset to the right or left (relative to the vessel) for the first half of the default evading period, then sets the breakTarget to be 150m right or left of the attacker.
+                        { // This sets breakTarget to the attackers position, then applies an up to 500m offset to the right or left (relative to the vessel) for the first half of the default evading period, then sets the breakTarget to be 150m right or left of the attacker.
                             breakTarget = threatRelativePosition;
                             if (evasiveTimer < 1.5f * evasionMult)
                                 breakTarget += Mathf.Sin((float)vessel.missionTime * 2) * vesselTransform.right * 500;

--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -747,23 +747,17 @@ namespace BDArmory.Modules
             }
 
             // Calculate threat rating from any threats
-            if (evasiveTimer > 0 || (weaponManager && evasionMult > 0f && !ramming && (weaponManager.missileIsIncoming || weaponManager.isChaffing || weaponManager.isFlaring || weaponManager.underFire))) // Don't evade while ramming.            {
+            if (weaponManager)
             {
-                if (evasiveTimer < 3f * evasionMult)
-                {
-                    if (weaponManager)
-                    {
-                        threatRating = 0f; // Allow entering evasion code if we're under missile fire
+                threatRating = 0f; // Allow entering evasion code if we're under missile fire
 
-                        if (weaponManager.underFire && weaponManager.incomingWeaponManager != null)
-                        {
-                            threatRating = ThreatRating();
-                        }
-                    }
+                if (weaponManager.underFire && weaponManager.incomingWeaponManager != null && !ramming)
+                {
+                    threatRating = ThreatRating();
                 }
             }
 
-            if (evasiveTimer > 0 || (weaponManager && evasionMult > 0f && threatRating < evasionThreshold && !ramming && (weaponManager.missileIsIncoming || weaponManager.isChaffing || weaponManager.isFlaring || weaponManager.underFire))) // Don't evade while ramming.            {
+            if (evasiveTimer > 0 || (weaponManager && evasionMult > 0f && threatRating < evasionThreshold && (weaponManager.missileIsIncoming || weaponManager.isChaffing || weaponManager.isFlaring || (weaponManager.underFire && !ramming)))) // Don't evade while ramming.            {
             {
                 if (evasiveTimer < 3f * evasionMult)
                 {

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -346,6 +346,7 @@ namespace BDArmory.Modules
 
         public Vector3 incomingThreatPosition;
         public Vessel incomingThreatVessel;
+        public MissileFire incomingWeaponManager;
 
         bool guardFiringMissile;
         bool disabledRocketAimers;
@@ -4006,6 +4007,7 @@ namespace BDArmory.Modules
         {
             ViewScanResults results = RadarUtils.GuardScanInDirection(this, transform, guardAngle, guardRange);
             incomingThreatVessel = null;
+            incomingWeaponManager = null;
 
             if (results.foundMissile)
             {
@@ -4084,6 +4086,7 @@ namespace BDArmory.Modules
                 }
                 if (results.threatWeaponManager != null)
                 {
+                    incomingWeaponManager = results.threatWeaponManager;
                     TargetInfo nearbyFriendly = BDATargetManager.GetClosestFriendly(this);
                     TargetInfo nearbyThreat = BDATargetManager.GetTargetFromWeaponManager(results.threatWeaponManager);
 


### PR DESCRIPTION
Add threatRating, which corresponds to the distance between the enemy craft's current aim point and its desired aim point (in other words, how much distance it will miss its shots by). 

Added evasionThreshold, a user-defined distance threshold set to 175m by default. If threatRating  < evasionThreshold, the craft can enter the evasion routine, otherwise it will not evade.