### PR TITLE
Adjust TargetPriAcceleration for no engine condition

### DIFF
--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -352,7 +352,9 @@ namespace BDArmory.Targeting
         {
             float bodyGravity = (float)PhysicsGlobals.GravitationalAcceleration * (float)vessel.orbit.referenceBody.GeeASL; // Set gravity for calculations;
             float maxAccel = MaxThrust(vessel) / vessel.GetTotalMass(); // This assumes that all thrust is in the same direction.
-            return 0.1f * Mathf.Clamp(maxAccel / bodyGravity, 0f, 10f); // Output is 0-1 (0.1 is equal to body gravity)
+            maxAccel = 0.1f * Mathf.Clamp(maxAccel / bodyGravity, 0f, 10f);
+            maxAccel = maxAccel == 0 ? -1 : maxAccel; // If max acceleration is zero (no engnines), set to -1 for stronger target priority
+            return maxAccel; // Output is -1 or 0-1 (0.1 is equal to body gravity)
         }
 
         public float TargetPriClosureTime(MissileFire myMf) // Time to closest point of approach, normalized for one minute


### PR DESCRIPTION
 Use -1 instead of 0 for TargetPriAcceleration when craft have zero max acceleration (no engines). Allows better switching off targets that have lost their engines.