### PR TITLE
Rocket damage & weapon priority

### DIFF
--- a/BDArmory/Bullets/PooledBullet.cs
+++ b/BDArmory/Bullets/PooledBullet.cs
@@ -1,17 +1,14 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using BDArmory.Core;
 using BDArmory.Core.Extension;
-using BDArmory.Core.Module;
 using BDArmory.FX;
 using BDArmory.Parts;
 using BDArmory.Shaders;
-using BDArmory.UI;
 using BDArmory.Control;
-using BDArmory.Competition;
 using UnityEngine;
+using BDArmory.Misc;
 
 namespace BDArmory.Bullets
 {
@@ -330,7 +327,7 @@ namespace BDArmory.Bullets
                                         - (hitPart.rb.velocity + Krakensbane.GetFrameVelocityV3f())).magnitude;
                                 else
                                     impactVelocity = currentVelocity.magnitude * dragVelocityFactor;
-                                ApplyDamage(hitPart, hit, 1, 1);
+                                ProjectileUtils.ApplyDamage(hitPart, hit, 1, 1, caliber, bulletMass, impactVelocity, bulletDmgMult, distanceTraveled, explosive, hasRichocheted, sourceVessel, bullet.name);
                                 break;
                             }
 
@@ -344,9 +341,9 @@ namespace BDArmory.Bullets
 
                             float hitAngle = Vector3.Angle(impactVector, -hit.normal);
 
