### PR TITLE
Add target mass priority setting

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -201,6 +201,7 @@ Localization
 		#LOC_BDArmory_TargetPriority_TargetAcceleration = Target Acceleration
 		#LOC_BDArmory_TargetPriority_ShorterClosingTime = Shorter Closing Time
 		#LOC_BDArmory_TargetPriority_TargetWeaponNumber = Target Weapon Number
+		#LOC_BDArmory_TargetPriority_TargetMass = Target Mass
 		#LOC_BDArmory_TargetPriority_FewerTeammatesEngaging = Fewer Teammates Engaging
 		#LOC_BDArmory_TargetPriority_TargetThreat = Target Threat
 		#LOC_BDArmory_TargetPriority_AngleOverDistance = Angle / Distance

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -440,6 +440,11 @@ namespace BDArmory.Modules
          UI_FloatRange(minValue = -10f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_Scene.All)]
         public float targetWeightWeaponNumber = 0;
 
+        private string targetMassLabel = Localizer.Format("#LOC_BDArmory_TargetPriority_TargetMass");
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_TargetPriority_TargetMass", advancedTweakable = true, groupName = "targetPriority", groupDisplayName = "#LOC_BDArmory_TargetPriority_Settings", groupStartCollapsed = true),//Target Mass
+         UI_FloatRange(minValue = -10f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_Scene.All)]
+        public float targetWeightMass = 0;
+
         private string targetFriendliesEngagingLabel = Localizer.Format("#LOC_BDArmory_TargetPriority_FewerTeammatesEngaging");
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_TargetPriority_FewerTeammatesEngaging", advancedTweakable = true, groupName = "targetPriority", groupDisplayName = "#LOC_BDArmory_TargetPriority_Settings", groupStartCollapsed = true),//Number Friendlies Engaging
          UI_FloatRange(minValue = -10f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_Scene.All)]
@@ -3301,6 +3306,7 @@ namespace BDArmory.Modules
             var TargetAccelFields = Fields["targetWeightAccel"];
             var TargetClosureTimeFields = Fields["targetWeightClosureTime"];
             var TargetWeaponNumberFields = Fields["targetWeightWeaponNumber"];
+            var TargetMassFields = Fields["targetWeighMass"];
             var TargetFriendliesEngagingFields = Fields["targetWeightFriendliesEngaging"];
             var TargetThreatFields = Fields["targetWeightThreat"];
 
@@ -3312,6 +3318,7 @@ namespace BDArmory.Modules
             float targetAccelValue = target.TargetPriAcceleration();
             float targetClosureTimeValue = target.TargetPriClosureTime(this);
             float targetWeaponNumberValue = target.TargetPriWeapons(target.weaponManager, this);
+            float targetMassValue = target.TargetPriMass(target.weaponManager, this);
             float targetFriendliesEngagingValue = target.TargetPriFriendliesEngaging(this);
             float targetThreatValue = target.TargetPriThreat(target.weaponManager, this);
 
@@ -3322,6 +3329,7 @@ namespace BDArmory.Modules
                 targetWeightAccel * targetAccelValue +
                 targetWeightClosureTime * targetClosureTimeValue +
                 targetWeightWeaponNumber * targetWeaponNumberValue +
+                targetWeightMass * targetMassValue +
                 targetWeightFriendliesEngaging * targetFriendliesEngagingValue +
                 targetWeightThreat * targetThreatValue +
                 targetWeightAoD * targetAoDValue);
@@ -3334,6 +3342,7 @@ namespace BDArmory.Modules
             TargetAccelFields.guiName = targetAccelLabel + ": " + targetAccelValue.ToString("0.00");
             TargetClosureTimeFields.guiName = targetClosureTimeLabel + ": " + targetClosureTimeValue.ToString("0.00");
             TargetWeaponNumberFields.guiName = targetWeaponNumberLabel + ": " + targetWeaponNumberValue.ToString("0.00");
