### PR TITLE
Armor Overhaul Beta

### DIFF
--- a/BDArmory.Core/Extension/PartExtensions.cs
+++ b/BDArmory.Core/Extension/PartExtensions.cs
@@ -416,10 +416,9 @@ namespace BDArmory.Core.Extension
                     {
                         Debug.Log("[BDArmory.PartExtensions]: Damage Before Reduction : " + damage);
                         Debug.Log("[BDArmory.PartExtensions]: Damage Reduction (%) : " + 1 + (((strength * (density / 1000)) * armor) / 1000000));
-                        Debug.Log("[BDArmory.PartExtensions]: Damage After Armor : " + (damage *= 1 + (((strength * (density / 1000)) * armor) / 1000000)));
+                        Debug.Log("[BDArmory.PartExtensions]: Damage After Armor : " + (damage /= 1 + (((strength * (density / 1000)) * armor) / 1000000)));
                     }
-                    damage *= 1 + (((strength * (density / 1000)) * armor) / 1000000); //500mm of DU yields about 95% reduction, 500mm steel = 80% reduction, Aramid = 73% reduction
-                    //still need to look into spalling implementation for explosions
+                    damage /= 1 + (((strength * (density / 1000)) * armor) / 1000000); //500mm of DU yields about 95% reduction, 500mm steel = 80% reduction, Aramid = 73% reduction
                     break;
                 default:
                     if (!(penetrationfactor >= 1f))

--- a/BDArmory.Core/Extension/PartExtensions.cs
+++ b/BDArmory.Core/Extension/PartExtensions.cs
@@ -143,7 +143,7 @@ namespace BDArmory.Core.Extension
             if (BDArmorySettings.DRAW_DEBUG_LABELS)
             {
                 Debug.Log("[BDArmory.PartExtensions]: mass: " + mass + " caliber: " + caliber + " multiplier: " + multiplier + " velocity: " + impactVelocity + " penetrationfactor: " + penetrationfactor);
-                Debug.Log("[BDArmory.PartExtensions]: Ballistic Hitpoints Applied : " + damage_);
+                Debug.Log("[BDArmory.PartExtensions]: Ballistic Hitpoints Applied to " + p.name + ": " + damage_);
             }
         }
 

--- a/BDArmory.Core/Module/HitpointTracker.cs
+++ b/BDArmory.Core/Module/HitpointTracker.cs
@@ -162,37 +162,6 @@ namespace BDArmory.Core.Module
 
                 Hitpoints = maxHitPoints_;
 
-                //Add Armor
-                if (maxSupportedArmor < 0)
-                {
-                    if (part.IsAero())
-                    {
-                        maxSupportedArmor = 20;
-                    }
-                    else if (part.partName.Contains("Armor")) //BDA Armor panels, etc.
-                    {
-                        maxSupportedArmor = 500; //could always be higher if you really want that 1x1x0.1m armor panel be able to mount 1500mm of armor...
-                        ArmorTypeNum = 2; //numtype 1 is armor type None, ensure armor panels start with armor
-
-                    }
-                    else
-                    {
-                        maxSupportedArmor = ((partSize.x / 20) * 1000); //~62mm for Size1, 125mm for S2, 185mm for S3
-                    }
-                }
-                if (ArmorThickness != 0 && ArmorThickness > maxSupportedArmor)
-                {
-                    maxSupportedArmor = ArmorThickness;
-                }
-                UI_FloatRange armorFieldFlight = (UI_FloatRange)Fields["Armor"].uiControlFlight;
-                armorFieldFlight.minValue = 0f;
-                armorFieldFlight.maxValue = maxSupportedArmor;
-                UI_FloatRange armorFieldEditor = (UI_FloatRange)Fields["Armor"].uiControlEditor;
-                armorFieldEditor.maxValue = maxSupportedArmor;
-                armorFieldEditor.minValue = 0f;
-                armorFieldEditor.onFieldChanged = ArmorSetup;
-                part.RefreshAssociatedWindows();
-
                 if (!ArmorSet) overrideArmorSetFromConfig();
 
                 previousHitpoints = maxHitPoints_;
@@ -278,7 +247,7 @@ namespace BDArmory.Core.Module
                 var sphereSurface = 4 * Mathf.PI * sphereRadius * sphereRadius;
                 var structuralVolume = sphereSurface * 0.1f;
 
-                var density = ((part.mass-armorMass) * 1000f) / structuralVolume;
+                var density = ((part.mass - armorMass) * 1000f) / structuralVolume;
                 density = Mathf.Clamp(density, 1000, 10000);
                 // if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDArmory.HitpointTracker]: Hitpoint Calc" + part.name + " | structuralVolume : " + structuralVolume);
                 // if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDArmory.HitpointTracker]: Hitpoint Calc" + part.name + " | Density : " + density);
@@ -439,37 +408,73 @@ namespace BDArmory.Core.Module
             {                                                                                               //Wings at least could use WingLiftArea as a workaround for approx. surface area...
                 sizeAdjust = 0.5f; //armor on one side, otherwise will have armor thickness on both sides of the panel, nonsensical + doiuble weight
             }
+            SetMaxArmor();
             armorVolume = ((Armor) *  // thickness * armor mass
             ((((partSize.x * partSize.y) * 2) + ((partSize.x * partSize.z) * 2) + ((partSize.y * partSize.z) * 2)) * sizeAdjust)); //mass * surface area approximation of a cylinder, where H/W are unknown
-            if (guiArmorTypeString != "None" && ArmorThickness == 0) //don't grab armor panels
+            if (guiArmorTypeString != "None") //don't grab armor panels
             {
                 armorMass = armorVolume * (Density / 1000000);
-                if (OldMaxArmor != maxSupportedArmor) maxSupportedArmor = OldMaxArmor; //if armor != None, reset max supported armor
-                UI_FloatRange armorFieldEditor = (UI_FloatRange)Fields["Armor"].uiControlEditor;
-                armorFieldEditor.maxValue = maxSupportedArmor;
+                armorCost = armorVolume * Cost;
             }
-            else
-            {
-                OldMaxArmor = maxSupportedArmor; //store max armor a part can ahve
-                maxSupportedArmor = 10; //then max none armor to 10 (simulate part skin of alimunium)
-                Armor = 10;
-                UI_FloatRange armorFieldEditor = (UI_FloatRange)Fields["Armor"].uiControlEditor;
-                armorFieldEditor.maxValue = maxSupportedArmor;
-            }
-
-            armorCost = armorVolume * Cost;
             if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[ARMOR]: part size is (X: " + partSize.x + ";, Y: " + partSize.y + "; Z: " + partSize.z);
             if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[ARMOR]: size adjust mult: " + sizeAdjust + "; part srf area: " + ((((partSize.x * partSize.y) * 2) + ((partSize.x * partSize.z) * 2) + ((partSize.y * partSize.z) * 2)) * sizeAdjust));
             using (IEnumerator<UIPartActionWindow> window = FindObjectsOfType(typeof(UIPartActionWindow)).Cast<UIPartActionWindow>().GetEnumerator())
-		while (window.MoveNext())
-		    {
-		    if (window.Current == null) continue;
-			if (window.Current.part == part)
-			    {
-				window.Current.displayDirty = true;
-			    }
-		    }
+                while (window.MoveNext())
+                {
+                    if (window.Current == null) continue;
+                    if (window.Current.part == part)
+                    {
+                        window.Current.displayDirty = true;
+                    }
+                }
         }
