### PR TITLE
Some updates

### DIFF
--- a/BDArmory.Core/BDArmorySettings.cs
+++ b/BDArmory.Core/BDArmorySettings.cs
@@ -54,6 +54,7 @@ namespace BDArmory.Core
         [BDAPersistantSettingsField] public static bool IGNORE_TERRAIN_CHECK = false;
         [BDAPersistantSettingsField] public static bool DISPLAY_PATHING_GRID = false;             //laggy when the grid gets large
         [BDAPersistantSettingsField] public static bool ADVANCED_EDIT = true;                     //Used for debug fields not nomrally shown to regular users
+        [BDAPersistantSettingsField] public static bool DISPLAY_COMPETITION_STATUS = true;             //Display competition status
 
         // General slider settings
         [BDAPersistantSettingsField] public static int COMPETITION_DURATION = 5;                       // Competition duration in minutes

--- a/BDArmory.Core/BDArmorySettings.cs
+++ b/BDArmory.Core/BDArmorySettings.cs
@@ -33,7 +33,7 @@ namespace BDArmory.Core
         [BDAPersistantSettingsField] public static bool DRAW_DEBUG_LINES = false;
         [BDAPersistantSettingsField] public static bool DRAW_DEBUG_LABELS = false;
         [BDAPersistantSettingsField] public static bool REMOTE_SHOOTING = false;
-        [BDAPersistantSettingsField] public static bool BOMB_CLEARANCE_CHECK = true;
+        [BDAPersistantSettingsField] public static bool BOMB_CLEARANCE_CHECK = false;
         [BDAPersistantSettingsField] public static bool SHOW_AMMO_GAUGES = false;
         [BDAPersistantSettingsField] public static bool SHELL_COLLISIONS = true;
         [BDAPersistantSettingsField] public static bool BULLET_DECALS = true;

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -257,10 +257,13 @@ namespace BDArmory.Control
                 message += "\n" + currentVesselStatus;
             }
 
-            GUI.Label(cShadowRect, message, cShadowStyle);
-            GUI.Label(cLabelRect, message, cStyle);
+            if (BDArmorySettings.DISPLAY_COMPETITION_STATUS)
+            {
+                GUI.Label(cShadowRect, message, cShadowStyle);
+                GUI.Label(cLabelRect, message, cStyle);
+            }
 
-            if (!BDArmorySetup.GAME_UI_ENABLED && competitionStartTime > 0)
+            if (!BDArmorySetup.GAME_UI_ENABLED && BDArmorySettings.DISPLAY_COMPETITION_STATUS && competitionStartTime > 0)
             {
                 Rect clockRect = new Rect(10, 6, Screen.width, 20);
                 GUIStyle clockStyle = new GUIStyle(cStyle);
@@ -1703,7 +1706,7 @@ namespace BDArmory.Control
                     pilotActions[vesselName] = "";
 
                     // try to create meaningful activity strings
-                    if (mf.AI != null && mf.AI.currentStatus != null)
+                    if (mf.AI != null && mf.AI.currentStatus != null && BDArmorySettings.DISPLAY_COMPETITION_STATUS)
                     {
                         pilotActions[vesselName] = "";
                         if (mf.vessel.LandedOrSplashed)

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -123,7 +123,7 @@ Localization
 
         #LOC_BDArmory_Settings_AdvTargeting = Advanced Targeting
         #LOC_BDArmory_Settings_NumTargets = Max Simultaneous Targets
-        #LOC_BDArmory_Settings_AdvTargetToggle = Anvanced Targeting Options
+        #LOC_BDArmory_Settings_AdvTargetToggle = Advanced Targeting Options
         #LOC_BDArmory_Settings_AT_COM = Target CoM
         #LOC_BDArmory_Settings_AT_Weapons = Target Weapons
         #LOC_BDArmory_Settings_AT_Engines = Target Engines

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -94,6 +94,7 @@ Localization
         #LOC_BDArmory_Settings_AutoEnableVesselSwitching = Auto-Enable Vessel-Switching
         #LOC_BDArmory_Settings_AutonomousCombatSeats = Autonomous Combat Seats
         #LOC_BDArmory_Settings_DestroyWMWhenNotControlled = Destroy Uncontrolled WMs
+        #LOC_BDArmory_Settings_DisplayCompetitionStatus = Display Competition Status
         #LOC_BDArmory_Settings_ResetHP = Reset Max HP of Parts
         #LOC_BDArmory_Settings_KerbalSafety = Kerbal Safety
         #LOC_BDArmory_Settings_KerbalSafetyInventory = Kerbal Inventory

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -1252,8 +1252,8 @@ namespace BDArmory.Radar
                                         Vector3 relV = missileBase.vessel.Velocity() - myWpnManager.vessel.Velocity();
                                         bool approaching = Vector3.Dot(relV, vectorFromMissile) > 0;
                                         bool withinRadarFOV = (missileBase.TargetingMode == MissileBase.TargetingModes.Radar || missileBase.TargetingModeTerminal == MissileBase.TargetingModes.Radar) ?
-                                            (Vector3.Angle(missileBase.GetForwardTransform(), vectorFromMissile) <= Mathf.Clamp(missileBase.lockedSensorFOV, 1f, 90f)/2f) : false;
-                                        var missileBlastRadiusSqr = missileBase.GetBlastRadius();
+                                            (Vector3.Angle(missileBase.GetForwardTransform(), vectorFromMissile) <= Mathf.Clamp(missileBase.lockedSensorFOV, 40f, 90f)/2f) : false;
+                                        var missileBlastRadiusSqr = 1.5f * missileBase.GetBlastRadius();
                                         missileBlastRadiusSqr *= missileBlastRadiusSqr;
 
                                         if (missileBase.HasFired && missileBase.TimeIndex > 1f && approaching &&

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1580,6 +1580,7 @@ namespace BDArmory.UI
                 if (BDArmorySettings.ADVANCED_TARGETING != (BDArmorySettings.ADVANCED_TARGETING = GUI.Toggle(SLeftRect(++line), BDArmorySettings.ADVANCED_TARGETING, Localizer.Format("#LOC_BDArmory_Settings_AdvTargeting"))))
                 { updateTargetableParts = true; }
                 BDArmorySettings.AUTONOMOUS_COMBAT_SEATS = GUI.Toggle(SRightRect(line), BDArmorySettings.AUTONOMOUS_COMBAT_SEATS, Localizer.Format("#LOC_BDArmory_Settings_AutonomousCombatSeats"));
+                BDArmorySettings.DISPLAY_COMPETITION_STATUS = GUI.Toggle(SLeftRect(++line), BDArmorySettings.DISPLAY_COMPETITION_STATUS, Localizer.Format("#LOC_BDArmory_Settings_DisplayCompetitionStatus"));
                 if (HighLogic.LoadedSceneIsEditor)
                 {
                     if (BDArmorySettings.SHOW_CATEGORIES != (BDArmorySettings.SHOW_CATEGORIES = GUI.Toggle(SLeftRect(++line), BDArmorySettings.SHOW_CATEGORIES, Localizer.Format("#LOC_BDArmory_Settings_ShowEditorSubcategories"))))//"Show Editor Subcategories"


### PR DESCRIPTION
 - Add toggle for whether competition status messages are displayed
- Add 1.5 safety factor to blast radius determination for missile evasion
- Clamp the minimum radar missile FOV used for missile evasion to 40 degrees, results in fewer instances of craft turning back towards a missile at inopportune times.
- Fix typo
- Default clearance check to off