### PR TITLE
Add VIP Settings

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -271,12 +271,18 @@ Localization
         #LOC_BDArmory_TargetPriority_FewerTeammatesEngaging = Less Teammates Engaging
         #LOC_BDArmory_TargetPriority_TargetThreat = Target Threat
         #LOC_BDArmory_TargetPriority_AngleOverDistance = Angle / Distance
+        #LOC_BDArmory_TargetPriority_TargetProtectVIP = Protect My VIPs
+        #LOC_BDArmory_TargetPriority_TargetAttackVIP = Attack Enemy VIPs
         
         #LOC_BDArmory_Countermeasure_Settings = Countermeasure Settings
         #LOC_BDArmory_CMThreshold = Time to Impact Before CM
         #LOC_BDArmory_CMRepetition = CM Dump per Sequence
         #LOC_BDArmory_CMInterval = CM Dump Interval Time
         #LOC_BDArmory_CMWaitTime = Sequence Restart Delay
+
+        #LOC_BDArmory_IsVIP = Is VIP?
+        #LOC_BDArmory_IsVIP_enabledText = Yes
+        #LOC_BDArmory_IsVIP_disabledText = No
 
         // Modular Missile, Custom Weapons
         #LOC_BDArmory_SteerLimiter = Steer Limiter

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -441,9 +441,19 @@ namespace BDArmory.Modules
         public float targetWeightFriendliesEngaging = 1f;
 
         private string targetThreatLabel = Localizer.Format("#LOC_BDArmory_TargetPriority_TargetThreat");
-        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_TargetPriority_TargetThreat", advancedTweakable = true, groupName = "targetPriority", groupDisplayName = "#LOC_BDArmory_TargetPriority_Settings", groupStartCollapsed = true),//Number Friendlies Engaging
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_TargetPriority_TargetThreat", advancedTweakable = true, groupName = "targetPriority", groupDisplayName = "#LOC_BDArmory_TargetPriority_Settings", groupStartCollapsed = true),//Target threat
          UI_FloatRange(minValue = -10f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_Scene.All)]
         public float targetWeightThreat = 0f;
+
+        private string targetProtectVIPLabel = Localizer.Format("#LOC_BDArmory_TargetPriority_TargetProtectVIP");
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_TargetPriority_TargetProtectVIP", advancedTweakable = true, groupName = "targetPriority", groupDisplayName = "#LOC_BDArmory_TargetPriority_Settings", groupStartCollapsed = true),//Protect VIPs
+         UI_FloatRange(minValue = -10f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_Scene.All)]
+        public float targetWeightProtectVIP = 0f;
+
+        private string targetAttackVIPLabel = Localizer.Format("#LOC_BDArmory_TargetPriority_TargetAttackVIP");
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_TargetPriority_TargetAttackVIP", advancedTweakable = true, groupName = "targetPriority", groupDisplayName = "#LOC_BDArmory_TargetPriority_Settings", groupStartCollapsed = true),//Attack Enemy VIPs
+         UI_FloatRange(minValue = -10f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_Scene.All)]
+        public float targetWeightAttackVIP = 0f;
         #endregion
 
         #region Countermeasure Settings
@@ -463,6 +473,10 @@ namespace BDArmory.Modules
          UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_Scene.All)]
         public float cmWaitTime = 1.0f; // Works well
         #endregion
+
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_IsVIP", advancedTweakable = true),// Is VIP, throwback to TF Classic (Hunted Game Mode)
+            UI_Toggle(enabledText = "#LOC_BDArmory_IsVIP_enabledText", disabledText = "#LOC_BDArmory_IsVIP_disabledText", scene = UI_Scene.All),]//yes--no
+        public bool isVIP = false;
 
         public void ToggleGuardMode()
         {
@@ -3229,6 +3243,8 @@ namespace BDArmory.Modules
             var TargetMassFields = Fields["targetWeightMass"];
             var TargetFriendliesEngagingFields = Fields["targetWeightFriendliesEngaging"];
             var TargetThreatFields = Fields["targetWeightThreat"];
+            var TargetProtectVIPFields = Fields["targetWeightProtectVIP"];
+            var TargetAttackVIPFields = Fields["targetWeightAttackVIP"];
 
             // Calculate score values
             float targetBiasValue = targetBias;
@@ -3241,6 +3257,8 @@ namespace BDArmory.Modules
             float targetMassValue = target.TargetPriMass(target.weaponManager, this);
             float targetFriendliesEngagingValue = target.TargetPriFriendliesEngaging(this);
             float targetThreatValue = target.TargetPriThreat(target.weaponManager, this);
+            float targetProtectVIPValue = target.TargetPriProtectVIP(target.weaponManager);
+            float targetAttackVIPValue = target.TargetPriAttackVIP(target.weaponManager);
 
             // Calculate total target score
             float targetScore = targetBiasValue * (
@@ -3252,7 +3270,9 @@ namespace BDArmory.Modules
                 targetWeightMass * targetMassValue +
                 targetWeightFriendliesEngaging * targetFriendliesEngagingValue +
                 targetWeightThreat * targetThreatValue +
-                targetWeightAoD * targetAoDValue);
+                targetWeightAoD * targetAoDValue +
+                targetWeightProtectVIP * targetProtectVIPValue +
+                targetWeightAttackVIP * targetAttackVIPValue);
 
             // Update GUI
             TargetBiasFields.guiName = targetBiasLabel + ": " + targetBiasValue.ToString("0.00");