+
+        void SetMaxArmor()
+        {
+            if (guiArmorTypeString != "None") 
+            {
+                if (maxSupportedArmor < 0)
+                {
+                    if (part.IsAero())
+                    {
+                        maxSupportedArmor = 20;
+                    }
+                    else if (part.partName.Contains("Armor") || ArmorThickness > 0) //BDA Armor panels, etc.
+                    {
+                        maxSupportedArmor = 500; //could always be higher if you really want that 1x1x0.1m armor panel be able to mount 1500mm of armor...
+                        ArmorTypeNum = 2; //numtype 1 is armor type None, ensure armor panels start with armor
+                    }
+                    else
+                    {
+                        maxSupportedArmor = ((partSize.x / 20) * 1000); //~62mm for Size1, 125mm for S2, 185mm for S3
+                    }
+                }
+                if (ArmorThickness != 0 && ArmorThickness > maxSupportedArmor)
+                {
+                    maxSupportedArmor = ArmorThickness;
+                }
+                UI_FloatRange armorFieldFlight = (UI_FloatRange)Fields["Armor"].uiControlFlight;
+                armorFieldFlight.minValue = 0f;
+                armorFieldFlight.maxValue = maxSupportedArmor;
+                UI_FloatRange armorFieldEditor = (UI_FloatRange)Fields["Armor"].uiControlEditor;
+                armorFieldEditor.maxValue = maxSupportedArmor;
+                armorFieldEditor.minValue = 0f;
+                armorFieldEditor.onFieldChanged = ArmorSetup;
+                part.RefreshAssociatedWindows();
+            }
+            else
+            {
+                Armor = 10;
+                UI_FloatRange armorFieldEditor = (UI_FloatRange)Fields["Armor"].uiControlEditor;
+                armorFieldEditor.maxValue = 10; //max none armor to 10 (simulate part skin of alimunium)
+                armorFieldEditor.minValue = 10f;
+                UI_FloatRange armorFieldFlight = (UI_FloatRange)Fields["Armor"].uiControlFlight;
+                armorFieldFlight.minValue = 0f;
+                armorFieldFlight.maxValue = 10;
+            }
+
+        }
+
         private static Bounds CalcPartBounds(Part p, Transform t)
         {
             Bounds result = new Bounds(t.position, Vector3.zero);

--- a/BDArmory/Bullets/PooledBullet.cs
+++ b/BDArmory/Bullets/PooledBullet.cs
@@ -526,7 +526,11 @@ namespace BDArmory.Bullets
                                 transform.position += (currentVelocity * period) / 3;
 
                                 distanceTraveled += hit.distance;
-                                ExplosiveDetonation(hitPart, hit, bulletRay);
+                                if (explosive)
+                                {
+                                    ExplosiveDetonation(hitPart, hit, bulletRay);
+                                    ProjectileUtils.CalculateShrapnelDamage(hitPart, hit, caliber, tntMass, 0, sourceVesselName, bulletMass, penetrationFactor); //calc daamge from bullet exploding
+                                }
                                 hasDetonated = true;
                                 KillBullet();
                                 return true;
@@ -551,6 +555,7 @@ namespace BDArmory.Bullets
                             distanceTraveled += hit.distance;
                             hasPenetrated = false;
                             ProjectileUtils.ApplyDamage(hitPart, hit, 1, penetrationFactor, caliber, bulletMass, impactVelocity, bulletDmgMult, distanceTraveled, explosive, hasRicocheted, sourceVessel, bullet.name);
+                            ProjectileUtils.CalculateShrapnelDamage(hitPart, hit, caliber, tntMass, 0, sourceVesselName, bulletMass, penetrationFactor); 
                             ExplosiveDetonation(hitPart, hit, bulletRay);
                             hasDetonated = true;
                             KillBullet();

--- a/BDArmory/Bullets/PooledBullet.cs
+++ b/BDArmory/Bullets/PooledBullet.cs
@@ -85,6 +85,7 @@ namespace BDArmory.Bullets
         public float bulletVelocity; //muzzle velocity
         public bool explosive = false;
         public float apBulletMod = 0;
+        public bool sabot = false;
         public float ballisticCoefficient;
         public float flightTimeElapsed;
         public static Shader bulletShader;
@@ -113,6 +114,10 @@ namespace BDArmory.Bullets
         {
             startPosition = transform.position;
             initialSpeed = currentVelocity.magnitude; // this is the velocity used for drag estimations (only), use total velocity, not muzzle velocity
+            if (initialSpeed > 1500 && caliber < 30)
+            {
+                sabot = true; //assume anyround moving more that 1500m/s is a sabot round
+            }
             distanceTraveled = 0; // Reset the distance travelled for the bullet (since it comes from a pool).
 
             if (!wasInitiated)
@@ -275,7 +280,7 @@ namespace BDArmory.Bullets
             if (ProximityAirDetonation((float)distanceTraveled))
             {
                 //detonate
-                ExplosionFx.CreateExplosion(currPosition, tntMass, explModelPath, explSoundPath, ExplosionSourceType.Bullet, caliber, null, sourceVesselName, null, currentVelocity);
+                ExplosionFx.CreateExplosion(currPosition, tntMass, explModelPath, explSoundPath, ExplosionSourceType.Bullet, caliber, null, sourceVesselName, null, currentVelocity, false, bulletMass);
                 KillBullet();
 
                 return;
@@ -437,7 +442,7 @@ namespace BDArmory.Bullets
                         if (impulse != 0 && hitPart.rb != null)
                         {
                             hitPart.rb.AddForceAtPosition(impactVector.normalized * impulse, hit.point, ForceMode.Acceleration);
-                            ProjectileUtils.ApplyScore(hitPart, sourceVessel, distanceTraveled, 0, bullet.name);
+                            ProjectileUtils.ApplyScore(hitPart, sourceVesselName, distanceTraveled, 0, bullet.name);
                             break; //impulse rounds shouldn't penetrate/do damage
                         }
                         float anglemultiplier = (float)Math.Cos(Math.PI * hitAngle / 180.0);
@@ -461,10 +466,10 @@ namespace BDArmory.Bullets
                             //calculate bullet deformation
                             float newCaliber = ProjectileUtils.CalculateDeformation(armorStrength, bulletEnergy, caliber, impactVelocity, hardness, apBulletMod, Density);
                             //calculate penetration
-                            penetration = ProjectileUtils.CalculatePenetration(caliber, newCaliber, bulletEnergy, Ductility, Density, Strength, thickness);
+                            penetration = ProjectileUtils.CalculatePenetration(caliber, newCaliber, bulletMass, Ductility, Density, Strength, thickness, impactVelocity);
                             caliber = newCaliber; //update bullet with new caliber post-deformation(if any)
                             penetrationFactor = ProjectileUtils.CalculateArmorPenetration(hitPart, penetration);                            
-                            ProjectileUtils.CalculateArmorDamage(hitPart, penetrationFactor, caliber, hardness, Ductility, Density, impactVelocity, sourceVessel);
+                            ProjectileUtils.CalculateArmorDamage(hitPart, penetrationFactor, caliber, hardness, Ductility, Density, impactVelocity, sourceVessel.GetName());
 
                             //calculate return bullet post-pen vel
 
@@ -489,7 +494,7 @@ namespace BDArmory.Bullets
                         {
                             if (RicochetOnPart(hitPart, hit, hitAngle, impactVelocity, hit.distance / dist, period))
                             {
-                                bool viableBullet = ProjectileUtils.CalculateBulletStatus(bulletMass, caliber);
+                                bool viableBullet = ProjectileUtils.CalculateBulletStatus(bulletMass, caliber, sabot);
                                 if (!viableBullet)
                                 {
                                     KillBullet();
@@ -506,7 +511,7 @@ namespace BDArmory.Bullets
                         if (penetrationFactor > 1 && !hasRicocheted) //fully penetrated continue ballistic damage
                         {
                             hasPenetrated = true;
-                            bool viableBullet = ProjectileUtils.CalculateBulletStatus(bulletMass, caliber);
+                            bool viableBullet = ProjectileUtils.CalculateBulletStatus(bulletMass, caliber, sabot);
                             ProjectileUtils.ApplyDamage(hitPart, hit, 1, penetrationFactor, caliber, bulletMass, impactVelocity, bulletDmgMult, distanceTraveled, explosive, hasRicocheted, sourceVessel, bullet.name);
                             penTicker += 1;
                             ProjectileUtils.CheckPartForExplosion(hitPart);
@@ -670,11 +675,11 @@ namespace BDArmory.Bullets
 
                     if (airDetonation)
                     {
-                        ExplosionFx.CreateExplosion(hit.point, GetExplosivePower(), explModelPath, explSoundPath, ExplosionSourceType.Bullet, caliber, null, sourceVesselName);
+                        ExplosionFx.CreateExplosion(hit.point, GetExplosivePower(), explModelPath, explSoundPath, ExplosionSourceType.Bullet, caliber, null, sourceVesselName, null, default, false, bulletMass);
                     }
                     else
                     {
-                        ExplosionFx.CreateExplosion(hit.point - (ray.direction * 0.1f), GetExplosivePower(), explModelPath, explSoundPath, ExplosionSourceType.Bullet, caliber, null, sourceVesselName);
+                        ExplosionFx.CreateExplosion(hit.point - (ray.direction * 0.1f), GetExplosivePower(), explModelPath, explSoundPath, ExplosionSourceType.Bullet, caliber, null, sourceVesselName, null, default, false, bulletMass);
                     }
 
                     KillBullet();

--- a/BDArmory/Bullets/PooledRocket.cs
+++ b/BDArmory/Bullets/PooledRocket.cs
@@ -347,6 +347,7 @@ namespace BDArmory.Bullets
                                 hasPenetrated = true;
                                 bool viableBullet = ProjectileUtils.CalculateBulletStatus(rocketMass*1000, caliber);
                                 ProjectileUtils.ApplyDamage(hitPart, hit, 1, penetrationFactor, caliber, rocketMass*1000, impactVelocity, bulletDmgMult, distanceFromStart, explosive, false, sourceVessel, rocketName);
+                                ProjectileUtils.CalculateShrapnelDamage(hitPart, hit, caliber, tntMass, 0, sourceVesselName, (rocketMass*1000), penetrationFactor);
                                 penTicker += 1;
                                 ProjectileUtils.CheckPartForExplosion(hitPart);
 
@@ -376,6 +377,7 @@ namespace BDArmory.Bullets
 
                                 hasPenetrated = false;
                                 ProjectileUtils.ApplyDamage(hitPart, hit, 1, penetrationFactor, caliber, (rocketMass*1000), impactVelocity, bulletDmgMult, distanceFromStart, explosive, false, sourceVessel, rocketName);
+                                ProjectileUtils.CalculateShrapnelDamage(hitPart, hit, caliber, tntMass, 0, sourceVesselName, (rocketMass*1000), penetrationFactor);
                                 Detonate(hit.point, false);
                                 hasDetonated = true;
                             }

--- a/BDArmory/Bullets/PooledRocket.cs
+++ b/BDArmory/Bullets/PooledRocket.cs
@@ -323,10 +323,10 @@ namespace BDArmory.Bullets
                                 //calculate bullet deformation
                                 float newCaliber = ProjectileUtils.CalculateDeformation(armorStrength, bulletEnergy, caliber, impactVelocity, hardness, 1, Density);
                                 //calculate penetration
-                                penetration = ProjectileUtils.CalculatePenetration(caliber, newCaliber, bulletEnergy, Ductility, Density, Strength, thickness);
+                                penetration = ProjectileUtils.CalculatePenetration(caliber, newCaliber, rocketMass*1000, impactVelocity, Ductility, Density, Strength, thickness);
                                 caliber = newCaliber; //update bullet with new caliber post-deformation(if any)
                                 penetrationFactor = ProjectileUtils.CalculateArmorPenetration(hitPart, penetration);
-                                ProjectileUtils.CalculateArmorDamage(hitPart, penetrationFactor, caliber, hardness, Ductility, Density, impactVelocity, sourceVessel);
+                                ProjectileUtils.CalculateArmorDamage(hitPart, penetrationFactor, caliber, hardness, Ductility, Density, impactVelocity, sourceVessel.GetName());
 
                                 //calculate return bullet post-pen vel
 
@@ -535,7 +535,7 @@ namespace BDArmory.Bullets
                     }
                     else
                     {
-                        ExplosionFx.CreateExplosion(pos, tntMass, explModelPath, explSoundPath, ExplosionSourceType.Bullet, caliber, null, sourceVesselName, null, direction);
+                        ExplosionFx.CreateExplosion(pos, tntMass, explModelPath, explSoundPath, ExplosionSourceType.Bullet, caliber, null, sourceVesselName, null, direction, false, (rocketMass * 1000));
                     }
                     if (gravitic)
                     {

--- a/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Bullets.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Bullets.cfg
@@ -740,11 +740,11 @@ BULLET
     name = 120mmBulletHE
 	caliber = 120
 	bulletVelocity = 800
-	bulletMass = 19.6
+	bulletMass = 11.4
 	//HE Bullet Values
 	explosive = True
-	tntMass = 15.68
-	fuzeType = None 
+	tntMass = 8
+	fuzeType = None //proximity apparently?
 	projectileColor = 250, 130, 0, 128
 	fadeColor = False
 	startColor = 128, 128, 128, 0
@@ -756,7 +756,7 @@ BULLET
 BULLET
 {
     name = 120mmBulletSabot
-	caliber = 20
+	caliber = 27
 	bulletVelocity = 1750
 	bulletMass = 9
 	//HE Bullet Values
@@ -774,9 +774,9 @@ BULLET
 BULLET
 {
     name = 120mmBulletCannister
-	caliber = 20
+	caliber = 9.5 
 	bulletVelocity = 1200
-	bulletMass = 0.17
+	bulletMass = 0.00853
 	//HE Bullet Values
 	explosive = False
 	tntMass = 0
@@ -784,8 +784,8 @@ BULLET
 	projectileColor = 250, 70, 0, 128
 	fadeColor = False
 	startColor = 128, 128, 128, 0
-	subProjectileCount = 40
-	apBulletMod = 0.7
+	subProjectileCount = 300 //IRL 1098!
+	apBulletMod = 0.8
 	bulletDragTypeName = AnalyticEstimate
 }
 

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -25,6 +25,7 @@ namespace BDArmory.FX
         private float MaxTime { get; set; }
         public float Range { get; set; }
         public float Caliber { get; set; }
+        public float ProjMass { get; set; }
         public ExplosionSourceType ExplosionSource { get; set; }
         public string SourceVesselName { get; set; }
         public string SourceWeaponName { get; set; }
@@ -135,7 +136,7 @@ namespace BDArmory.FX
                         break;
                 }
             }
-            using (var hitCollidersEnu = Physics.OverlapSphere(Position, Range, 9076737).AsEnumerable().GetEnumerator())
+            using (var hitCollidersEnu = Physics.OverlapSphere(Position, (Range*2), 9076737).AsEnumerable().GetEnumerator())
             {
                 while (hitCollidersEnu.MoveNext())
                 {
@@ -233,16 +234,20 @@ namespace BDArmory.FX
                 if (IsAngleAllowed(Direction, hit))
                 {
                     //Adding damage hit
-                    eventList.Add(new PartBlastHitEvent()
+                    if (distance <= Range)//part within blast
                     {
-                        Distance = distance,
-                        Part = part,
-                        TimeToImpact = distance / ExplosionVelocity,
-                        HitPoint = hit.point,
-                        Hit = hit,
-                        SourceVesselName = sourceVesselName,
-                        IntermediateParts = intermediateParts
-                    });
+                        eventList.Add(new PartBlastHitEvent()
+                        {
+                            Distance = distance,
+                            Part = part,
+                            TimeToImpact = distance / ExplosionVelocity,
+                            HitPoint = hit.point,
+                            Hit = hit,
+                            SourceVesselName = sourceVesselName,
+                            IntermediateParts = intermediateParts
+                        });
+                    }
+                    ProjectileUtils.CalculateShrapnelDamage(part, hit, 120, Power, distance, sourceVesselName, ProjMass); //part hit by shrapnel, but not pressure wave
                     partsAdded.Add(part);
                     return true;
                 }
@@ -446,49 +451,50 @@ namespace BDArmory.FX
                             BDArmorySettings.EXP_IMP_MOD,
                             eventToExecute.HitPoint + rb.velocity * TimeIndex);
                     }
-
-                    var damage = part.AddExplosiveDamage(blastInfo.Damage, Caliber, ExplosionSource);
-                    if (BDArmorySettings.BATTLEDAMAGE)
+                    var damage = 0f;
+                    if (!ProjectileUtils.CalculateExplosiveArmorDamage(part, blastInfo.TotalPressure, SourceVesselName, eventToExecute.Hit)) //false = armor blowthrough
                     {
-                        Misc.BattleDamageHandler.CheckDamageFX(part, 50, 0.5f, true, SourceVesselName, eventToExecute.Hit);
+                        damage = part.AddExplosiveDamage(blastInfo.Damage, Caliber, ExplosionSource);
                     }
-
-                    // Update scoring structures
-                    switch (ExplosionSource)
+                    if (damage > 0) //else damage from spalling done in CalcExplArmorDamage
                     {
-                        case ExplosionSourceType.Bullet:
-                        case ExplosionSourceType.Missile:
-                            var aName = eventToExecute.SourceVesselName; // Attacker
-                            var tName = part.vessel.GetName(); // Target
-                            if (aName != tName && BDACompetitionMode.Instance.Scores.ContainsKey(tName) && BDACompetitionMode.Instance.Scores.ContainsKey(aName))
-                            {
-                                var tData = BDACompetitionMode.Instance.Scores[tName];
-                                // Track damage
-                                switch (ExplosionSource)
+                        // Update scoring structures
+                        switch (ExplosionSource)
+                        {
+                            case ExplosionSourceType.Bullet:
+                            case ExplosionSourceType.Missile:
+                                var aName = eventToExecute.SourceVesselName; // Attacker
+                                var tName = part.vessel.GetName(); // Target
+                                if (aName != tName && BDACompetitionMode.Instance.Scores.ContainsKey(tName) && BDACompetitionMode.Instance.Scores.ContainsKey(aName))
                                 {
-                                    case ExplosionSourceType.Bullet:
-                                        if (tData.damageFromBullets.ContainsKey(aName))
-                                            tData.damageFromBullets[aName] += damage;
-                                        else
-                                            tData.damageFromBullets.Add(aName, damage);
-                                        if (BDArmorySettings.REMOTE_LOGGING_ENABLED)
-                                            BDAScoreService.Instance.TrackDamage(aName, tName, damage);
-                                        break;
-                                    case ExplosionSourceType.Missile:
-                                        if (tData.damageFromMissiles.ContainsKey(aName))
-                                            tData.damageFromMissiles[aName] += damage;
-                                        else
-                                            tData.damageFromMissiles.Add(aName, damage);
-                                        if (BDArmorySettings.REMOTE_LOGGING_ENABLED)
-                                            BDAScoreService.Instance.TrackMissileDamage(aName, tName, damage);
-                                        break;
-                                    default:
-                                        break;
+                                    var tData = BDACompetitionMode.Instance.Scores[tName];
+                                    // Track damage
+                                    switch (ExplosionSource)
+                                    {
+                                        case ExplosionSourceType.Bullet:
+                                            if (tData.damageFromBullets.ContainsKey(aName))
+                                                tData.damageFromBullets[aName] += damage;
+                                            else
+                                                tData.damageFromBullets.Add(aName, damage);
+                                            if (BDArmorySettings.REMOTE_LOGGING_ENABLED)
+                                                BDAScoreService.Instance.TrackDamage(aName, tName, damage);
+                                            break;
+                                        case ExplosionSourceType.Missile:
+                                            if (tData.damageFromMissiles.ContainsKey(aName))
+                                                tData.damageFromMissiles[aName] += damage;
+                                            else
+                                                tData.damageFromMissiles.Add(aName, damage);
+                                            if (BDArmorySettings.REMOTE_LOGGING_ENABLED)
+                                                BDAScoreService.Instance.TrackMissileDamage(aName, tName, damage);
+                                            break;
+                                        default:
+                                            break;
+                                    }
                                 }
-                            }
-                            break;
-                        default:
-                            break;
+                                break;
+                            default:
+                                break;
+                        }
                     }
                 }
                 else if (BDArmorySettings.DRAW_DEBUG_LABELS)
@@ -547,7 +553,7 @@ namespace BDArmory.FX
             }
         }
 
-        public static void CreateExplosion(Vector3 position, float tntMassEquivalent, string explModelPath, string soundPath, ExplosionSourceType explosionSourceType, float caliber = 0, Part explosivePart = null, string sourceVesselName = null, string sourceWeaponName = null, Vector3 direction = default(Vector3), bool isfx = false)
+        public static void CreateExplosion(Vector3 position, float tntMassEquivalent, string explModelPath, string soundPath, ExplosionSourceType explosionSourceType, float caliber = 0, Part explosivePart = null, string sourceVesselName = null, string sourceWeaponName = null, Vector3 direction = default(Vector3), bool isfx = false, float projectilemass = 0)
         {
             CreateObjectPool(explModelPath, soundPath);
 
@@ -567,6 +573,7 @@ namespace BDArmory.FX
             eFx.Range = BlastPhysicsUtils.CalculateBlastRange(tntMassEquivalent);
             eFx.Position = position;
             eFx.Power = tntMassEquivalent;
+            eFx.ProjMass = projectilemass;
             eFx.ExplosionSource = explosionSourceType;
             eFx.SourceVesselName = sourceVesselName != null ? sourceVesselName : explosionSourceType == ExplosionSourceType.Missile ? (explosivePart != null && explosivePart.vessel != null ? explosivePart.vessel.GetName() : null) : null; // Use the sourceVesselName if specified, otherwise get the sourceVesselName from the missile if it is one.
             eFx.SourceWeaponName = sourceWeaponName;

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -136,7 +136,12 @@ namespace BDArmory.FX
                         break;
                 }
             }
