### PR TITLE
RCS/ECM Fixes

### DIFF
--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -7,6 +7,7 @@ using BDArmory.Core;
 using BDArmory.Misc;
 using BDArmory.Modules;
 using BDArmory.Competition;
+using BDArmory.Radar;
 using BDArmory.UI;
 using UnityEngine;
 
@@ -371,6 +372,7 @@ namespace BDArmory.Control
             finalGracePeriodStart = -1;
             lastTagUpdateTime = competitionStartTime;
             Log("[BDArmoryCompetition:" + CompetitionID.ToString() + "]: Competition Started");
+            RadarUtils.ForceUpdateRadarCrossSections(); // Update RCS
         }
 
         public void ResetCompetitionScores()

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/ecmJammer/ecmj131.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/ecmJammer/ecmj131.cfg
@@ -56,7 +56,7 @@ MODULE
 	jammerStrength = 1200		// this is a factor (in relation to a vessels base radar cross section) how much the crafts DETECTABILITY is INCREASED(!) when the jammer is active
 
 	lockBreaker = true		// true: jammer serves to break radar locks (default: true)
-	lockBreakerStrength = 500	// factor (in relation to a vessels base radar cross section) how strong the lockbreaking effect is
+	lockBreakerStrength = 250	// factor (in relation to a vessels base radar cross section) how strong the lockbreaking effect is, 500 makes craft at 5m^2 RCS unlockable with AN/APG-63
 
 	rcsReduction = false		// jammer reduces a crafts radar cross section, simulating 2nd generation stealth (radar obsorbent coating)
 	rcsReductionFactor = 0		// factor for radar cross section: from 0 (craft is invisible) to 1 (no effect)

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/ecmJammer/ecmj131.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/ecmJammer/ecmj131.cfg
@@ -56,7 +56,7 @@ MODULE
 	jammerStrength = 1200		// this is a factor (in relation to a vessels base radar cross section) how much the crafts DETECTABILITY is INCREASED(!) when the jammer is active
 
 	lockBreaker = true		// true: jammer serves to break radar locks (default: true)
-	lockBreakerStrength = 250	// factor (in relation to a vessels base radar cross section) how strong the lockbreaking effect is, 500 makes craft at 5m^2 RCS unlockable with AN/APG-63
+	lockBreakerStrength = 300	// factor (in relation to a vessels base radar cross section) how strong the lockbreaking effect is
 
 	rcsReduction = false		// jammer reduces a crafts radar cross section, simulating 2nd generation stealth (radar obsorbent coating)
 	rcsReductionFactor = 0		// factor for radar cross section: from 0 (craft is invisible) to 1 (no effect)

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -266,7 +266,7 @@ namespace BDArmory.Radar
                 //4) lockbreaking strength relative to jammer's lockbreak strength in relation to vessel rcs signature:
                 // lockbreak_factor = baseSig/modifiedSig x (1 � lopckBreakStrength/baseSig/100)
                 // Use clamp to prevent RCS reduction resulting in increased lockbreak factor, which negates value of RCS reduction)
-                ti.radarLockbreakFactor = Mathf.Max(Mathf.Clamp01(ti.radarBaseSignature / ti.radarModifiedSignature) * (1 - (vesseljammer.lockBreakStrength / ti.radarBaseSignature / 100)), 0.001f); // 0.001 is minimum lockbreak factor
+                ti.radarLockbreakFactor = Mathf.Max(Mathf.Clamp01(ti.radarBaseSignature / ti.radarModifiedSignature) * (1 - (vesseljammer.lockBreakStrength / ti.radarBaseSignature / 100)), 0); // 0 is minimum lockbreak factor
             }
 
             return ti.radarModifiedSignature;

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -62,7 +62,7 @@ namespace BDArmory.Radar
 
         internal static float rcsTotal;               // dito
 
