### PR TITLE
Fix craft not responding to multiple missile threats

### DIFF
--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -901,10 +901,6 @@ namespace BDArmory.Radar
                                             break;
                                         }
                                     }
-                                    else
-                                    {
-                                        break;
-                                    }
                                 }
                             }
                             else


### PR DESCRIPTION
Fix for major bug from 2015 that prevented craft from responding correctly to multiple missile threats. Prior to this, if a missile missed, but other missiles were inbound, it would ignore the inbound missiles and still focus on the missile that missed.