### PR TITLE
Fix engagement range for lasers, add missile turning term to DLZ calculation

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/Parts/aim-120/amraam.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/aim-120/amraam.cfg
@@ -66,13 +66,13 @@ PART
 		boostTransformName = boostTransform
 		boostExhaustTransformName = boostTransform
 
-		optimumAirspeed = 1372 //deals with how missile leads the target... should match the max speed of your missile
+		optimumAirspeed = 1372 //deals with how missile leads the target and calculation of turn radius for dynamic launch zone calculation, should match the max speed of your missile
 
 		aero = true //Missile has aerodynamics
 		liftArea = 0.0020 //increases lift which helps with manuevering and turning, but also increases drag
 		steerMult = 8 //big number = steer harder...
 		maxTorque = 60 //ammount of torque that will be applied to the missile for turning
-		maxAoA = 30 //not sure really I do not think it has much effect
+		maxAoA = 30 //max AoA missile can turn at, will limit missile's turn radius below what is possible with maxTorque if set too low
 
 		missileType = missile
 		homingType = aam //air to air missile different types are AAM, AGM, Cruise and Ballistic
@@ -82,8 +82,8 @@ PART
 		allAspect = false // Only affects when missile can launch for radar-guided missiles, see comment on maxOffBoresight for how. For heat-seeking missiles this also allows lock-on after launch.
 		lockedSensorFOV = 7 //the field of view the missile can see to maintain a lock after launch, will affect accuracy
 
-		minStaticLaunchRange = 500 //closest range in meters to target you can launch the missile
-		maxStaticLaunchRange = 25000 //furthest rangein meters from the target the missile can be launched
+		minStaticLaunchRange = 500 // minimum launch range in meters assuming craft don't move, final min launch distance is dynamically calculated based on target/launching craft speeds
+		maxStaticLaunchRange = 25000 // maximum launch range in meters assuming craft don't move, final max launch distance is dynamically calculated based on target/launching craft speeds
 
 		radarLOAL = true //radar lock on after launch
 

--- a/BDArmory/Misc/MissileLaunchParams.cs
+++ b/BDArmory/Misc/MissileLaunchParams.cs
@@ -44,6 +44,8 @@ namespace BDArmory.Misc
             float minLaunchRange = missile.minStaticLaunchRange;
             float maxLaunchRange = missile.maxStaticLaunchRange;
 
+            float bodyGravity = (float)PhysicsGlobals.GravitationalAcceleration * (float)missile.vessel.orbit.referenceBody.GeeASL; // Set gravity for calculations;
+
             float missileActiveTime = 2f;
 
             float rangeAddMin = 0;
@@ -56,13 +58,30 @@ namespace BDArmory.Misc
             Vector3 relVProjected = Vector3.Project(relV, vectorToTarget);
             relSpeed = -Mathf.Sign(Vector3.Dot(relVProjected, vectorToTarget)) * relVProjected.magnitude;
 
-            // Basic time estimate for missile to drop and travel a safe distance from vessel assuming constant acceleration and firing vessel not accelerating
             if (missile.GetComponent<BDModularGuidance>() == null)
             {
+                // Basic time estimate for missile to drop and travel a safe distance from vessel assuming constant acceleration and firing vessel not accelerating
                 MissileLauncher ml = missile.GetComponent<MissileLauncher>();
                 float maxMissileAccel = ml.thrust / missile.part.mass;
                 float blastRadius = Mathf.Min(missile.GetBlastRadius(), 150f); // Allow missiles with absurd blast ranges to still be launched if desired
                 missileActiveTime = Mathf.Min((missile.vessel.LandedOrSplashed ? 0f : missile.dropTime) + Mathf.Sqrt(2 * blastRadius / maxMissileAccel), 2f); // Clamp at 2s for now
+
+                // Rough range estimate of max missile G in a turn after launch, the following code is quite janky but works decently well in practice
+                float maxEstimatedGForce = (bodyGravity * ml.maxTorque); // Rough estimate of max G based on missile torque
+                if (ml.aero) // If missile has aerodynamics, modify G force by AoA limit
+                {
+                    maxEstimatedGForce *= Mathf.Sin(ml.maxAoA * Mathf.Deg2Rad);
+                }
+
+                // Rough estimate of turning radius and arc length to travel
+                float futureTime = Mathf.Clamp((missile.vessel.LandedOrSplashed ? 0f : missile.dropTime), 0f, 2f);
+                Vector3 futureRelPosition = (targetPosition + targetVelocity * futureTime) - (missile.part.transform.position + launcherVelocity * futureTime);
+                float missileTurnRadius = (ml.optimumAirspeed * ml.optimumAirspeed) / maxEstimatedGForce; 
+                float targetAngle = Vector3.Angle(missile.GetForwardTransform(), futureRelPosition);
+                float arcLength = Mathf.Deg2Rad * targetAngle * missileTurnRadius;
+
+                // Add additional range term for the missile to manuever to target at missileActiveTime
+                rangeAddMin += arcLength;
             }
 
             float missileMaxRangeTime = 8f; // Placeholder value since this doesn't really matter much in BDA combat

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -3398,19 +3398,26 @@ namespace BDArmory.Modules
                             float candidateTraverse = ((ModuleWeapon)item.Current).yawRange;
                             bool electrolaser = ((ModuleWeapon)item.Current).electroLaser;
 
-                            if (electrolaser = true && target.isDebilitated) continue; // don't select EMP weapons if craft already disabld
+                            if (electrolaser = true && target.isDebilitated) continue; // don't select EMP weapons if craft already disabled
 
                             if ((targetWeapon != null) && (candidateGimbal = true && candidateTraverse > 0))
                             {
                                 candidatePower *= 1.5f; // weight selection towards turreted lasers
                             }
                             if ((targetWeapon != null) && (targetLaserDamage > candidatePower))
-                                continue; //dont replace better guns (but do replace missiles)
-
-                            targetWeapon = item.Current;
-                            targetLaserDamage = candidatePower;
-                            if (distance <= gunRange)
-                                break;
+                                continue; // Don't replace better lasers or replace with a weapon outside of its engage range
+                            else if ((targetWeapon == null) || (distance > ((EngageableWeapon)item.Current).engageRangeMin))
+                            {
+                                targetWeapon = item.Current;
+                                targetLaserDamage = candidatePower;
+                                if ((distance <= gunRange) && (distance > ((EngageableWeapon)item.Current).engageRangeMin))
+                                    break;  //If within engage range, use the laser
+                                else
+                                    continue; // If outside of engage range, keep looking for viable weapons,
+                            }
+                            else
+                                continue;
+                            
                         }
 
                         if (candidateClass == WeaponClasses.Gun)


### PR DESCRIPTION
- Make lasers respect engageRangeMin.
- Add term to DLZ calculation for minimum range to approximate distance it will take for the missile to turn towards an off-boresight target. Fixes high off-boresight missiles firing in situations where missile has a low chance of hitting.