-            using (var hitCollidersEnu = Physics.OverlapSphere(Position, (Range*2), 9076737).AsEnumerable().GetEnumerator())
+            float shrapnelrange = Range;
+            if (ProjMass > 0)
+            {
+                shrapnelrange = Range*2;
+            }
+            using (var hitCollidersEnu = Physics.OverlapSphere(Position, shrapnelrange, 9076737).AsEnumerable().GetEnumerator())
             {
                 while (hitCollidersEnu.MoveNext())
                 {
@@ -247,7 +252,10 @@ namespace BDArmory.FX
                             IntermediateParts = intermediateParts
                         });
                     }
-                    ProjectileUtils.CalculateShrapnelDamage(part, hit, 120, Power, distance, sourceVesselName, ProjMass); //part hit by shrapnel, but not pressure wave
+                    if (ProjMass > 0)
+                    {
+                        ProjectileUtils.CalculateShrapnelDamage(part, hit, 120, Power, distance, sourceVesselName, ProjMass); //part hit by shrapnel, but not pressure wave
+                    }
                     partsAdded.Add(part);
                     return true;
                 }

--- a/BDArmory/FX/FireFX.cs
+++ b/BDArmory/FX/FireFX.cs
@@ -305,7 +305,7 @@ namespace BDArmory.FX
                         }
                     }
                 }