@@ -3265,6 +3285,8 @@ namespace BDArmory.Modules
             TargetMassFields.guiName = targetMassLabel + ": " + targetMassValue.ToString("0.00");
             TargetFriendliesEngagingFields.guiName = targetFriendliesEngagingLabel + ": " + targetFriendliesEngagingValue.ToString("0.00");
             TargetThreatFields.guiName = targetThreatLabel + ": " + targetThreatValue.ToString("0.00");
+            TargetProtectVIPFields.guiName = targetProtectVIPLabel + ": " + targetProtectVIPValue.ToString("0.00");
+            TargetAttackVIPFields.guiName = targetAttackVIPLabel + ": " + targetAttackVIPValue.ToString("0.00");
 
             TargetScoreLabel = targetScore.ToString("0.00");
             TargetLabel = target.Vessel.GetDisplayName();

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -449,6 +449,34 @@ namespace BDArmory.Targeting
                 return 0;
             }
         }
+
+        public float TargetPriProtectVIP(MissileFire mf) // If target is attacking our VIP(s)
+        {
+            if (mf == null) return 0;
+            if ((mf.vessel != null) && (mf.currentTarget != null) && (mf.currentTarget.weaponManager != null))
+            {
+                bool attackingOurVIPs = mf.currentTarget.weaponManager.isVIP;
+                return ((attackingOurVIPs == true) ? 1 : -1); // Ranges -1 to 1, 1 if target is attacking our VIP(s), -1 if it is not
+            }
+            else
+            {
+                return 0;
+            }
+        }
+
+        public float TargetPriAttackVIP(MissileFire mf) // If target is enemy VIP
+        {
+            if (mf == null) return 0;
+            if (mf.vessel != null)
+            {
+                bool isVIP = mf.isVIP;
+                return ((isVIP == true) ? 1 : -1); // Ranges -1 to 1, 1 if target is an enemy VIP, -1 if it is not
+            }
+            else
+            {
+                return 0;
+            }
+        }
         // End functions used for prioritizing targets
         #endregion
 

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -988,7 +988,9 @@ namespace BDArmory.UI
                             mf.targetWeightMass * target.Current.TargetPriMass(target.Current.weaponManager, mf) +
                             mf.targetWeightFriendliesEngaging * target.Current.TargetPriFriendliesEngaging(mf) +
                             mf.targetWeightThreat * target.Current.TargetPriThreat(target.Current.weaponManager, mf) +
-                            mf.targetWeightAoD * target.Current.TargetPriAoD(mf));
+                            mf.targetWeightAoD * target.Current.TargetPriAoD(mf) +
+                            mf.targetWeightProtectVIP * target.Current.TargetPriProtectVIP(target.Current.weaponManager) +
+                            mf.targetWeightAttackVIP * target.Current.TargetPriAttackVIP(target.Current.weaponManager));
                         if (finalTarget == null || targetScore > finalTargetScore)
                         {
                             finalTarget = target.Current;


### PR DESCRIPTION
 Added VIPs, which allow you to set up behavior such as guarding your VIP, or attacking enemy VIPs and ignoring craft defending them.

- Add new "Is VIP" toggle to the weapons manager. Allows you to set a craft as a "VIP" which opens up new target priority options.
- Added new target priority options "Protect My VIPs" and "Attack Enemy VIPs". Setting positive values on these sliders will result in the craft targeting enemies that are targeting VIPs on its own team, or attacking enemy VIPs, respectively.