### PR TITLE
Fix for craft evading when they shouldn't

### DIFF
--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -12,7 +12,6 @@ using BDArmory.Misc;
 using BDArmory.Targeting;
 using BDArmory.UI;
 using Expansions.Missions;
-using KSP.UI;
 using KSP.UI.Screens;
 using Smooth.Algebraics;
 using UnityEngine;

--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -748,7 +748,6 @@ namespace BDArmory.Modules
             }
 
             // Calculate threat rating from any threats
-            threatRating = evasionThreshold + 1f; // Don't evade by default
             if (weaponManager && (weaponManager.missileIsIncoming || weaponManager.isChaffing || weaponManager.isFlaring))
                 threatRating = 0f; // Allow entering evasion code if we're under missile fire
             else if(weaponManager.underFire && weaponManager.incomingWeaponManager != null && !ramming)
@@ -951,7 +950,7 @@ namespace BDArmory.Modules
             else
             {
                 // Debug.Log("[BDArmoryCompetition]: No threat to " + vessel.name);
-                return evasionThreshold + 1f;
+                return evasionThreshold + 1f; // Don't evade by default
             }
         }
 

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -95,7 +95,7 @@ namespace BDArmory.Modules
         private Vector3 targetVelocityPrevious; // for acceleration calculation
         private Vector3 targetAccelerationPrevious;
         private Vector3 relativeVelocity;
-        Vector3 finalAimTarget;
+        public Vector3 finalAimTarget;
         Vector3 lastFinalAimTarget;
         public Vessel visualTargetVessel;
         bool targetAcquired;


### PR DESCRIPTION
Set evasion to off by default except when:
1. Incoming missiles
2. Enemy guns have a valid firing firing solution within our evasion threshold.

Improved accuracy of angle/distance calculations.

Feel free to delete debugging statements