-                ExplosionFx.CreateExplosion(parentPart.transform.position, tntMassEquivilent, explModelPath, explSoundPath, ExplosionSourceType.Bullet, 0, null, parentPart.vessel != null ? parentPart.vessel.name : null, null);
+                ExplosionFx.CreateExplosion(parentPart.transform.position, tntMassEquivilent, explModelPath, explSoundPath, ExplosionSourceType.Bullet, 0, null, parentPart.vessel != null ? parentPart.vessel.name : null, null,default, false, parentPart.mass);
                 // needs to be Explosiontype Bullet since missile only returns Module MissileLauncher
                 gameObject.SetActive(false);
             }

--- a/BDArmory/Misc/ProjectileUtils.cs
+++ b/BDArmory/Misc/ProjectileUtils.cs
@@ -230,7 +230,7 @@ namespace BDArmory.Misc
                 float shrapnelCount = Mathf.Clamp((frangibility / (4 * Mathf.PI * Mathf.Pow(detonationDist, 2))), 0, (frangibility*.4f)); //fragments/m2
                 shrapnelCount *= (float)(hitPart.radiativeArea / 3); //shrapnelhits/part
                 float shrapnelMass = ((projmass * (1 - HERatio)) / frangibility) * shrapnelCount;
-
+		// go through and make sure all unit conversions correct
                 if (penetrationFactor == -1) //airburst/parts caught in AoE
                 {
                     if (detonationDist > (5 * caliber)) //contact detonation
@@ -316,15 +316,16 @@ namespace BDArmory.Misc
             float spallMass;
             float damage;
             var Armor = hitPart.FindModuleImplementing<HitpointTracker>();
-			if (Armor != null)
-			{
-				float ductility = Armor.Ductility;
-				float hardness = Armor.Hardness;
-				float Strength = Armor.Strength;
-				float Density = Armor.Density;
+	    if (Armor != null)
+	    {
+		float ductility = Armor.Ductility;
+		float hardness = Armor.Hardness;
+		float Strength = Armor.Strength;
+		float Density = Armor.Density;
 
                 float ArmorTolerance = Strength * (1+ductility) * thickness;
                 float blowthroughFactor = (float)BlastPressure / ArmorTolerance;
+		//is BlastUtils maxpressure in MPa? confirm blast pressure from ExplosionUtils on same scale/magnitude as armorTolerance
                 if (ductility > 0.20f)
                 {
                     if (BlastPressure > ArmorTolerance) //material stress tolerance exceeded, armor rupture

--- a/BDArmory/Misc/ProjectileUtils.cs
+++ b/BDArmory/Misc/ProjectileUtils.cs
@@ -35,11 +35,10 @@ namespace BDArmory.Misc
             // Debug.Log("DEBUG Ballistic damage to " + hitPart + ": " + damage + ", calibre: " + caliber + ", multiplier: " + multiplier + ", pen: " + penetrationfactor);
 
             // Update scoring structures
-            ApplyScore(hitPart, sourceVessel, distanceTraveled, damage, name);
+            ApplyScore(hitPart, sourceVessel.GetName(), distanceTraveled, damage, name);
         }
-        public static void ApplyScore(Part hitPart, Vessel sourceVessel, double distanceTraveled, float damage, string name)
+        public static void ApplyScore(Part hitPart, string aName, double distanceTraveled, float damage, string name)
         {
-            var aName = sourceVessel.GetName();
             var tName = hitPart.vessel.GetName();
 
             if (aName != null && tName != null && aName != tName && BDACompetitionMode.Instance.Scores.ContainsKey(aName) && BDACompetitionMode.Instance.Scores.ContainsKey(tName))
@@ -90,8 +89,8 @@ namespace BDArmory.Misc
             ///////////////////////////////////////////////////////////////////////
 
             float thickness = (float)hitPart.GetArmorThickness();
-			
-            var penetrationFactor = penetration / thickness; 
+
+            var penetrationFactor = penetration / thickness;
 
             if (BDArmorySettings.DRAW_DEBUG_LABELS)
             {
@@ -106,7 +105,7 @@ namespace BDArmory.Misc
             }
             return penetrationFactor;
         }
-        public static void CalculateArmorDamage(Part hitPart, float penetrationFactor, float caliber, float hardness, float ductility, float density, float impactVel, Vessel sourceVessel)
+        public static void CalculateArmorDamage(Part hitPart, float penetrationFactor, float caliber, float hardness, float ductility, float density, float impactVel, string sourceVesselName)
         {
             float thickness = (float)hitPart.GetArmorThickness();
             double volumeToReduce = -1;
@@ -116,7 +115,7 @@ namespace BDArmory.Misc
             //Spalling/Armor damage
             if (ductility > 0.20f)
             {
-                if (penetrationFactor > 2) //proj fast material can't stretch fast enough, necking/point embrittlelment/etc, material tears
+                if (penetrationFactor > 2) //material can't stretch fast enough, necking/point embrittlelment/etc, material tears
                 {
                     if (thickness < 2 * caliber)
                     {
@@ -127,7 +126,7 @@ namespace BDArmory.Misc
                         caliberModifier = 2;
                     }
                     spallCaliber = caliber * (caliberModifier / 2);
-                    spallMass = Mathf.Pow(0.5f * spallCaliber, 2) * Mathf.PI / 1000 * thickness * (density/1000000);
+                    spallMass = Mathf.Pow(0.5f * spallCaliber, 2) * Mathf.PI / 1000 * thickness * (density / 1000000);
                     if (BDArmorySettings.DRAW_DEBUG_LABELS)
                     {
                         Debug.Log("[BDArmory.ProjectileUtils]: Armor spalling! Diameter: " + spallCaliber + "; mass: " + spallMass + "g");
@@ -166,7 +165,7 @@ namespace BDArmory.Misc
                         if (BDArmorySettings.DRAW_DEBUG_LABELS)
                         {
                             Debug.Log("[BDArmory.ProjectileUtils]: Armor failure!");
-                            Debug.Log("[BDArmory.ProjectileUtils]: Armor spalling! Diameter: " + spallCaliber + "; mass: " + spallMass +"g");
+                            Debug.Log("[BDArmory.ProjectileUtils]: Armor spalling! Diameter: " + spallCaliber + "; mass: " + spallMass + "g");
                         }
                     }
                 }
@@ -194,29 +193,251 @@ namespace BDArmory.Misc
                 float damage = hitPart.AddBallisticDamage(spallMass, spallCaliber, 1, 1.1f, 1, (impactVel / 3));
                 if (BDArmorySettings.DRAW_DEBUG_LABELS)
                 {
-                    Debug.Log("[BDArmory.ProjectileUtils]: Spall damage: "+damage);
+                    Debug.Log("[BDArmory.ProjectileUtils]: Spall damage: " + damage);
                 }
-                ApplyScore(hitPart, sourceVessel, 1, damage, "Spall Damage");
+                //ApplyScore(hitPart, sourceVessel, 1, damage, "Spall Damage");
             }
         }
-        /*
-        public static float CalculatePenetration(float caliber, float projMass, float impactVel, float apBulletMod = 1)
+        public static void CalculateShrapnelDamage(Part hitPart, RaycastHit hit, float caliber, float HEmass, float detonationDist, string sourceVesselName, float penetrationFactor = -1, float projmass = -1)
         {
-            float penetration = 0;
-            if (apBulletMod <= 0) // sanity check/legacy compatibility
+            float thickness = (float)hitPart.GetArmorThickness();
+            double volumeToReduce;
+            var Armor = hitPart.FindModuleImplementing<HitpointTracker>();
+            if (Armor != null)
             {
-                apBulletMod = 1;
-            }
+                float Ductility = Armor.Ductility;
+                float hardness = Armor.Hardness;
+                float Strength = Armor.Strength;
+                float Density = Armor.Density;
+                //Spalling/Armor damage
+                //minimum armor thickness to stop shrapnel is 0.08 calibers for 1.4-3.5% HE by mass; 0.095 calibers for 3.5-5.99% HE by mass; and .11 calibers for 6% HE by mass, assuming detonation is > 5calibers away
+                //works out to y = 0.0075x^(1.05)+0.06
+                //20mm Vulcan is HE fraction 13%, so 0.17 calibers(3.4mm), GAU ~0.19, or 0.22calibers(6.6mm), AbramsHe 80%, so 0.8calibers(96mm)
+                //HE contact detonation penetration; minimum thickness of armor to receive caliber sized hole: thickness = (2.576 * 10 ^ -20) * Caliber * ((velocity/3.2808) ^ 5.6084) * Cos(2 * angle - 45)) +(0.156 * diameter)
+                //TL;Dr; armor thickness needed is .156*caliber, and if less than, will generate a caliber*proj length hole. half the min thickness will yield a 2x size hole
+                //angle and impact vel have negligible impact on hole size
+                //if the round penetrates, increased damage; min thickness of .187 calibers to prevent armor cracking //is this per the 6% HE fraction above, or ? could just do the shrapnelfraction * 1.41/1.7
+                //in calculating shrapnel, sim shrapnel in HE detonations? so change EplosionFX from grabbing everything within the balst pressure wave (which caps explosion size to 100m or so) to grabbing everything within the pressure wave + some multiplier?
+                //everything outside the blastwave can only take shrapnel damage, num of shrapnel hits decreases with range, have hits randomly assigned to LOS parts(should be less performance intensive than calculating a whole bunch of raycasts using gaussian distribution
+                float HERatio = 0.06f;
+				if (projmass > 0)
+				{
+					HERatio = HEmass / projmass;
+				}
+                float frangibility = 5000 * HERatio;
+                float shrapnelThickness = (Mathf.Pow(0.0075f * HERatio, 1.05f) + 0.06f) * caliber; //min thickness of material for HE to blow caliber size hole in steel
+                shrapnelThickness *= (950 / Strength) * (8000 / Density) * (Mathf.Sqrt(1100 / Density)); //adjusted min thickness after material hardness/strength/density
+                float shrapnelCount = Mathf.Clamp((frangibility / (4 * Mathf.PI * Mathf.Pow(detonationDist, 2))), 0, (frangibility*.4f)); //fragments/m2
+                shrapnelCount *= (float)(hitPart.radiativeArea / 3); //shrapnelhits/part
+                float shrapnelMass = (((projmass-HEmass) * (1 - HERatio)) / frangibility) * shrapnelCount;
 
-            if (caliber > 5) //use the "krupp" penetration formula for anything larger than HMGs
-            {
-                penetration = (float)(16f * impactVel * Math.Sqrt(projMass / 1000) / Math.Sqrt(caliber) * apBulletMod); //APBulletMod now actually implemented, serves as penetration multiplier, 1 being neutral, <1 for soft rounds, >1 for AP penetrators
+                if (penetrationFactor < 0) //airburst/parts caught in AoE
+                {
+                    if (detonationDist > (5 * caliber)) //contact detonation
+                    {
+                        if (thickness < shrapnelThickness && shrapnelCount > 0)
+                        {
+                            //armor penetration by subcaliber shrapnel; use dist to abstract # of fragments that hit to calculate damage, assuming 5k fragments for now
+                            volumeToReduce = ((caliber / (100 / (1 - HERatio))) * thickness * shrapnelCount);
+                            hitPart.ReduceArmor(volumeToReduce);
+                            if (BDArmorySettings.DRAW_DEBUG_LABELS)
+                            {
+                                Debug.Log("[BDArmory.ProjectileUtils]: Shrapnel penetration; Armor damage: " + volumeToReduce + "; part damage: ");
+                            }
+                            hitPart.AddBallisticDamage(shrapnelMass, 0.1f, 1, (shrapnelThickness / thickness), 1, 6500); //expansion rate of tnt/petn ~7500m/s
+                            CalculateArmorDamage(hitPart, (shrapnelThickness / thickness), ((caliber / 5000) * shrapnelCount), hardness, Ductility, Density, 6500, sourceVesselName);
+                            BattleDamageHandler.CheckDamageFX(hitPart, caliber, (shrapnelThickness / thickness), false, sourceVesselName, hit); //bypass score mechanic so HE rounds don't have inflated scores
+                        }
+                    }
+                    else //within 5 calibers of detonation
+                    {
+                        if (thickness < (shrapnelThickness * 1.41f))
+                        {
+                            //armor breach
+                            volumeToReduce = (caliber * thickness * (caliber * 4));
+                            hitPart.ReduceArmor(volumeToReduce);
+                            if (BDArmorySettings.DRAW_DEBUG_LABELS)
+                            {
+                                Debug.Log("[BDArmory.ProjectileUtils]: Shrapnel penetration; Armor damage: " + volumeToReduce + "; part damage: ");
+                            }
+                            hitPart.AddBallisticDamage(shrapnelMass, 0.1f, 1, (shrapnelThickness / thickness), 1, 7500); //within 5 calibers shrapnel still getting pushed/accelerated by blast
+                            CalculateArmorDamage(hitPart, (shrapnelThickness / thickness), ((caliber / 5000) * shrapnelCount), hardness, Ductility, Density, 7500, sourceVesselName);
+                            BattleDamageHandler.CheckDamageFX(hitPart, caliber, (shrapnelThickness / thickness), true, sourceVesselName, hit);
+                        }
+                        else
+                        {
+                            if (thickness < (shrapnelThickness * 1.7))//armor cracks; 
+                            {
+                                volumeToReduce = (Mathf.Pow(Mathf.CeilToInt(caliber / 100), 2) * 100 * thickness);
+                                hitPart.ReduceArmor(volumeToReduce);
+                                if (BDArmorySettings.DRAW_DEBUG_LABELS)
+                                {
+                                    Debug.Log("[BDArmory.ProjectileUtils]: Explosive Armor failure; Armor damage: " + volumeToReduce);
+                                }
+                            }
+                        }
+                    }
+                }
+                else //detonates in armor
+                {
+                    if (penetrationFactor < 1)
+                    {
+                        thickness *= (1 - penetrationFactor); //armor thickness reduced from projectile penetrating some distance, less distance from proj to back of plate
+                        if (thickness < (shrapnelThickness * 1.41f))
+                        {
+                            //armor breach
+                            volumeToReduce = (caliber * thickness * (caliber * 4)) * 2;
+                            hitPart.ReduceArmor(volumeToReduce);
+                            if (BDArmorySettings.DRAW_DEBUG_LABELS)
+                            {
+                                Debug.Log("[BDArmory.ProjectileUtils]: Shrapnel penetration; Armor damage: " + volumeToReduce + "; part damage: ");
+                            }
+                            hitPart.AddBallisticDamage(shrapnelMass, 0.1f, 1, (shrapnelThickness / thickness), 1, 7500); //within 5 calibers shrapnel still getting pushed/accelerated by blast
+                            CalculateArmorDamage(hitPart, (shrapnelThickness / thickness), ((caliber / 5000) * shrapnelCount), hardness, Ductility, Density, 7500, sourceVesselName);
+                            BattleDamageHandler.CheckDamageFX(hitPart, caliber, (shrapnelThickness / thickness), true, sourceVesselName, hit);
+                        }
+                    }
+                    else //internal detonation
+                    {
+                        hitPart.AddBallisticDamage(projmass, 0.1f, 1, 1.9f, 1, 7500); //internal det catches entire shrapnel mass
+                    }
+                }
             }
-
-            return penetration;
         }
-        */
-        public static float CalculateProjectileEnergy(float projMass, float impactVel)
+        public static bool CalculateExplosiveArmorDamage(Part hitPart, double BlastPressure, string sourcevessel, RaycastHit hit)
+        {
+            //use blastTotalPressure to get MPa of shock on plate, compare to armor mat tolerances
+            float thickness = (float)hitPart.GetArmorThickness();
+            float spallCaliber = ((float)hitPart.radiativeArea / 3)*1000;  //using this as a hack for affected srf. area, convert m2 to mm2
+            float spallMass;
+            float damage;
+            var Armor = hitPart.FindModuleImplementing<HitpointTracker>();
+			if (Armor != null)
+			{
+				float ductility = Armor.Ductility;
+				float hardness = Armor.Hardness;
+				float Strength = Armor.Strength;
+				float Density = Armor.Density;
+
+                float ArmorTolerance = Strength * (1+ductility) * thickness;
+                float blowthroughFactor = (float)BlastPressure / ArmorTolerance;
+                if (ductility > 0.20f)
+                {
+                    if (BlastPressure > ArmorTolerance) //material stress tolerance exceeded, armor rupture
+                    {
+                        spallMass = Mathf.Pow(0.5f * spallCaliber, 2) * Mathf.PI/1000 * thickness * (Density / 1000000);
+                        hitPart.ReduceArmor(spallCaliber * thickness);
+                        if (BDArmorySettings.DRAW_DEBUG_LABELS)
+                        {
+                            Debug.Log("[BDArmory.ProjectileUtils]: Armor rupture! Size: " + spallCaliber + "; mass: " + spallMass + "kg");
+                        }
+                        damage = hitPart.AddBallisticDamage(spallMass, spallCaliber, 1, blowthroughFactor, 1, 500);
+                        ApplyScore(hitPart, sourcevessel, 1, damage, "Spall Damage");
+                        if (BDArmorySettings.BATTLEDAMAGE)
+                        {
+                            BattleDamageHandler.CheckDamageFX(hitPart, spallCaliber, blowthroughFactor, true, sourcevessel, hit);
+                        }
+                        return false;
+                    }
+                    if (blowthroughFactor > 0.66) //armor holds, spalling
+                    {
+                        spallCaliber *= ((1 - ductility) * blowthroughFactor);
+                        spallMass = Mathf.Pow(0.5f * spallCaliber, 2) * Mathf.PI/1000 * (thickness/10) * (Density / 1000000);
+                        hitPart.ReduceArmor(spallCaliber * (thickness / 10));
+                        if (BDArmorySettings.DRAW_DEBUG_LABELS)
+                        {
+                            Debug.Log("[BDArmory.ProjectileUtils]: Explosive Armor spalling! Size: " + spallCaliber + "; mass: " + spallMass + "kg");
+                        }
+                        damage = hitPart.AddBallisticDamage(spallMass, spallCaliber, 1, blowthroughFactor, 1, 500);
+                        ApplyScore(hitPart, sourcevessel, 1, damage, "Spall Damage");
+                        if (BDArmorySettings.BATTLEDAMAGE)
+                        {
+                            BattleDamageHandler.CheckDamageFX(hitPart, spallCaliber, blowthroughFactor, false, sourcevessel, hit);
+                        }
+                        return true;
+                    }
+                }
+                else //ductility < 0.20
+                {
+                    if (hardness > 500)
+                    {
+                        if (blowthroughFactor > 1)
+                        {
+                            if (ductility < 0.05f) //ceramics
+                            {
+                                hitPart.ReduceArmor((Mathf.Pow(Mathf.CeilToInt(spallCaliber / 100), 2) * 100 * thickness));
+                                //total failue of 10x10cm armor tile(s)
+                                if (BDArmorySettings.DRAW_DEBUG_LABELS)
+                                {
+                                    Debug.Log("[BDArmory.ProjectileUtils]: Armor destruction!");
+                                }
+                                if (BDArmorySettings.BATTLEDAMAGE)
+                                {
+                                    BattleDamageHandler.CheckDamageFX(hitPart, spallCaliber, blowthroughFactor, true, sourcevessel, hit);
+                                }
+                            }
+                            else; //0.05-0.19 ductility - harder steels, etc
+                            {
+                                spallCaliber *= ((1.2f - ductility) * blowthroughFactor);
+                                spallMass = Mathf.Pow(0.5f * spallCaliber, 2) * Mathf.PI/1000 * thickness * (Density / 1000000);
+                                hitPart.ReduceArmor(spallCaliber * thickness);
+                                damage = hitPart.AddBallisticDamage(spallMass, spallCaliber, 1, blowthroughFactor, 1, 500);
+                                ApplyScore(hitPart, sourcevessel, 1, damage, "Spall Damage");
+                                if (BDArmorySettings.DRAW_DEBUG_LABELS)
+                                {
+                                    Debug.Log("[BDArmory.ProjectileUtils]: Armor sundered!");
+                                }
+                                if (BDArmorySettings.BATTLEDAMAGE)
+                                {
+                                    BattleDamageHandler.CheckDamageFX(hitPart, spallCaliber, blowthroughFactor, true, sourcevessel, hit);
+                                }
+                            }
+                            return false;
+                        }
+                        else
+                        {
+                            if (blowthroughFactor > 0.66)
+                            {
+                                spallCaliber *= ((1 - ductility) * blowthroughFactor);
+                                hitPart.ReduceArmor(spallCaliber * (thickness / 5));
+                                spallMass = Mathf.Pow(0.5f * spallCaliber, 2) * Mathf.PI / 1000 * (thickness/5) * (Density / 1000000);
+                                damage = hitPart.AddBallisticDamage(spallMass, spallCaliber, 1, blowthroughFactor, 1, 500);
+                                ApplyScore(hitPart, sourcevessel, 1, damage, "Spall Damage");
+                                if (BDArmorySettings.DRAW_DEBUG_LABELS)
+                                {
+                                    Debug.Log("[BDArmory.ProjectileUtils]: Explosive Armor spalling! Diameter: " + spallCaliber + "; mass: " + spallMass + "g");
+                                }
+                                if (BDArmorySettings.BATTLEDAMAGE)
+                                {
+                                    BattleDamageHandler.CheckDamageFX(hitPart, spallCaliber, blowthroughFactor, false, sourcevessel, hit);
+                                }
+                                return true;
+                            }
+                        }
+                    }
+                    //else //low hardness non ductile materials (i.e. kevlar/aramid) not going to spall
+                }
+            }
+            return false;
+        }
+    /*
+    public static float CalculatePenetration(float caliber, float projMass, float impactVel, float apBulletMod = 1)
+    {
+        float penetration = 0;
+        if (apBulletMod <= 0) // sanity check/legacy compatibility
+        {
+            apBulletMod = 1;
+        }
+
+        if (caliber > 5) //use the "krupp" penetration formula for anything larger than HMGs
+        {
+            penetration = (float)(16f * impactVel * Math.Sqrt(projMass / 1000) / Math.Sqrt(caliber) * apBulletMod); //APBulletMod now actually implemented, serves as penetration multiplier, 1 being neutral, <1 for soft rounds, >1 for AP penetrators
+        }
+
+        return penetration;
+    }
+    */
+    public static float CalculateProjectileEnergy(float projMass, float impactVel)
         {
             float bulletEnergy = (projMass * 1000) * impactVel; //(should this be 1/2(mv^2) instead? prolly at somepoint, but the abstracted calcs I have use mass x vel, and work, changing it would require refactoring calcs
             if (BDArmorySettings.DRAW_DEBUG_LABELS)
@@ -286,6 +507,7 @@ namespace BDArmory.Misc
                 {
                     newCaliber *= (impactVel / 1000);
                 }
+                //replace this with tensile srength of bullet calcs?
                 if (BDArmorySettings.DRAW_DEBUG_LABELS)
                 {
                     Debug.Log("[BDArmory.ProjectileUtils]: Bullet Deformation modifier " + newCaliber);
@@ -298,11 +520,16 @@ namespace BDArmory.Misc
                 return newCaliber;
             }
         }
-        public static bool CalculateBulletStatus(float projMass, float newCaliber)
+        public static bool CalculateBulletStatus(float projMass, float newCaliber, bool sabot = false)
         {
             //does the bullet suvive its impact?
             //calculate bullet lengh, in mm
-            float bulletLength = projMass / (Mathf.Pow(0.5f * newCaliber, 2) * Mathf.PI / 1000 * 11.34f) + 10; //srf.Area in mmm2 x density of lead to get mass per 1 cm length of bullet / total mass to get total length,
+            float density = 11.34f;
+            if (sabot)
+            {
+                density = 19;
+            }
+            float bulletLength = (projMass*1000) / (Mathf.Pow(0.5f * newCaliber, 2) * Mathf.PI / 1000 * density) + 10; //srf.Area in mmm2 x density of lead to get mass per 1 cm length of bullet / total mass to get total length,
                                                                                                                                        //+ 10 to accound for ogive/mushroom head post-deformation instead of perfect cylinder
             if (newCaliber > (bulletLength * 2)) //has the bullet flattened into a disc, and is no longer a viable penetrator?
             {
@@ -315,22 +542,30 @@ namespace BDArmory.Misc
             else return true;
         }
 
-        public static float CalculatePenetration(float caliber, float newCaliber, float bulletEnergy, float Ductility, float Density, float Strength, float thickness)
+        public static float CalculatePenetration(float caliber, float newCaliber, float projMass, float impactVel, float Ductility, float Density, float Strength, float thickness)
         {
-            if (BDArmorySettings.DRAW_DEBUG_LABELS)
-            {
-                Debug.Log("[BDArmory.ProjectileUtils]: properties: Energy: " + bulletEnergy + "; caliber: " + caliber + "; newCaliber: " + newCaliber);
-                Debug.Log("[BDArmory.ProjectileUtils]: Ductility:" + Ductility + "; Density: " + Density + "; Strength: " + Strength + "; thickness: " + thickness);
-            }
+
+            float Energy = CalculateProjectileEnergy(projMass, impactVel);
             //the harder the material, the more the bullet is deformed, and the more energy it needs to expend to deform the armor 
             float penetration;
-             //bullet's deformed, penetration using larger crosssection  
-            penetration = bulletEnergy / (Mathf.Pow(((0.5f * caliber) + ((0.5f * newCaliber) * (2 * (Ductility * Ductility)))), 2) * Mathf.PI / 100 * Strength * (Density/7850) * thickness);
+            //bullet's deformed, penetration using larger crosssection  
+            if (impactVel > 1500 && caliber < 30) //hypervelocity KE penetrators, for convenience, assume any round moving this fast is made of Tungsten/Depleted ranium
+            {
+                float length = (projMass * 1000) / (Mathf.Pow(0.5f * newCaliber, 2) * Mathf.PI / 1000 * 19) + 10;
+                penetration = length * Mathf.Sqrt(19000 / Density); //at hypervelocity, impacts are akin to fluid displacement 
+            }
+            else
+            {
+                penetration = Energy / (Mathf.Pow(((0.5f * caliber) + ((0.5f * newCaliber) * (2 * (Ductility * Ductility)))), 2) * Mathf.PI / 100 * Strength * (Density / 7850) * thickness);
+            }
+            //apparently shattered projectiles add 30% to armor thickness; oblique impact beyond 55deg decreases effective thickness(splatted projectile digs in to plate instead of richochets)
+            penetration *= 10; //convert from cm to mm
             if (BDArmorySettings.DRAW_DEBUG_LABELS)
             {
+                Debug.Log("[BDArmory.ProjectileUtils]: Properties: Energy: " + Energy + "; caliber: " + caliber + "; newCaliber: " + newCaliber);
+                Debug.Log("[BDArmory.ProjectileUtils]: Ductility:" + Ductility + "; Density: " + Density + "; Strength: " + Strength + "; thickness: " + thickness);
                 Debug.Log("[BDArmory.ProjectileUtils]: Penetration: " + penetration + " cm");
             }
-            penetration *= 10; //convert from cm to mm
             return penetration;
         }
         public static float CalculateThickness(Part hitPart, float anglemultiplier)

--- a/BDArmory/Modules/BDExplosivePart.cs
+++ b/BDArmory/Modules/BDExplosivePart.cs
@@ -292,7 +292,7 @@ namespace BDArmory.Modules
                     direction = (part.transform.position + part.rb.velocity * Time.deltaTime).normalized;
                 }
                 var sourceWeapon = part.FindModuleImplementing<EngageableWeapon>();
-                ExplosionFx.CreateExplosion(part.transform.position, tntMass, explModelPath, explSoundPath, ExplosionSourceType.Missile, 0, part, sourcevessel != null ? sourcevessel.vesselName : null, sourceWeapon != null ? sourceWeapon.GetShortName() : null, direction);
+                ExplosionFx.CreateExplosion(part.transform.position, tntMass, explModelPath, explSoundPath, ExplosionSourceType.Missile, 0, part, sourcevessel != null ? sourcevessel.vesselName : null, sourceWeapon != null ? sourceWeapon.GetShortName() : null, direction, false, part.mass);
                 hasDetonated = true;
                 if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDArmory.BDExplosivePart]: " + part + " (" + (uint)(part.GetInstanceID()) + ") from " + (sourcevessel != null ? sourcevessel.vesselName : null) + " detonating.");
             }
@@ -304,7 +304,7 @@ namespace BDArmory.Modules
             {
                 if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDArmory.BDExplosivePart]: " + part + " (" + (uint)(part.GetInstanceID()) + ") from " + (sourcevessel != null ? sourcevessel.vesselName : null) + " detonating.");
                 var sourceWeapon = part.FindModuleImplementing<EngageableWeapon>();
-                ExplosionFx.CreateExplosion(part.transform.position, tntMass, explModelPath, explSoundPath, ExplosionSourceType.Missile, 0, part, sourcevessel != null ? sourcevessel.vesselName : null, sourceWeapon != null ? sourceWeapon.GetShortName() : null);
+                ExplosionFx.CreateExplosion(part.transform.position, tntMass, explModelPath, explSoundPath, ExplosionSourceType.Missile, 0, part, sourcevessel != null ? sourcevessel.vesselName : null, sourceWeapon != null ? sourceWeapon.GetShortName() : null, default, false, part.mass);
                 hasDetonated = true;
                 part.Destroy();
             }

