### PR TITLE
Fix Spelling Error on Weapon Manager

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -222,7 +222,7 @@ Localization
 		#LOC_BDArmory_VisualRange = Visual Range
 		#LOC_BDArmory_GunsRange = Guns Range
 		#LOC_BDArmory_MissilesORTarget = Missiles/Target
-		#LOC_BDArmory_GaurdMode = Gaurd Mode:\u0020
+		#LOC_BDArmory_GuardMode = Guard Mode:\u0020
 		#LOC_BDArmory_Team = Team
 		#LOC_BDArmory_Weapon = Weapon
 		#LOC_BDArmory_Direction = Direction:\u0020

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -417,7 +417,7 @@ namespace BDArmory.Modules
 
         //[KSPField(isPersistant = true)] public bool guardMode;
 
-        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false, guiName = "#LOC_BDArmory_GaurdMode"),//Gaurd Mode: 
+        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false, guiName = "#LOC_BDArmory_GuardMode"),//Guard Mode: 
             UI_Toggle(disabledText = "OFF", enabledText = "ON")]
         public bool guardMode;
 


### PR DESCRIPTION
Change "Gaurd" to "Guard" on the Weapon Manager UI