-                            if (CheckGroundHit(hitPart, hit))
+                            if (ProjectileUtils.CheckGroundHit(hitPart, hit, caliber))
                             {
-                                CheckBuildingHit(hit);
+                                ProjectileUtils.CheckBuildingHit(hit, bulletMass, currentVelocity, bulletDmgMult);
                                 if (!RicochetScenery(hitAngle))
                                 {
                                     ExplosiveDetonation(hitPart, hit, bulletRay);
@@ -364,8 +361,15 @@ namespace BDArmory.Bullets
                             impactVelocity = impactVector.magnitude;
                             float anglemultiplier = (float)Math.Cos(Math.PI * hitAngle / 180.0);
 
-                            float penetrationFactor = CalculateArmorPenetration(hitPart, anglemultiplier, hit);
-
+                            float thickness = ProjectileUtils.CalculateThickness(hitPart, anglemultiplier);
+                            float penetration = ProjectileUtils.CalculatePenetration(caliber, bulletMass, impactVelocity, apBulletMod);
+                            float penetrationFactor = ProjectileUtils.CalculateArmorPenetration(hitPart, anglemultiplier, hit, penetration, thickness, caliber);
+                            if (penetration > thickness)
+                            {
+                                currentVelocity = currentVelocity * (float)Math.Sqrt(thickness / penetration);
+                                if (penTicker > 0) currentVelocity *= 0.55f;
+                                flightTimeElapsed -= Time.fixedDeltaTime;
+                            }
                             if (penetrationFactor >= 2)
                             {
                                 //its not going to bounce if it goes right through
@@ -380,9 +384,9 @@ namespace BDArmory.Bullets
                             if (penetrationFactor > 1 && !hasRichocheted) //fully penetrated continue ballistic damage
                             {
                                 hasPenetrated = true;
-                                ApplyDamage(hitPart, hit, 1, penetrationFactor);
+                                ProjectileUtils.ApplyDamage(hitPart, hit, 1, penetrationFactor, caliber, bulletMass, impactVelocity, bulletDmgMult, distanceTraveled, explosive, hasRichocheted, sourceVessel, bullet.name);
                                 penTicker += 1;
-                                CheckPartForExplosion(hitPart);
+                                ProjectileUtils.CheckPartForExplosion(hitPart);
 
                                 //Explosive bullets that penetrate should explode shortly after
                                 //if penetration is very great, they will have moved on
@@ -417,7 +421,7 @@ namespace BDArmory.Bullets
                                 }
 
                                 hasPenetrated = false;
-                                ApplyDamage(hitPart, hit, 1, penetrationFactor);
+                                ProjectileUtils.ApplyDamage(hitPart, hit, 1, penetrationFactor, caliber, bulletMass, impactVelocity, bulletDmgMult, distanceTraveled, explosive, hasRichocheted, sourceVessel, bullet.name);
                                 ExplosiveDetonation(hitPart, hit, bulletRay);
                                 hasDetonated = true;
                                 KillBullet();
@@ -522,84 +526,6 @@ namespace BDArmory.Bullets
             return detonate;
         }
 
-        private void ApplyDamage(Part hitPart, RaycastHit hit, float multiplier, float penetrationfactor)
-        {
-            //hitting a vessel Part
-            //No struts, they cause weird bugs :) -BahamutoD
-            if (hitPart == null) return;
-            if (hitPart.partInfo.name.Contains("Strut")) return;
-
-            // Add decals
-            if (BDArmorySettings.BULLET_HITS)
-            {
-                BulletHitFX.CreateBulletHit(hitPart, hit.point, hit, hit.normal, hasRichocheted, caliber, penetrationfactor);
-            }
-
-            // Apply damage
-            float damage;
-            //if (explosive)
-            //{
-            //    damage = hitPart.AddBallisticDamage(bulletMass - tntMass, caliber, multiplier, penetrationfactor, bulletDmgMult, impactVelocity, hit, sourceVessel.GetName());
-            //} //why? The mass of HE filler isn't going to have disapeared before the bullet hits something, and if it has, it means there isn't a bullet left to hit things
-            //else
-            //{
-            damage = hitPart.AddBallisticDamage(bulletMass, caliber, multiplier, penetrationfactor, bulletDmgMult, impactVelocity);
-            //}
-            if (BDArmorySettings.BATTLEDAMAGE)
-            {
-                Misc.BattleDamageHandler.CheckDamageFX(hitPart, caliber, penetrationfactor, explosive, sourceVessel.GetName(), hit);
-            }
-            // Debug.Log("DEBUG Ballistic damage to " + hitPart + ": " + damage + ", calibre: " + caliber + ", multiplier: " + multiplier + ", pen: " + penetrationfactor);
-
-            // Update scoring structures
-            var aName = this.sourceVessel.GetName();
-            var tName = hitPart.vessel.GetName();
-
-            if (aName != null && tName != null && aName != tName && BDACompetitionMode.Instance.Scores.ContainsKey(aName) && BDACompetitionMode.Instance.Scores.ContainsKey(tName))
-            {
-                //Debug.Log("[BDArmory]: Weapon from " + aName + " damaged " + tName);
-
-                if (BDArmorySettings.REMOTE_LOGGING_ENABLED)
-                {
-                    BDAScoreService.Instance.TrackHit(aName, tName, bullet.name, distanceTraveled);
-                    BDAScoreService.Instance.TrackDamage(aName, tName, damage);
-                }
-
-                // update scoring structure on attacker
-                {
-                    var aData = BDACompetitionMode.Instance.Scores[aName];
-                    aData.Score += 1;
-                    // keep track of who shot who for point keeping
-
-                    // competition logic for 'Pinata' mode - this means a pilot can't be named 'Pinata'
-                    if (hitPart.vessel.GetName() == "Pinata")
-                    {
-                        aData.PinataHits++;
-                    }
-
-                }
-
-                // update scoring structure on the defender.
-                {
-                    var tData = BDACompetitionMode.Instance.Scores[tName];
-                    tData.lastPersonWhoHitMe = aName;
-                    tData.lastHitTime = Planetarium.GetUniversalTime();
-                    tData.everyoneWhoHitMe.Add(aName);
-                    // Track hits
-                    if (tData.hitCounts.ContainsKey(aName))
-                        ++tData.hitCounts[aName];
-                    else
-                        tData.hitCounts.Add(aName, 1);
-                    // Track damage
-                    if (tData.damageFromBullets.ContainsKey(aName))
-                        tData.damageFromBullets[aName] += damage;
-                    else
-                        tData.damageFromBullets.Add(aName, damage);
-                }
-            }
-
-        }
-
         private void CalculateDragNumericalIntegration()
         {
             Vector3 dragAcc = currentVelocity * currentVelocity.magnitude *
@@ -623,80 +549,6 @@ namespace BDArmory.Bullets
             //velocity as a function of time under the assumption of a projectile only acted upon by drag with a constant drag area
 
             dragVelocityFactor = analyticDragVelAdjustment / initialSpeed;
-        }
-
-        private float CalculateArmorPenetration(Part hitPart, float anglemultiplier, RaycastHit hit)
-        {
-            ///////////////////////////////////////////////////////////////////////
-            // Armor Penetration
-            ///////////////////////////////////////////////////////////////////////
-
-            float penetration = CalculatePenetration();
-
-            //TODO: Extract bdarmory settings from this values
-            float thickness = CalculateThickness(hitPart, anglemultiplier);
-            if (thickness < 1) thickness = 1; //prevent divide by zero or other odd behavior
-
-            var penetrationFactor = penetration / thickness;
-
-            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-            {
-                Debug.Log("[BDArmory]: Armor penetration = " + penetration + " | Thickness = " + thickness);
-            }
-
-            bool fullyPenetrated = penetration > thickness; //check whether bullet penetrates the plate
-
-            double massToReduce = Math.PI * Math.Pow((caliber * 0.001) / 2, 2) * (penetration);
-
-            if (fullyPenetrated)
-            {
-                //lower velocity on penetrating armor plate
-                //does not affect low impact parts so that rounds can go through entire tank easily
-                //If round penetrates easily it should not loose much velocity
-
-                //if (penetrationFactor < 2)
-                currentVelocity = currentVelocity * (float)Math.Sqrt(thickness / penetration);
-                //signifincanly reduce velocity on subsequent penetrations
-                if (penTicker > 0) currentVelocity *= 0.55f;
-
-                //updating impact velocity
-                //impactVelocity = currentVelocity.magnitude;
-
-                flightTimeElapsed -= Time.fixedDeltaTime;
-            }
-            else
-            {
-                massToReduce *= 0.125f;
-
-                if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                {
-                    Debug.Log("[BDArmory]: Bullet Stopped by Armor");
-                }
-            }
-            hitPart.ReduceArmor(massToReduce);
-            return penetrationFactor;
-        }
-
-        private float CalculatePenetration()
-        {
-            float penetration = 0;
-            if (apBulletMod <= 0) // sanity check/legacy compatibility
-            {
-                apBulletMod = 1;
-            }
-
-            if (caliber > 5) //use the "krupp" penetration formula for anything larger than HMGs
-            {
-                penetration = (float)(16f * impactVelocity * Math.Sqrt(bulletMass / 1000) / Math.Sqrt(caliber) * apBulletMod); //APBulletMod now actually implemented, serves as penetration multiplier, 1 being neutral, <1 for soft rounds, >1 for AP penetrators
-            }
-
-            return penetration;
-        }
-
-        private static float CalculateThickness(Part hitPart, float anglemultiplier)
-        {
-            float thickness = (float)hitPart.GetArmorThickness();
-            return Mathf.Max(thickness / anglemultiplier, 1);
         }
 
         private bool ExplosiveDetonation(Part hitPart, RaycastHit hit, Ray ray, bool airDetonation = false)
@@ -730,51 +582,6 @@ namespace BDArmory.Bullets
                     hasDetonated = true;
                     return true;
                 }
-            }
-            return false;
-        }
-
-        private bool CheckGroundHit(Part hitPart, RaycastHit hit)
-        {
-            if (hitPart == null)
-            {
-                if (BDArmorySettings.BULLET_HITS)
-                {
-                    BulletHitFX.CreateBulletHit(hitPart, hit.point, hit, hit.normal, true, caliber, 0);
-                }
-
-                return true;
-            }
-            return false;
-        }
-
-        private bool CheckBuildingHit(RaycastHit hit)
-        {
-            DestructibleBuilding building = null;
-            try
-            {
-                building = hit.collider.gameObject.GetComponentUpwards<DestructibleBuilding>();
-                building.damageDecay = 600f;
-            }
-            catch (Exception) { }
-
-            if (building != null && building.IsIntact)
-            {
-                float damageToBuilding = ((0.5f * (bulletMass * Mathf.Pow(currentVelocity.magnitude, 2)))
-                            * (BDArmorySettings.DMG_MULTIPLIER / 100) * bulletDmgMult
-                            * 1e-4f);
-                damageToBuilding /= 8f;
-                building.AddDamage(damageToBuilding);
-                if (building.Damage > building.impactMomentumThreshold * 150)
-                {
-                    building.Demolish();
-                }
-                if (BDArmorySettings.DRAW_DEBUG_LABELS)
-                    Debug.Log("[BDArmory]: Ballistic hit destructible building! Hitpoints Applied: " + Mathf.Round(damageToBuilding) +
-                             ", Building Damage : " + Mathf.Round(building.Damage) +
-                             " Building Threshold : " + building.impactMomentumThreshold);
-
-                return true;
             }
             return false;
         }
