### PR TITLE
Remove SetTarget(null); that breaks FFA Target Hysteresis

### DIFF
--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -3924,7 +3924,6 @@ namespace BDArmory.Modules
                 if (!guardFiringMissile)
                 {
 
-                    SetTarget(null);
                     SmartFindTarget();
 
                     if (guardTarget == null || selectedWeapon == null)


### PR DESCRIPTION
Removed unnecessary SetTarget(null) call that unsets currentTarget, breaking the hysteresis logic in FFA Targeting. SmartFindTarget() will unset the currentTarget when a new target is found, which is why this call is unnecessary.