-        internal const float RCS_NORMALIZATION_FACTOR = 4.0f;       //IMPORTANT FOR RCS CALCULATION! DO NOT CHANGE! (sphere with 1m^2 cross section should have 1m^2 RCS)
+        internal const float RCS_NORMALIZATION_FACTOR = 3.8f;       //IMPORTANT FOR RCS CALCULATION! DO NOT CHANGE! (sphere with 1m^2 cross section should have 1m^2 RCS)
         internal const float RCS_MISSILES = 999f;                    //default rcs value for missiles if not configured in the part config
         internal const float RWR_PING_RANGE_FACTOR = 2.0f;
         internal const float RADAR_IGNORE_DISTANCE_SQR = 100f;

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -374,7 +374,7 @@ namespace BDArmory.Radar
             {
                 // Determine camera vector for aspect
                 aspect = Vector3.RotateTowards(t.up, -t.up, rcsAspects[i, 0] / 180f * Mathf.PI, 0);
-                aspect = Vector3.RotateTowards(aspect, Vector3.Cross(t.right, t.up), rcsAspects[i, 1] / 180f * Mathf.PI, 0);
+                aspect = Vector3.RotateTowards(aspect, Vector3.Cross(t.right, t.up), -rcsAspects[i, 1] / 180f * Mathf.PI, 0);
                 
                 // Render aspect
                 RenderSinglePass(t, false, aspect, vesselbounds, radarDistance, radarFOV, rcsRenderingVariable, drawTextureVariable);
@@ -440,11 +440,11 @@ namespace BDArmory.Radar
             {
                 // Determine camera vectors for aspects
                 Vector3 aspect1 = Vector3.RotateTowards(t.up, -t.up, worstRCSAspects[0, 0] / 180f * Mathf.PI, 0);
-                aspect1 = Vector3.RotateTowards(aspect1, Vector3.Cross(t.right, t.up), worstRCSAspects[0, 1] / 180f * Mathf.PI, 0);
+                aspect1 = Vector3.RotateTowards(aspect1, Vector3.Cross(t.right, t.up), -worstRCSAspects[0, 1] / 180f * Mathf.PI, 0);
                 Vector3 aspect2 = Vector3.RotateTowards(t.up, -t.up, worstRCSAspects[1, 0] / 180f * Mathf.PI, 0);
-                aspect2 = Vector3.RotateTowards(aspect2, Vector3.Cross(t.right, t.up), worstRCSAspects[1, 1] / 180f * Mathf.PI, 0);
+                aspect2 = Vector3.RotateTowards(aspect2, Vector3.Cross(t.right, t.up), -worstRCSAspects[1, 1] / 180f * Mathf.PI, 0);
                 Vector3 aspect3 = Vector3.RotateTowards(t.up, -t.up, worstRCSAspects[2, 0] / 180f * Mathf.PI, 0);
-                aspect3 = Vector3.RotateTowards(aspect3, Vector3.Cross(t.right, t.up), worstRCSAspects[2, 1] / 180f * Mathf.PI, 0);
+                aspect3 = Vector3.RotateTowards(aspect3, Vector3.Cross(t.right, t.up), -worstRCSAspects[2, 1] / 180f * Mathf.PI, 0);
 
                 // Render three highest aspects
                 RenderSinglePass(t, inEditorZoom, aspect1, vesselbounds, radarDistance, radarFOV, rcsRendering1, drawTexture1);

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -171,6 +171,15 @@ namespace BDArmory.Radar
         public static float[,] worstRCSAspects = new float[3, 3]; // Worst three aspects
 
         /// <summary>
+        /// Force radar signature update
+        /// </summary>
+        public static void ForceUpdateRadarCrossSections()
+        {
+            foreach (var vessel in FlightGlobals.Vessels)
+                GetVesselRadarCrossSection(vessel, true);
+        }
+
+        /// <summary>
         /// Get a vessel radar siganture, including all modifiers (ECM, stealth, ...)
         /// </summary>
         public static TargetInfo GetVesselRadarSignature(Vessel v)
@@ -187,7 +196,7 @@ namespace BDArmory.Radar
         /// <summary>
         /// Internal method: get a vessel base radar signature
         /// </summary>
-        private static TargetInfo GetVesselRadarCrossSection(Vessel v)
+        private static TargetInfo GetVesselRadarCrossSection(Vessel v, bool force = false)
         {
             //read vesseltargetinfo, or render against radar cameras
             TargetInfo ti = v.gameObject.GetComponent<TargetInfo>();
@@ -214,11 +223,8 @@ namespace BDArmory.Radar
                 }
             }
 
-            if (BDACompetitionMode.Instance.competitionStarting && !BDACompetitionMode.Instance.competitionIsActive)
-                ti.radarBaseSignatureCompetitionUpdate = false; // Reset competition update if a new competition was started
-
             // Run intensive RCS rendering if 1. It has not been done yet, 2. If the competition just started (capture vessel changes such as gear-raise or robotics)
-            if (ti.radarBaseSignature == -1 || ti.radarBaseSignatureNeedsUpdate || (!ti.radarBaseSignatureCompetitionUpdate && BDACompetitionMode.Instance.competitionIsActive))
+            if (force || ti.radarBaseSignature == -1 || ti.radarBaseSignatureNeedsUpdate)
             {
                 // is it just some debris? then dont bother doing a real rcs rendering and just fake it with the parts mass
                 if (v.vesselType == VesselType.Debris && !v.IsControllable)
@@ -233,7 +239,6 @@ namespace BDArmory.Radar
 
                 ti.radarBaseSignatureNeedsUpdate = false;
                 ti.alreadyScheduledRCSUpdate = false;
-                ti.radarBaseSignatureCompetitionUpdate = true;
             }
 
             return ti;

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -19,7 +19,6 @@ namespace BDArmory.Targeting
 
         public float radarBaseSignature = -1;
         public bool radarBaseSignatureNeedsUpdate = true;
-        public bool radarBaseSignatureCompetitionUpdate = true;
         public float radarModifiedSignature;
         public float radarLockbreakFactor;
         public float radarJammingDistance;

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -19,6 +19,7 @@ namespace BDArmory.Targeting
 
         public float radarBaseSignature = -1;
         public bool radarBaseSignatureNeedsUpdate = true;
+        public bool radarBaseSignatureCompetitionUpdate = true;
         public float radarModifiedSignature;
         public float radarLockbreakFactor;
         public float radarJammingDistance;


### PR DESCRIPTION
- Fix lockbreak factor being negative. New minimum (best) value is 0.
- Re-run RCS calc on Competition Start (no more landing gear interfering with RCS!).
-  Nerf ECM lockbreaking strength to 300 for better balance with the new RCS system, was agreed upon value after some discussion with BDAc communities.
- Fix rendered elevations being negative of the intended elevation
- Adjust RCS normalization from 4.0 to 3.8 so sphere with 1m^2 cross section has 1m^2 RCS.