@@ -862,98 +669,6 @@ namespace BDArmory.Bullets
 
             currentVelocity = Vector3.RotateTowards(currentVelocity, randomDirection,
                 UnityEngine.Random.Range(0f, 5f) * Mathf.Deg2Rad, 0);
-        }
-
-        public void CheckPartForExplosion(Part hitPart)
-        {
-            if (!hitPart.FindModuleImplementing<HitpointTracker>()) return;
-
-            switch (hitPart.GetExplodeMode())
-            {
-                case "Always":
-                    CreateExplosion(hitPart);
-                    break;
-
-                case "Dynamic":
-                    float probability = CalculateExplosionProbability(hitPart);
-                    if (probability >= 3)
-                        CreateExplosion(hitPart);
-                    break;
-
-                case "Never":
-                    break;
-            }
-        }
-
-        private float CalculateExplosionProbability(Part part)
-        {
-            ///////////////////////////////////////////////////////////////
-            float probability = 0;
-            float fuelPct = 0;
-            for (int i = 0; i < part.Resources.Count; i++)
-            {
-                PartResource current = part.Resources[i];
-                switch (current.resourceName)
-                {
-                    case "LiquidFuel":
-                        fuelPct = (float)(current.amount / current.maxAmount);
-                        break;
-                        //case "Oxidizer":
-                        //   probability += (float) (current.amount/current.maxAmount);
-                        //    break;
-                }
-            }
-
-            if (fuelPct > 0 && fuelPct <= 0.60f)
-            {
-                probability = Core.Utils.BDAMath.RangedProbability(new[] { 50f, 25f, 20f, 5f });
-            }
-            else
-            {
-                probability = Core.Utils.BDAMath.RangedProbability(new[] { 50f, 25f, 20f, 2f });
-            }
-
-            if (fuelPct == 1f || fuelPct == 0f)
-                probability = 0f;
-
-            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-            {
-                Debug.Log("[BDArmory]: Explosive Probablitliy " + probability);
-            }
-
-            return probability;
-        }
-
-        public void CreateExplosion(Part part)
-        {
-            float explodeScale = 0;
-            IEnumerator<PartResource> resources = part.Resources.GetEnumerator();
-            while (resources.MoveNext())
-            {
-                if (resources.Current == null) continue;
-                switch (resources.Current.resourceName)
-                {
-                    case "LiquidFuel":
-                        explodeScale += (float)resources.Current.amount;
-                        break;
-
-                    case "Oxidizer":
-                        explodeScale += (float)resources.Current.amount;
-                        break;
-                }
-            }
-
-            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-            {
-                Debug.Log("[BDArmory]: Penetration of bullet detonated fuel!");
-            }
-
-            resources.Dispose();
-
-            explodeScale /= 100;
-            part.explosionPotential = explodeScale;
-
-            PartExploderSystem.AddPartToExplode(part);
         }
 
         private float GetExplosivePower()

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -28,6 +28,7 @@ Localization
         #LOC_BDArmory_WMWindow_FiringInterval = Firing Interval
         #LOC_BDArmory_WMWindow_BurstLength = Burst Length
         #LOC_BDArmory_WMWindow_FiringTolerance = Firing Angle
