### PR TITLE
Add Option to Disable Kill Timer and Don't Disable Guard Mode on Tanks

### DIFF
--- a/BDArmory.Core/BDArmorySettings.cs
+++ b/BDArmory.Core/BDArmorySettings.cs
@@ -62,5 +62,6 @@ namespace BDArmory.Core
         [BDAPersistantSettingsField] public static bool SHOW_CATEGORIES = false;
         [BDAPersistantSettingsField] public static int TERRAIN_ALERT_FREQUENCY = 1;               // Controls how often terrain avoidance checks are made (gets scaled by 1+(radarAltitude/500)^2)
         [BDAPersistantSettingsField] public static bool DEBUG_RAMMING_LOGGING = false;                // Controls whether ramming logging debug information is printed to the Debug.Log
+        [BDAPersistantSettingsField] public static bool DISABLE_KILL_TIMER = false;                 //disables the kill timers.
     }
 }

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -1289,6 +1289,7 @@ namespace BDArmory.Control
                         if (!BDArmorySettings.INFINITE_AMMO)
                         {
                             var pilotAI = v.Current.FindPartModuleImplementing<BDModulePilotAI>(); // Get the pilot AI if the vessel has one.
+                            var surfaceAI = v.Current.FindPartModuleImplementing<BDModuleSurfaceAI>(); // Get the surface AI if the vessel has one.
                             if (pilotAI != null && pilotAI.outOfAmmo && !outOfAmmo.Contains(vesselName)) // Report being out of ammo/guns once.
                             {
                                 outOfAmmo.Add(vesselName);

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -55,6 +55,7 @@ Localization
 		#LOC_BDArmory_Settings_ShellCollisions = Shell Collisions
 		#LOC_BDArmory_Settings_BulletHoleDecals = Bullet Hole Decals
 		#LOC_BDArmory_Settings_PerformanceLogging = Performance Logging
+		#LOC_BDArmory_Settings_DisableKillTimer = Disable Kill Timer
 		#LOC_BDArmory_Settings_ShowEditorSubcategories = Show Editor Subcategories
 		#LOC_BDArmory_Settings_AutocategorizeParts = Autocategorize Parts
 		#LOC_BDArmory_Settings_MaxBulletHoles = Max Bullet Holes

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1400,6 +1400,7 @@ namespace BDArmory.UI
             BDArmorySettings.FFA_COMBAT_STYLE = GUI.Toggle(SLeftRect(line), BDArmorySettings.FFA_COMBAT_STYLE, Localizer.Format("#LOC_BDArmory_Settings_FFACombatStyle"));// Free-for-all combat style
             BDArmorySettings.DEBUG_RAMMING_LOGGING = GUI.Toggle(SRightRect(line), BDArmorySettings.DEBUG_RAMMING_LOGGING, Localizer.Format("#LOC_BDArmory_Settings_DebugRammingLogging"));// Disable Ramming
             line++;
+            BDArmorySettings.DISABLE_KILL_TIMER = GUI.Toggle(SLeftRect(line), BDArmorySettings.DISABLE_KILL_TIMER, Localizer.Format("#LOC_BDArmory_Settings_DisableKillTimer"));//"Disable Kill Timer"
             BDArmorySettings.PERFORMANCE_LOGGING = GUI.Toggle(SLeftRect(line), BDArmorySettings.PERFORMANCE_LOGGING, Localizer.Format("#LOC_BDArmory_Settings_PerformanceLogging"));//"Performance Logging"
             line++;
             if (HighLogic.LoadedSceneIsEditor)

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1400,8 +1400,8 @@ namespace BDArmory.UI
             BDArmorySettings.FFA_COMBAT_STYLE = GUI.Toggle(SLeftRect(line), BDArmorySettings.FFA_COMBAT_STYLE, Localizer.Format("#LOC_BDArmory_Settings_FFACombatStyle"));// Free-for-all combat style
             BDArmorySettings.DEBUG_RAMMING_LOGGING = GUI.Toggle(SRightRect(line), BDArmorySettings.DEBUG_RAMMING_LOGGING, Localizer.Format("#LOC_BDArmory_Settings_DebugRammingLogging"));// Disable Ramming
             line++;
-            BDArmorySettings.DISABLE_KILL_TIMER = GUI.Toggle(SLeftRect(line), BDArmorySettings.DISABLE_KILL_TIMER, Localizer.Format("#LOC_BDArmory_Settings_DisableKillTimer"));//"Disable Kill Timer"
             BDArmorySettings.PERFORMANCE_LOGGING = GUI.Toggle(SLeftRect(line), BDArmorySettings.PERFORMANCE_LOGGING, Localizer.Format("#LOC_BDArmory_Settings_PerformanceLogging"));//"Performance Logging"
+            BDArmorySettings.DISABLE_KILL_TIMER = GUI.Toggle(SRightRect(line), BDArmorySettings.DISABLE_KILL_TIMER, Localizer.Format("#LOC_BDArmory_Settings_DisableKillTimer"));//"Disable Kill Timer"
             line++;
             if (HighLogic.LoadedSceneIsEditor)
             {


### PR DESCRIPTION
Add checks to BDACompetitionMode.cs to not kill of craft or debris if the "Disable Kill Timer" setting is checked. Also guard mode will no longer be disabled on craft equipped with a surface AI module.