+            TargetMassFields.guiName = targetMassLabel + ": " + targetMassValue.ToString("0.00");
             TargetFriendliesEngagingFields.guiName = targetFriendliesEngagingLabel + ": " + targetFriendliesEngagingValue.ToString("0.00");
             TargetThreatFields.guiName = targetThreatLabel + ": " + targetThreatValue.ToString("0.00");
 

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -3306,7 +3306,7 @@ namespace BDArmory.Modules
             var TargetAccelFields = Fields["targetWeightAccel"];
             var TargetClosureTimeFields = Fields["targetWeightClosureTime"];
             var TargetWeaponNumberFields = Fields["targetWeightWeaponNumber"];
-            var TargetMassFields = Fields["targetWeighMass"];
+            var TargetMassFields = Fields["targetWeightMass"];
             var TargetFriendliesEngagingFields = Fields["targetWeightFriendliesEngaging"];
             var TargetThreatFields = Fields["targetWeightThreat"];
 

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -353,6 +353,20 @@ namespace BDArmory.Targeting
             float theta = Vector3.Angle(myMF.vessel.srf_vel_direction, relativePosition);
             return Mathf.Clamp(((Mathf.Pow(Mathf.Cos(theta / 2f), 2f) + 1f) * 100f / Mathf.Max(10f, relativePosition.magnitude))/2, 0, 1); // Ranges from 0 to 1, clamped at 1 for distances closer than 100m
         }
+
+        public float TargetPriMass(MissileFire mf, MissileFire myMf) // Relative mass compared to our own mass
+        {
+            if (mf.vessel != null)
+            {
+                float targetMass = mf.vessel.GetTotalMass();
+                float myMass = myMf.vessel.GetTotalMass();
+                return Mathf.Clamp((targetMass - myMass) / myMass, -1, 1); // Ranges -1 to 1, -1 if we are 10 times as heavy as target, 1 target is 10 times as heavy as us
+            }
+            else
+            {
+                return 0;
+            }
+        }
         // End functions used for prioritizing targets
         #endregion
 

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -360,7 +360,7 @@ namespace BDArmory.Targeting
             {
                 float targetMass = mf.vessel.GetTotalMass();
                 float myMass = myMf.vessel.GetTotalMass();
-                return Mathf.Clamp(Mathf.Log10(targetMass / myMass), -1, 1); // Ranges -1 to 1, -1 if we are 10 times as heavy as target, 1 target is 10 times as heavy as us
+                return Mathf.Clamp(Mathf.Log10(targetMass / myMass)/2f, -1, 1); // Ranges -1 to 1, -1 if we are 100 times as heavy as target, 1 target is 100 times as heavy as us
             }
             else
             {

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -360,7 +360,7 @@ namespace BDArmory.Targeting
             {
                 float targetMass = mf.vessel.GetTotalMass();
                 float myMass = myMf.vessel.GetTotalMass();
-                return Mathf.Clamp((targetMass - myMass) / myMass, -1, 1); // Ranges -1 to 1, -1 if we are 10 times as heavy as target, 1 target is 10 times as heavy as us
+                return Mathf.Clamp(Mathf.Log10(targetMass / myMass), -1, 1); // Ranges -1 to 1, -1 if we are 10 times as heavy as target, 1 target is 10 times as heavy as us
             }
             else
             {

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -971,6 +971,7 @@ namespace BDArmory.UI
                             mf.targetWeightAccel * target.Current.TargetPriAcceleration() +
                             mf.targetWeightClosureTime * target.Current.TargetPriClosureTime(mf) +
                             mf.targetWeightWeaponNumber * target.Current.TargetPriWeapons(target.Current.weaponManager, mf) +
+                            mf.targetWeightMass * target.Current.TargetPriMass(target.Current.weaponManager, mf) +
                             mf.targetWeightFriendliesEngaging * target.Current.TargetPriFriendliesEngaging(mf) +
                             mf.targetWeightThreat * target.Current.TargetPriThreat(target.Current.weaponManager, mf) +
                             mf.targetWeightAoD * target.Current.TargetPriAoD(mf));


### PR DESCRIPTION
- Add target mass priority setting, varies from -1 (target is 100 times lighter) to 1 (target is 100 times heavier). Originally requested by KerbalPowers community in order to facilitate targeting a ship (1000+ tons) compared to detached ship "subsystems" (100+ tons).