### PR TITLE
Use AG10 instead of AG1 on Competition Start

### DIFF
--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -329,7 +329,7 @@ namespace BDArmory.Control
 
             foreach (var pilot in readyToLaunch)
             {
-                pilot.vessel.ActionGroups.ToggleGroup(KM_dictAG[1]);
+                pilot.vessel.ActionGroups.ToggleGroup(KM_dictAG[10]); // Modular Missiles use lower AGs (1-3) for staging, use a high AG number to not affect them
                 pilot.CommandTakeOff();
                 if (pilot.weaponManager.guardMode)
                 {


### PR DESCRIPTION
Modular Missiles always use AG1 on launch, they sometimes use AG2, AG3, etc. if they have multiple stages. Let's use AG10 on competition start to not affect them.