+        #LOC_BDArmory_FiringPriority = Selection Priority
         #LOC_BDArmory_WMWindow_FieldofView = Field of View
         #LOC_BDArmory_WMWindow_VisualRange = Visual Range
         #LOC_BDArmory_WMWindow_GunsRange = Guns Range

--- a/BDArmory/Misc/ProjectileUtils.cs
+++ b/BDArmory/Misc/ProjectileUtils.cs
@@ -1,0 +1,269 @@
+﻿using BDArmory.Competition;
+using BDArmory.Control;
+using BDArmory.Core;
+using BDArmory.Core.Extension;
+using BDArmory.Core.Module;
+using BDArmory.FX;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace BDArmory.Misc
+{
+	class ProjectileUtils
+	{
+        public static void ApplyDamage(Part hitPart, RaycastHit hit, float multiplier, float penetrationfactor, float caliber, float projmass, float impactVelocity, float DmgMult, double distanceTraveled, bool explosive, bool hasRichocheted, Vessel sourceVessel, string name)
+        {
+            //hitting a vessel Part
+            //No struts, they cause weird bugs :) -BahamutoD
+            if (hitPart == null) return;
+            if (hitPart.partInfo.name.Contains("Strut")) return;
+
+            // Add decals
+            if (BDArmorySettings.BULLET_HITS)
+            {
+                BulletHitFX.CreateBulletHit(hitPart, hit.point, hit, hit.normal, hasRichocheted, caliber, penetrationfactor);
+            }
+            // Apply damage
+            float damage;
+            damage = hitPart.AddBallisticDamage(projmass, caliber, multiplier, penetrationfactor, DmgMult, impactVelocity);
+
+            if (BDArmorySettings.BATTLEDAMAGE)
+            {
+                BattleDamageHandler.CheckDamageFX(hitPart, caliber, penetrationfactor, explosive, sourceVessel.GetName(), hit);
+            }
+            // Debug.Log("DEBUG Ballistic damage to " + hitPart + ": " + damage + ", calibre: " + caliber + ", multiplier: " + multiplier + ", pen: " + penetrationfactor);
+
+            // Update scoring structures
+            var aName = sourceVessel.GetName();
+            var tName = hitPart.vessel.GetName();
+
+            if (aName != null && tName != null && aName != tName && BDACompetitionMode.Instance.Scores.ContainsKey(aName) && BDACompetitionMode.Instance.Scores.ContainsKey(tName))
+            {
+                //Debug.Log("[BDArmory]: Weapon from " + aName + " damaged " + tName);
+
+                if (BDArmorySettings.REMOTE_LOGGING_ENABLED)
+                {
+                    BDAScoreService.Instance.TrackHit(aName, tName, name, distanceTraveled);
+                    BDAScoreService.Instance.TrackDamage(aName, tName, damage);
+                }
+                // update scoring structure on attacker
+                {
+                    var aData = BDACompetitionMode.Instance.Scores[aName];
+                    aData.Score += 1;
+                    // keep track of who shot who for point keeping
+
+                    // competition logic for 'Pinata' mode - this means a pilot can't be named 'Pinata'
+                    if (hitPart.vessel.GetName() == "Pinata")
+                    {
+                        aData.PinataHits++;
+                    }
+                }
+                // update scoring structure on the defender.
+                {
+                    var tData = BDACompetitionMode.Instance.Scores[tName];
+                    tData.lastPersonWhoHitMe = aName;
+                    tData.lastHitTime = Planetarium.GetUniversalTime();
+                    tData.everyoneWhoHitMe.Add(aName);
+                    // Track hits
+                    if (tData.hitCounts.ContainsKey(aName))
+                        ++tData.hitCounts[aName];
+                    else
+                        tData.hitCounts.Add(aName, 1);
+                    // Track damage
+                    if (tData.damageFromBullets.ContainsKey(aName))
+                        tData.damageFromBullets[aName] += damage;
+                    else
+                        tData.damageFromBullets.Add(aName, damage);
+                }
+            }
+        }
+        public static float CalculateArmorPenetration(Part hitPart, float anglemultiplier, RaycastHit hit, float penetration, float thickness, float caliber)
+        {
+            ///////////////////////////////////////////////////////////////////////
+            // Armor Penetration
+            ///////////////////////////////////////////////////////////////////////
+
+            //TODO: Extract bdarmory settings from this values
+            if (thickness < 1) thickness = 1; //prevent divide by zero or other odd behavior
+
+            var penetrationFactor = penetration / thickness;
+
+            if (BDArmorySettings.DRAW_DEBUG_LABELS)
+            {
+                Debug.Log("[BDArmory]: Armor penetration = " + penetration + " | Thickness = " + thickness);
+            }
+
+            bool fullyPenetrated = penetration > thickness; //check whether bullet penetrates the plate
+
+            double massToReduce = Math.PI * Math.Pow((caliber * 0.001) / 2, 2) * (penetration);
+
+            if (!fullyPenetrated)
+            {
+                massToReduce *= 0.125f;
+
+                if (BDArmorySettings.DRAW_DEBUG_LABELS)
+                {
+                    Debug.Log("[BDArmory]: Bullet Stopped by Armor");
+                }
+            }
+            hitPart.ReduceArmor(massToReduce);
+            return penetrationFactor;
+        }
+        public static float CalculatePenetration(float caliber, float projMass, float impactVel, float apBulletMod = 1)
+        {
+            float penetration = 0;
+            if (apBulletMod <= 0) // sanity check/legacy compatibility
+            {
+                apBulletMod = 1;
+            }
+
+            if (caliber > 5) //use the "krupp" penetration formula for anything larger than HMGs
+            {
+                penetration = (float)(16f * impactVel * Math.Sqrt(projMass / 1000) / Math.Sqrt(caliber) * apBulletMod); //APBulletMod now actually implemented, serves as penetration multiplier, 1 being neutral, <1 for soft rounds, >1 for AP penetrators
+            }
+
+            return penetration;
+        }
+        public static float CalculateThickness(Part hitPart, float anglemultiplier)
+        {
+            float thickness = (float)hitPart.GetArmorThickness();
+            return Mathf.Max(thickness / anglemultiplier, 1);
+        }
+        public static bool CheckGroundHit(Part hitPart, RaycastHit hit, float caliber)
+        {
+            if (hitPart == null)
+            {
+                if (BDArmorySettings.BULLET_HITS)
+                {
+                    BulletHitFX.CreateBulletHit(hitPart, hit.point, hit, hit.normal, true, caliber, 0);
+                }
+
+                return true;
+            }
+            return false;
+        }
+        public static bool CheckBuildingHit(RaycastHit hit, float projMass, Vector3 currentVelocity, float DmgMult)
+        {
+            DestructibleBuilding building = null;
+            try
+            {
+                building = hit.collider.gameObject.GetComponentUpwards<DestructibleBuilding>();
+                building.damageDecay = 600f;
+            }
+            catch (Exception) { }
+
+            if (building != null && building.IsIntact)
+            {
+                float damageToBuilding = ((0.5f * (projMass * Mathf.Pow(currentVelocity.magnitude, 2)))
+                            * (BDArmorySettings.DMG_MULTIPLIER / 100) * DmgMult
+                            * 1e-4f);
+                damageToBuilding /= 8f;
+                building.AddDamage(damageToBuilding);
+                if (building.Damage > building.impactMomentumThreshold * 150)
+                {
+                    building.Demolish();
+                }
+                if (BDArmorySettings.DRAW_DEBUG_LABELS)
+                    Debug.Log("[BDArmory]: Ballistic hit destructible building! Hitpoints Applied: " + Mathf.Round(damageToBuilding) +
+                             ", Building Damage : " + Mathf.Round(building.Damage) +
+                             " Building Threshold : " + building.impactMomentumThreshold);
+
+                return true;
+            }
+            return false;
+        }
+
+        public static void CheckPartForExplosion(Part hitPart)
+        {
+            if (!hitPart.FindModuleImplementing<HitpointTracker>()) return;
+
+            switch (hitPart.GetExplodeMode())
+            {
+                case "Always":
+                    CreateExplosion(hitPart);
+                    break;
+
+                case "Dynamic":
+                    float probability = CalculateExplosionProbability(hitPart);
+                    if (probability >= 3)
+                        CreateExplosion(hitPart);
+                    break;
+
+                case "Never":
+                    break;
+            }
+        }
+
+        public static float CalculateExplosionProbability(Part part)
+        {
+            ///////////////////////////////////////////////////////////////
+            float probability = 0;
+            float fuelPct = 0;
+            for (int i = 0; i < part.Resources.Count; i++)
+            {
+                PartResource current = part.Resources[i];
+                switch (current.resourceName)
+                {
+                    case "LiquidFuel":
+                        fuelPct = (float)(current.amount / current.maxAmount);
+                        break;
+                        //case "Oxidizer":
+                        //   probability += (float) (current.amount/current.maxAmount);
+                        //    break;
+                }
+            }
+
+            if (fuelPct > 0 && fuelPct <= 0.60f)
+            {
+                probability = Core.Utils.BDAMath.RangedProbability(new[] { 50f, 25f, 20f, 5f });
+            }
+            else
+            {
+                probability = Core.Utils.BDAMath.RangedProbability(new[] { 50f, 25f, 20f, 2f });
+            }
+
+            if (fuelPct == 1f || fuelPct == 0f)
+                probability = 0f;
+
+            if (BDArmorySettings.DRAW_DEBUG_LABELS)
+            {
+                Debug.Log("[BDArmory]: Explosive Probablitliy " + probability);
+            }
+
+            return probability;
+        }
+
+        public static void CreateExplosion(Part part)
+        {
+            float explodeScale = 0;
+            IEnumerator<PartResource> resources = part.Resources.GetEnumerator();
+            while (resources.MoveNext())
+            {
+                if (resources.Current == null) continue;
+                switch (resources.Current.resourceName)
+                {
+                    case "LiquidFuel":
+                        explodeScale += (float)resources.Current.amount;
+                        break;
+
+                    case "Oxidizer":
+                        explodeScale += (float)resources.Current.amount;
+                        break;
+                }
+            }
+
+            if (BDArmorySettings.DRAW_DEBUG_LABELS)
+            {
+                Debug.Log("[BDArmory]: Penetration of bullet detonated fuel!");
+            }
+
+            resources.Dispose();
+
+            explodeScale /= 100;
+            part.explosionPotential = explodeScale;
+
+            PartExploderSystem.AddPartToExplode(part);
+        }
+    }
+}

