### PR TITLE
Miss distance based evasion

### DIFF
--- a/BDArmory/Misc/ViewScanResults.cs
+++ b/BDArmory/Misc/ViewScanResults.cs
@@ -10,6 +10,7 @@ namespace BDArmory.Misc
         public bool foundRadarMissile;
         public bool foundAGM;
         public bool firingAtMe;
+        public float missDistance;
         public float missileThreatDistance;
         public Vector3 threatPosition;
         public Vessel threatVessel;

--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -749,7 +749,7 @@ namespace BDArmory.Modules
             // Calculate threat rating from any threats
             if (weaponManager && (weaponManager.missileIsIncoming || weaponManager.isChaffing || weaponManager.isFlaring))
                 threatRating = 0f; // Allow entering evasion code if we're under missile fire
-            else if (weaponManager.underFire && weaponManager.incomingWeaponManager != null && !ramming)
+            else if (weaponManager.underFire && !ramming)
                 threatRating = weaponManager.incomingMissDistance; // If we're ramming, ignore gunfire.
             else
                 threatRating = evasionThreshold + 1f; // Don't evade by default

--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -749,16 +749,16 @@ namespace BDArmory.Modules
             // Calculate threat rating from any threats
             if (weaponManager && (weaponManager.missileIsIncoming || weaponManager.isChaffing || weaponManager.isFlaring))
                 threatRating = 0f; // Allow entering evasion code if we're under missile fire
-            else if(weaponManager.underFire && weaponManager.incomingWeaponManager != null && !ramming)
-                threatRating = ThreatRating(); // If we're ramming, ignore gunfire.
+            else if (weaponManager.underFire && weaponManager.incomingWeaponManager != null && !ramming)
+                threatRating = weaponManager.incomingMissDistance; // If we're ramming, ignore gunfire.
             else
                 threatRating = evasionThreshold + 1f; // Don't evade by default
 
-            // if (threatRating < evasionThreshold)
-                // Debug.Log("[BDArmoryCompetition]: Threat to " + vessel.name + " is:" + threatRating);
+            debugString.Append($"Threat Rating: {threatRating}");
+            debugString.Append(Environment.NewLine);
 
             // If we're currently evading or a threat is significant and we're not ramming.