--- a/BDArmory/Modules/ClusterBomb.cs
+++ b/BDArmory/Modules/ClusterBomb.cs
@@ -190,7 +190,7 @@ namespace BDArmory.Modules
         {
             ContactPoint contact = col.contacts[0];
             Vector3 pos = contact.point;
-            ExplosionFx.CreateExplosion(pos, blastForce, subExplModelPath, subExplSoundPath, ExplosionSourceType.Missile, 0, null, sourceVesselName);
+            ExplosionFx.CreateExplosion(pos, blastForce, subExplModelPath, subExplSoundPath, ExplosionSourceType.Missile, 0, null, sourceVesselName, null, default, false, rb.mass) ;
         }
 
         void FixedUpdate()
@@ -248,7 +248,7 @@ namespace BDArmory.Modules
 
         void Detonate(Vector3 pos)
         {
-            ExplosionFx.CreateExplosion(pos, blastForce, subExplModelPath, subExplSoundPath, ExplosionSourceType.Missile, 0, null, sourceVesselName);
+            ExplosionFx.CreateExplosion(pos, blastForce, subExplModelPath, subExplSoundPath, ExplosionSourceType.Missile, 0, null, sourceVesselName, null, default, false, rb.mass);
             Destroy(gameObject);
         }
 

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -3551,7 +3551,7 @@ namespace BDArmory.Modules
                             {
                                 candidateRPM *= 1.5f; // weight selection towards flak ammo
                             }
