### PR TITLE
Don't climb while extending against aerial targets and user-editable camera switch setting

### DIFF
--- a/BDArmory.Core/BDArmorySettings.cs
+++ b/BDArmory.Core/BDArmorySettings.cs
@@ -68,6 +68,7 @@ namespace BDArmory.Core
         [BDAPersistantSettingsField] public static bool AUTOCATEGORIZE_PARTS = true;
         [BDAPersistantSettingsField] public static bool SHOW_CATEGORIES = true;
         [BDAPersistantSettingsField] public static int TERRAIN_ALERT_FREQUENCY = 1;               // Controls how often terrain avoidance checks are made (gets scaled by 1+(radarAltitude/500)^2)
+        [BDAPersistantSettingsField] public static int CAMERA_SWITCH_FREQUENCY = 3;               // Controls the minimum time between automated camera switches
         [BDAPersistantSettingsField] public static float OUT_OF_AMMO_KILL_TIME = -1f;            // Out of ammo kill timer for continuous spawn mode.
         [BDAPersistantSettingsField] public static bool DEBUG_RAMMING_LOGGING = false;            // Controls whether ramming logging debug information is printed to the Debug.Log
         [BDAPersistantSettingsField] public static bool REMOTE_LOGGING_ENABLED = false;           // Enable/disable remote orchestration

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -60,6 +60,7 @@ Localization
 		#LOC_BDArmory_Settings_AutocategorizeParts = Autocategorize Parts
 		#LOC_BDArmory_Settings_MaxBulletHoles = Max Bullet Holes
 		#LOC_BDArmory_Settings_TerrainAlertFrequency = Terrain Check Frequency
+		#LOC_BDArmory_Settings_CameraSwitchFrequency = Camera Switch Frequency
 		#LOC_BDArmory_Settings_OutOfAmmoKillTime = Out Of Ammo Kill Time
 		#LOC_BDArmory_Settings_PeaceMode = Peace Mode
 		#LOC_BDArmory_Settings_DisableRamming = Disable Ramming

--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -1331,9 +1331,10 @@ namespace BDArmory.Modules
                     desiredMinAltitude = defaultAltitude;
                 }
 
-                if (targetVessel != null && !targetVessel.LandedOrSplashed) // We have a flying target, only extend a short distance.     //this is just asking for trouble at 800m
+                if (targetVessel != null && !targetVessel.LandedOrSplashed) // We have a flying target, only extend a short distance and don't climb.     //this is just asking for trouble at 800m
                 {
                     extendDistance = 300 * extendMult;
+                    desiredMinAltitude = minAltitude;
                 }
 
                 Vector3 srfVector = Vector3.ProjectOnPlane(vessel.transform.position - tPosition, upDirection);

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1461,6 +1461,13 @@ namespace BDArmory.UI
             terrainAlertFrequency = GUI.HorizontalSlider(SRightRect(line), terrainAlertFrequency, 1f, 5f);
             BDArmorySettings.TERRAIN_ALERT_FREQUENCY = (int)terrainAlertFrequency;
             line++;
+
+            GUI.Label(SLeftRect(line), $"{Localizer.Format("#LOC_BDArmory_Settings_CameraSwitchFrequency")}:  ({BDArmorySettings.CAMERA_SWITCH_FREQUENCY})", leftLabel); // Minimum camera switching frequency
+            float cameraSwitchFrequency = BDArmorySettings.CAMERA_SWITCH_FREQUENCY;
+            cameraSwitchFrequency = GUI.HorizontalSlider(SRightRect(line), cameraSwitchFrequency, 1f, 10f);
+            BDArmorySettings.CAMERA_SWITCH_FREQUENCY = (int)cameraSwitchFrequency;
+            line++;
+
             var outOfAmmoKillTimeStr = "never";
             if (BDArmorySettings.OUT_OF_AMMO_KILL_TIME > -1 && BDArmorySettings.OUT_OF_AMMO_KILL_TIME < 60)
                 outOfAmmoKillTimeStr = BDArmorySettings.OUT_OF_AMMO_KILL_TIME.ToString("G0") + "s";

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -947,7 +947,7 @@ namespace BDArmory.UI
                         }
                     }
                 }
-                if (timeSinceChange > 3)
+                if (timeSinceChange > BDArmorySettings.CAMERA_SWITCH_FREQUENCY)
                 {
                     if (bestVessel != null && !(bestVessel.isActiveVessel)) // if a vessel dies it'll use a default score for a few seconds
                     {


### PR DESCRIPTION
Don't force the craft to climb when extending against an aerial target.