-            if (evasiveTimer > 0 || (evasionMult > 0f && threatRating < evasionThreshold))
+            if ((evasionMult > 0f && threatRating < evasionThreshold))
             {
                 if (evasiveTimer < 3f * evasionMult)
                 {
@@ -918,39 +918,6 @@ namespace BDArmory.Modules
 
             badDirection = Vector3.zero;
             return false;
-        }
-
-        float ThreatRating() // Returns how far away bullets from enemy are from craft in meters
-        {
-            if (weaponManager.incomingWeaponManager.currentGun != null)
-            {
-                var threat_weapon = weaponManager.incomingWeaponManager.currentGun; // Threat vessel weapon
-
-                // Stolen from CheckAIAutofire(), ModuleWeapon.cs
-                Transform fireTransform = threat_weapon.fireTransforms[0];
-                Vector3 aimDirection = fireTransform.forward;
-                float targetCosAngle = threat_weapon.FiringSolutionVector != null ? Vector3.Dot(aimDirection, (Vector3)threat_weapon.FiringSolutionVector) : 0f; // If the weapon doesn't have a firing solution, set the angleThreat to 1.
-
-                // Find vertical component of aiming angle
-                float angleThreat = Mathf.Sin(Mathf.Acos(targetCosAngle));
-
-                // Calculate distance between incoming threat position and its aimpoint (or self position)
-                float distanceThreat = threat_weapon.finalAimTarget != null ? Vector3.Magnitude(threat_weapon.finalAimTarget - weaponManager.incomingThreatPosition) : Vector3.Magnitude(vesselTransform.position - weaponManager.incomingThreatPosition);
-
-                // For debugging
-                if ((angleThreat * distanceThreat) < evasionThreshold)
-                {
-                    // Debug.Log("[BDArmoryCompetition]: Threat to " + vessel.name + " from " + weaponManager.incomingThreatVessel.name + " is:");
-                    // Debug.Log("     ANGLE: " + Mathf.Asin(angleThreat) / Mathf.PI * 180 + "  DISTANCE: " + distanceThreat + "  RATING: " + angleThreat * distanceThreat);
-                }
-
-                return angleThreat * distanceThreat; // Calculate aiming arc length (how far away the bullets will travel)
-            }
-            else
-            {
-                // Debug.Log("[BDArmoryCompetition]: No threat to " + vessel.name);
-                return evasionThreshold + 1f; // Don't evade by default
-            }
         }
 
         public float ClosestTimeToCPA(Vessel v, float maxTime)

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -347,6 +347,7 @@ namespace BDArmory.Modules
         public Vector3 incomingThreatPosition;
         public Vessel incomingThreatVessel;
         public MissileFire incomingWeaponManager;
+        public float incomingMissDistance;
 
         bool guardFiringMissile;
         bool disabledRocketAimers;
@@ -4087,6 +4088,7 @@ namespace BDArmory.Modules
                 if (results.threatWeaponManager != null)
                 {
                     incomingWeaponManager = results.threatWeaponManager;
+                    incomingMissDistance = results.missDistance;
                     TargetInfo nearbyFriendly = BDATargetManager.GetClosestFriendly(this);
                     TargetInfo nearbyThreat = BDATargetManager.GetTargetFromWeaponManager(results.threatWeaponManager);
 

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -943,8 +943,7 @@ namespace BDArmory.Radar
             float targetCosAngle = threatWeapon.FiringSolutionVector != null ? Vector3.Dot(aimDirection, (Vector3)threatWeapon.FiringSolutionVector) : Vector3.Dot(aimDirection, (self.vesselTransform.position - threatWeapon.vessel.vesselTransform.position).normalized);
 
             // Find vertical component of aiming angle
-            targetCosAngle = Mathf.Clamp(targetCosAngle, 0, 1); // Treat angles beyond 90 deg as 90 deg
-            float angleThreat = Mathf.Sin(Mathf.Acos(targetCosAngle));
+            float angleThreat = targetCosAngle < 0 ? float.MaxValue : Mathf.Sin(Mathf.Acos(targetCosAngle));  // Treat angles beyond 90 degrees as not a threat
             
             // Calculate distance between incoming threat position and its aimpoint (or self position)
             float distanceThreat = threatWeapon.finalAimTarget != null ? Vector3.Magnitude(threatWeapon.finalAimTarget - threatWeapon.vessel.transform.position) : Vector3.Magnitude(self.vesselTransform.position - threatWeapon.vessel.transform.position);

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -824,6 +824,7 @@ namespace BDArmory.Radar
                 foundRadarMissile = false,
                 foundAGM = false,
                 firingAtMe = false,
+		missDistance = null,
                 missileThreatDistance = float.MaxValue,
                 threatVessel = null,
                 threatWeaponManager = null

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -940,7 +940,7 @@ namespace BDArmory.Radar
             // If we have a firing solution, use that, otherwise use relative vessel positions
             Transform fireTransform = threatWeapon.fireTransforms[0];
             Vector3 aimDirection = fireTransform.forward;
-            float targetCosAngle = threatWeapon.FiringSolutionVector != null ? Vector3.Dot(aimDirection, (Vector3)threatWeapon.FiringSolutionVector) : Vector3.Dot(aimDirection, (self.vesselTransform.position - threatWeapon.vessel.vesselTransform.position).normalized);
+            float targetCosAngle = threatWeapon.FiringSolutionVector != null ? Vector3.Dot(aimDirection, (Vector3)threatWeapon.FiringSolutionVector) : Vector3.Dot(threatWeapon.vessel.vesselTransform.up, (self.vesselTransform.position - threatWeapon.vessel.vesselTransform.position).normalized);
 
             // Find vertical component of aiming angle
             float angleThreat = targetCosAngle < 0 ? float.MaxValue : Mathf.Sqrt(1 - targetCosAngle * targetCosAngle);  // Treat angles beyond 90 degrees as not a threat

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -943,7 +943,7 @@ namespace BDArmory.Radar
             float targetCosAngle = threatWeapon.FiringSolutionVector != null ? Vector3.Dot(aimDirection, (Vector3)threatWeapon.FiringSolutionVector) : Vector3.Dot(aimDirection, (self.vesselTransform.position - threatWeapon.vessel.vesselTransform.position).normalized);
 
             // Find vertical component of aiming angle
-            float angleThreat = targetCosAngle < 0 ? float.MaxValue : Mathf.Sin(Mathf.Acos(targetCosAngle));  // Treat angles beyond 90 degrees as not a threat
+            float angleThreat = targetCosAngle < 0 ? float.MaxValue : Mathf.Sqrt(1 - targetCosAngle * targetCosAngle);  // Treat angles beyond 90 degrees as not a threat
             
             // Calculate distance between incoming threat position and its aimpoint (or self position)
             float distanceThreat = threatWeapon.finalAimTarget != null ? Vector3.Magnitude(threatWeapon.finalAimTarget - threatWeapon.vessel.transform.position) : Vector3.Magnitude(self.vesselTransform.position - threatWeapon.vessel.transform.position);


### PR DESCRIPTION
Updated RadarUtils.cs to calculate estimated bullet miss distance. Threats will be prioritized based on this distance (if they are not a missile). 

Updated BDModulePilotAI.cs to remove evasion timer as a condition for entering evasion. Whether or not the craft evades will solely be based on the miss distance calculated in RadarUtils.cs.