-                            if (targetWeapon != null && targetWeaponPriority < candidatePriority) //use priority gun
+                            if (targetWeaponPriority < candidatePriority) //use priority gun
                             {
                                 targetWeapon = item.Current;
                                 targetWeaponRPM = candidateRPM;

--- a/BDArmory/Modules/MissileLauncher.cs
+++ b/BDArmory/Modules/MissileLauncher.cs
@@ -29,6 +29,7 @@ namespace BDArmory.Modules
 
         public MissileTurret missileTurret = null;
         public BDRotaryRail rotaryRail = null;
+        //public DroneLauncher drone = null;
 
         [KSPField]
         public string exhaustPrefabPath;
@@ -716,6 +717,20 @@ namespace BDArmory.Modules
             if (HasFired) return;
 
             try // FIXME Remove this once the fix is sufficiently tested.
+/*
+            drone = part.GetComponent<DroneLauncher>();
+            if (drone != null)
+            {
+                Debug.Log("[BDArmory.MissileLauncher]: Launching Drone?");
+                drone.LaunchDrone();
+                Debug.Log("[BDArmory.MissileLauncher]: Drone Launched! " + vessel.vesselName);
+                HasFired = true;
+                BDATargetManager.FiredMissiles.Remove(this);
+                Debug.Log("[BDArmory.MissileLauncher]: Removing MissileLauncher on " + vessel.vesselName);
+            }
+            else
+*/
+
             {
                 SetupExplosive(this.part);
                 HasFired = true;
@@ -729,7 +744,6 @@ namespace BDArmory.Modules
                 {
                     BDArmorySetup.numberOfParticleEmitters++;
                 }
-
                 using (var wpm = vessel.FindPartModulesImplementing<MissileFire>().GetEnumerator())
                     while (wpm.MoveNext())
                     {
@@ -739,6 +753,7 @@ namespace BDArmory.Modules
                     }
 
                 if (sfAudioSource == null) SetupAudio();
+
                 sfAudioSource.PlayOneShot(GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/deployClick"));
                 SourceVessel = vessel;
 
@@ -1804,8 +1819,14 @@ namespace BDArmory.Modules
             else //TODO: Remove this backguard compatibility
             {
                 Vector3 position = transform.position;//+rigidbody.velocity*Time.fixedDeltaTime;
-
-                ExplosionFx.CreateExplosion(position, blastPower, explModelPath, explSoundPath, ExplosionSourceType.Missile, 0, part, SourceVessel.vesselName, part.FindModuleImplementing<EngageableWeapon>().GetShortName());
+                if (isSeismicCharge)
+                {
+                    SeismicChargeFX.CreateSeismicExplosion(position, transform.rotation, explModelPath);
+                }
+                else
+                {
+                    ExplosionFx.CreateExplosion(position, blastPower, explModelPath, explSoundPath, ExplosionSourceType.Missile, 0, part, SourceVessel.vesselName, part.FindModuleImplementing<EngageableWeapon>().GetShortName(), default, false, part.mass);
+                }
             }
 
             List<BDAGaplessParticleEmitter>.Enumerator e = gaplessEmitters.GetEnumerator();

--- a/BDArmory/Modules/ModuleCASE.cs
+++ b/BDArmory/Modules/ModuleCASE.cs
@@ -167,7 +167,7 @@ namespace BDArmory.Modules
                 GetBlastRadius();
                 if (CASELevel == 0) //a considerable quantity of explosives and propellants just detonated inside your ship
                 {
-                    ExplosionFx.CreateExplosion(part.transform.position, (float)ammoExplosionYield, explModelPath, explSoundPath, ExplosionSourceType.Missile, 0, part, vesselName, null, direction);
+                    ExplosionFx.CreateExplosion(part.transform.position, (float)ammoExplosionYield, explModelPath, explSoundPath, ExplosionSourceType.Missile, 0, part, vesselName, null, direction, false, part.mass);
                     if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDArmory.ModuleCASE] CASE 0 explosion, tntMassEquivilent: " + ammoExplosionYield);
                 }
                 else if (CASELevel == 1) // the blast is reduced. Damage is severe, but (potentially) survivable

--- a/BDArmory/Parts/SeismicChargeFX.cs
+++ b/BDArmory/Parts/SeismicChargeFX.cs
@@ -6,23 +6,33 @@ namespace BDArmory.Parts
 {
     public class SeismicChargeFX : MonoBehaviour
     {
+        //orphaned, incredibly limited in scope, functionality and requiring a specific FX model that isn't present, but,
+        //if the proper collider setup can be recovered/reverse-engineered, this has potential...
         AudioSource audioSource;
 
         public static float originalShipVolume;
         public static float originalMusicVolume;
         public static float originalAmbienceVolume;
 
+        [KSPField]
+        public string FXName = "lightFlare";
+        [KSPField]
+        public string DetonationSound = "BDArmory/Sounds/seismicCharge";
+
+        static string DefaultExplosionPath = "BDArmory/Models/seismicCharge/seismicExplosion";
+
         float startTime;
 
         Transform lightFlare;
-
         Rigidbody rb;
+
+        Vector3 explosionCoords;
+        Vector3 explosionUp;
 
         void Start()
         {
             transform.localScale = 2 * Vector3.one;
-            lightFlare = gameObject.transform.Find("lightFlare");
-
+            lightFlare = gameObject.transform.Find("FXName");
             startTime = Time.time;
 
             audioSource = gameObject.AddComponent<AudioSource>();
@@ -32,18 +42,22 @@ namespace BDArmory.Parts
             audioSource.pitch = UnityEngine.Random.Range(0.93f, 1f);
             audioSource.volume = Mathf.Sqrt(originalShipVolume);
 
-            audioSource.PlayOneShot(GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/seismicCharge"));
+            audioSource.PlayOneShot(GameDatabase.Instance.GetAudioClip(DetonationSound));
 
             rb = gameObject.AddComponent<Rigidbody>();
             rb.useGravity = false;
             rb.velocity = Vector3.zero;
+            rb.isKinematic = true;
+
+            explosionCoords = transform.position;
+            explosionUp = transform.up;
+
         }
 
         void FixedUpdate()
         {
-            lightFlare.LookAt(FlightCamera.fetch.mainCamera.transform.position,
-                FlightCamera.fetch.mainCamera.transform.up);
-
+            //lightFlare.LookAt(transform.position, transform.up);
+            lightFlare.LookAt(explosionCoords, explosionUp);
             if (Time.time - startTime < 1.25f)
             {
                 //
@@ -71,20 +85,22 @@ namespace BDArmory.Parts
         void OnTriggerEnter(Collider other)
         {
             //hitting parts
-            Part explodePart = null;
+            Part explodePart = null;     
             try
             {
                 explodePart = other.gameObject.GetComponentUpwards<Part>();
-                explodePart.Unpack();
+                //explodePart.Unpack();
             }
             catch (NullReferenceException e)
             {
-                Debug.LogWarning("[BDArmory.SeismicChargeFX]: Exception thrown in OnTriggerEnter: " + e.Message + "\n" + e.StackTrace);
+                Debug.LogWarning("[BDArmory.SeismicChargeFX]: Exception thrown in OnTriggerEnter: Where part?" + e.Message + "\n" + e.StackTrace);
             }
 
             if (explodePart != null)
             {
                 explodePart.Destroy();
+                //make a variant that breaks all connedctions/attach nodes, make it a shatter weapon?
+                Debug.Log("[SeismicCharge] Hit a part");
             }
             else
             {
@@ -96,19 +112,26 @@ namespace BDArmory.Parts
                 }
                 catch (NullReferenceException e)
                 {
-                    Debug.LogWarning("[BDArmory.SeismicChargeFX]: Exception thrown in OnTriggerEnter: " + e.Message + "\n" + e.StackTrace);
+                    Debug.LogWarning("[BDArmory.SeismicChargeFX]: Exception thrown in OnTriggerEnter: Where building? " + e.Message + "\n" + e.StackTrace);
                 }
                 if (hitBuilding != null && hitBuilding.IsIntact)
                 {
                     hitBuilding.Demolish();
+                    Debug.Log("[SeismicCharge] Hit a building");
                 }
             }
-            Destroy(gameObject);
+            ///Destroy(gameObject);
         }
 
-        public static void CreateSeismicExplosion(Vector3 pos, Quaternion rot)
+        public static void CreateSeismicExplosion(Vector3 pos, Quaternion rot, string Modelpath = null)
         {
-            GameObject explosionModel = GameDatabase.Instance.GetModel("BDArmory/Models/seismicCharge/seismicExplosion");
+            var FXTemplate = GameDatabase.Instance.GetModel(Modelpath);
+            if (FXTemplate == null)
+            {
+                Debug.LogError("[BDArmory.SeismicCharge]: " + Modelpath + " was not found, using the default explosion instead. Please fix your model.");
+                FXTemplate = GameDatabase.Instance.GetModel(DefaultExplosionPath);
+            }
+            GameObject explosionModel = FXTemplate;
             GameObject explosionObject = (GameObject)Instantiate(explosionModel, pos, rot);
             explosionObject.SetActive(true);
             explosionObject.AddComponent<SeismicChargeFX>();


### PR DESCRIPTION
Initial beta of the armor overhaul for review/testing.
Currently, BD_ArmorDef armor values are accurate-ish, but a few (cost, etc) may need tweaking.
laser-armor interaction could use review, but currently works within limitations of monolithic part armor system.
Spalling from explosions not yet implemented.
Armor config is currently per part, editor widget for universal armor assignment not yet implemented
Armor panel scaling module has issues with node positions; 
default 10 armor hasn't changed, may need adjustment. Loathe to give first 10 thickness for free, simply because a free 10mm of Depleted Uranium is bonkers