--- a/BDArmory/Modules/ModuleCASE.cs
+++ b/BDArmory/Modules/ModuleCASE.cs
@@ -81,7 +81,7 @@ namespace BDArmory.Modules
             //part.mass = CASEmass;
             CASEcost = (CASELevel * 1000);
             //part.transform.localScale = (Vector3.one * (origScale + (CASELevel/10)));
-            Debug.Log("[SST Debug] part.mass = " + part.mass + "; CASElevel = " + CASELevel + "; CASEMass = " + CASEmass + "; Scale = " + part.transform.localScale);
+            //Debug.Log("[SST Debug] part.mass = " + part.mass + "; CASElevel = " + CASELevel + "; CASEMass = " + CASEmass + "; Scale = " + part.transform.localScale);
         }
         public override void OnLoad(ConfigNode node)
         {

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -95,7 +95,7 @@ namespace BDArmory.Modules
 
         //used by AI to lead moving targets
         private float targetDistance = 8000f;
-        private float targetRadius = 35f; // Radius of target 2° @ 1km.
+        public float targetRadius = 35f; // Radius of target 2° @ 1km.
         public float targetAdjustedMaxCosAngle
         {
             get
@@ -296,6 +296,10 @@ namespace BDArmory.Modules
         private bool spinningDown;
 
         //weapon specifications
+        [KSPField(advancedTweakable = true, isPersistant = true, guiActive = false, guiActiveEditor = false, guiName = "#LOC_BDArmory_FiringPriority"),
+    UI_FloatRange(minValue = 0, maxValue = 10, stepIncrement = 1, scene = UI_Scene.All, affectSymCounterparts = UI_Scene.All)]
+        public float priority = 0; //per-weapon priority selection override
+
         [KSPField(isPersistant = true)]
         public bool FireAngleOverride = false;
 


### PR DESCRIPTION
Reworks rocket impact code, rockets now do kinetic damage/penetrate armor
Rockets now properly report both attacker and defender stats to the competition scoring
Shared bullet/rocket code moved to Misc.ProjectileUtils.cs for convenience/future-proofing in case of adding additional projectile types
Tweaks to Weapon selection; Guns targeting ground will now prioritize biggest impact (bullet mass * velocity) instead of tntmass
Guns targeting air will now prioritize RPM for fighter-sized targets, and prioritize larger caliber guns when targeting larger targets (bombers/zeppelins/Ace Combat superweapons)
Adds weapon priority slider allowing setting custom weapon selection order for guns/rockets
