### PR TITLE
Use Body Gravity Instead of 9.81 m/s^2

### DIFF
--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -14,6 +14,7 @@ using BDArmory.UI;
 using Expansions.Missions;
 using KSP.UI.Screens;
 using Smooth.Algebraics;
+using Steamworks;
 using UnityEngine;
 
 namespace BDArmory.Modules
@@ -316,6 +317,7 @@ namespace BDArmory.Modules
         //instantaneous turn radius and possible acceleration from lift
         //properties can be used so that other AI modules can read this for future maneuverability comparisons between craft
         float turnRadius;
+        float bodyGravity = 9.80665f; // Equivalent to (float)PhysicsGlobals.GravitationalAcceleration
 
         public float TurnRadius
         {
@@ -575,6 +577,8 @@ namespace BDArmory.Modules
             prevTargetDir = vesselTransform.up;
             if (initialTakeOff && !vessel.LandedOrSplashed) // In case we activate pilot after taking off manually.
                 initialTakeOff = false;
+
+            bodyGravity = 9.80665f * (float)vessel.orbit.referenceBody.GeeASL; // Set gravity for calculations;
         }
 
         void Update()
@@ -1031,7 +1035,7 @@ namespace BDArmory.Modules
                             {
                                 //figuring how much to lead the target's movement to get there after its movement assuming we can manage a constant speed turn
                                 //this only runs if we're not aiming and not that far from the target and the target is in front of us
-                                float curVesselMaxAccel = Math.Min(dynDynPresGRecorded * (float)vessel.dynamicPressurekPa, maxAllowedGForce * 9.81f);
+                                float curVesselMaxAccel = Math.Min(dynDynPresGRecorded * (float)vessel.dynamicPressurekPa, maxAllowedGForce * bodyGravity);
                                 if (curVesselMaxAccel > 0)
                                 {
                                     float timeToTurn = (float)vessel.srfSpeed * angleToTarget * Mathf.Deg2Rad / curVesselMaxAccel;
@@ -1926,7 +1930,7 @@ namespace BDArmory.Modules
 
             float invVesselDynPreskPa = 1f / (float)vessel.dynamicPressurekPa;
 
-            maxCosAoA = maxAllowedGForce * 9.81f * invVesselDynPreskPa;
+            maxCosAoA = maxAllowedGForce * bodyGravity * invVesselDynPreskPa;
             minCosAoA = -maxCosAoA;
 
             maxCosAoA -= gOffsetPerDynPres;
@@ -2017,7 +2021,7 @@ namespace BDArmory.Modules
             negLim = negPitchDynPresLimitIntegrator * invVesselDynPreskPa + negPitchDynPresLimit;
             if (negLim > s.pitch)
             {
-                if (currentG > -(maxAllowedGForce * 0.97f * 9.81f))
+                if (currentG > -(maxAllowedGForce * 0.97f * bodyGravity))
                 {
                     negPitchDynPresLimitIntegrator -= (float)(0.15 * vessel.dynamicPressurekPa);        //jsut an override in case things break
 
@@ -2037,7 +2041,7 @@ namespace BDArmory.Modules
             posLim = posPitchDynPresLimitIntegrator * invVesselDynPreskPa + posPitchDynPresLimit;
             if (posLim < s.pitch)
             {
-                if (currentG < (maxAllowedGForce * 0.97f * 9.81f))
+                if (currentG < (maxAllowedGForce * 0.97f * bodyGravity))
                 {
                     posPitchDynPresLimitIntegrator += (float)(0.15 * vessel.dynamicPressurekPa);        //jsut an override in case things break
 
@@ -2068,7 +2072,7 @@ namespace BDArmory.Modules
         {
             maxLiftAcceleration = dynDynPresGRecorded * (float)vessel.dynamicPressurekPa; //maximum acceleration from lift that the vehicle can provide
 
-            maxLiftAcceleration = Mathf.Clamp(maxLiftAcceleration, 9.81f, maxAllowedGForce * 9.81f); //limit it to whichever is smaller, what we can provide or what we can handle. Assume minimum of 1G to avoid extremely high turn radiuses.
+            maxLiftAcceleration = Mathf.Clamp(maxLiftAcceleration, bodyGravity, maxAllowedGForce * bodyGravity); //limit it to whichever is smaller, what we can provide or what we can handle. Assume minimum of 1G to avoid extremely high turn radiuses.
 
             turnRadius = dynMaxVelocityMagSqr / maxLiftAcceleration; //radius that we can turn in assuming constant velocity, assuming simple circular motion (this is a terrible assumption, the AI usually turns on afterboosters!)
         }

--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -14,7 +14,6 @@ using BDArmory.UI;
 using Expansions.Missions;
 using KSP.UI.Screens;
 using Smooth.Algebraics;
-using Steamworks;
 using UnityEngine;
 
 namespace BDArmory.Modules


### PR DESCRIPTION
Update calculations in BDModulePilotAI to use the gravity of the reference body, and not Kerbin's gravity.