### PR TITLE
Fix missiles not being targeted

### DIFF
--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -42,12 +42,16 @@ namespace BDArmory.Modules
             if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDArmory.BDModulePilotAI]: " + vessel.vesselName + " stopped extending due to request");
         }
 
-        public void RequestExtend(Vector3 tPosition)
+        public void RequestExtend(Vector3 tPosition, Vessel target = null)
         {
             requestedExtend = true;
             requestedExtendTpos = tPosition;
             extendingReason = "Request";
+            if (target != null)
+                extendTarget = target;
         }
+
+        public Vessel extendTarget = null;
 
         public override bool CanEngage()
         {
@@ -939,6 +943,7 @@ namespace BDArmory.Modules
             {
                 threatRating = 0f; // Allow entering evasion code if we're under missile fire
                 minimumEvasionTime = 0f; //  Trying to evade missile threats when they don't exist will result in NREs
+                StopExtending(); // Don't keep trying to extend if under fire from missiles
             }
             else if (weaponManager.underFire && !ramming) // If we're ramming, ignore gunfire.
             {
@@ -1011,6 +1016,7 @@ namespace BDArmory.Modules
                         extending = true;
                         extendingReason = "Too steeply below";
                         lastTargetPosition = targetVessel.vesselTransform.position;
+                        extendTarget = targetVessel;
                     }
 
                     if (Vector3.Angle(targetVessel.vesselTransform.position - vesselTransform.position, vesselTransform.up) > 35) // If target is outside of 35° cone ahead of us then keep flying straight.
@@ -1033,12 +1039,13 @@ namespace BDArmory.Modules
                         extending = true;
                         extendingReason = "Can't turn fast enough";
                         lastTargetPosition = targetVessel.vesselTransform.position - vessel.Velocity();       //we'll set our last target pos based on the enemy vessel and where we were 1 seconds ago
+                        extendTarget = targetVessel;
                         weaponManager.ForceScan();
                     }
                     if (canExtend && turningTimer > 15)
                     {
                         //extend if turning circles for too long
-                        RequestExtend(targetVessel.vesselTransform.position);
+                        RequestExtend(targetVessel.vesselTransform.position, targetVessel);
                         extendingReason = "Turning too long";
                         turningTimer = 0;
                         weaponManager.ForceScan();
@@ -1059,6 +1066,7 @@ namespace BDArmory.Modules
                         extending = true;
                         extendingReason = "Surface target";
                         lastTargetPosition = targetVessel.transform.position;
+                        extendTarget = targetVessel;
                         weaponManager.ForceScan();
                     }
                 }
@@ -1069,7 +1077,7 @@ namespace BDArmory.Modules
                     {
                         ramming = false;
                         SetStatus("Engaging");
-                        debugString.AppendLine($"Flying to target");
+                        debugString.AppendLine($"Flying to target " + targetVessel.vesselName);
                         FlyToTargetVessel(s, targetVessel);
                     }
                 }
@@ -1305,7 +1313,7 @@ namespace BDArmory.Modules
                 && distanceToTarget < MissileLaunchParams.GetDynamicLaunchParams(missile, v.Velocity(), v.transform.position).minLaunchRange
                 && vessel.srfSpeed > idleSpeed)
             {
-                RequestExtend(lastTargetPosition); // Get far enough away to use the missile.
+                RequestExtend(targetVessel.transform.position, targetVessel); // Get far enough away to use the missile.
                 extendingReason = "Too close for missile";
             }
 

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -1248,20 +1248,7 @@ namespace BDArmory.Radar
                                     {
                                         if (missileBase.SourceVessel == myWpnManager.vessel) continue; // ignore missiles we've fired
 
-                                        Vector3 vectorFromMissile = myWpnManager.vessel.CoM - missileBase.part.transform.position;
-                                        Vector3 relV = missileBase.vessel.Velocity() - myWpnManager.vessel.Velocity();
-                                        bool approaching = Vector3.Dot(relV, vectorFromMissile) > 0;
-                                        bool withinRadarFOV = (missileBase.TargetingMode == MissileBase.TargetingModes.Radar || missileBase.TargetingModeTerminal == MissileBase.TargetingModes.Radar) ?
-                                            (Vector3.Angle(missileBase.GetForwardTransform(), vectorFromMissile) <= Mathf.Clamp(missileBase.lockedSensorFOV, 40f, 90f)/2f) : false;
-                                        var missileBlastRadiusSqr = 1.5f * missileBase.GetBlastRadius();
-                                        missileBlastRadiusSqr *= missileBlastRadiusSqr;
-
-                                        if (missileBase.HasFired && missileBase.TimeIndex > 1f && approaching &&
-                                            (
-                                                (missileBase.TargetPosition - (myWpnManager.vessel.CoM + (myWpnManager.vessel.Velocity() * Time.fixedDeltaTime))).sqrMagnitude < missileBlastRadiusSqr || // Target position is within blast radius of missile.
-                                                myWpnManager.vessel.PredictClosestApproachSqrSeparation(missileBase.vessel, 2f) < missileBlastRadiusSqr || // Closest approach is within blast radius of missile. 
-                                                withinRadarFOV // We are within radar FOV of missile boresight.
-                                            ))
+                                        if (MissileIsThreat(missileBase, myWpnManager))
                                         {
                                             results.incomingMissiles.Add(new IncomingMissile
                                             {
@@ -1324,6 +1311,55 @@ namespace BDArmory.Radar
             }
 
             return results;
+        }
+
+        public static bool MissileIsThreat(MissileBase missile, MissileFire mf, bool threatToMeOnly = true)
+        {
+            if (threatToMeOnly)
+            {
+                Vector3 vectorFromMissile = mf.vessel.CoM - missile.part.transform.position;
+                Vector3 relV = missile.vessel.Velocity() - mf.vessel.Velocity();
+                bool approaching = Vector3.Dot(relV, vectorFromMissile) > 0;
+                bool withinRadarFOV = (missile.TargetingMode == MissileBase.TargetingModes.Radar || missile.TargetingModeTerminal == MissileBase.TargetingModes.Radar) ?
+                    (Vector3.Angle(missile.GetForwardTransform(), vectorFromMissile) <= Mathf.Clamp(missile.lockedSensorFOV, 40f, 90f) / 2f) : false;
+                var missileBlastRadiusSqr = 1.5f * missile.GetBlastRadius();
+                missileBlastRadiusSqr *= missileBlastRadiusSqr;
+
+                return (missile.HasFired && missile.TimeIndex > 1f && approaching &&
+                            (
+                                (missile.TargetPosition - (mf.vessel.CoM + (mf.vessel.Velocity() * Time.fixedDeltaTime))).sqrMagnitude < missileBlastRadiusSqr || // Target position is within blast radius of missile.
+                                mf.vessel.PredictClosestApproachSqrSeparation(missile.vessel, 2f) < missileBlastRadiusSqr || // Closest approach is within blast radius of missile. 
+                                withinRadarFOV // We are within radar FOV of missile boresight.
+                            ));
+            }
+            else
+            {
+                using (var friendly = FlightGlobals.Vessels.GetEnumerator())
+                    while (friendly.MoveNext())
+                    {
+                        if (friendly.Current == null)
+                            continue;
+                        var wms = friendly.Current.FindPartModuleImplementing<MissileFire>();
+                        if (wms == null || wms.Team != mf.Team)
+                            continue;
+
+                        Vector3 vectorFromMissile = wms.vessel.CoM - missile.part.transform.position;
+                        Vector3 relV = missile.vessel.Velocity() - wms.vessel.Velocity();
+                        bool approaching = Vector3.Dot(relV, vectorFromMissile) > 0;
+                        bool withinRadarFOV = (missile.TargetingMode == MissileBase.TargetingModes.Radar || missile.TargetingModeTerminal == MissileBase.TargetingModes.Radar) ?
+                            (Vector3.Angle(missile.GetForwardTransform(), vectorFromMissile) <= Mathf.Clamp(missile.lockedSensorFOV, 40f, 90f) / 2f) : false;
+                        var missileBlastRadiusSqr = 1.5f * missile.GetBlastRadius();
+                        missileBlastRadiusSqr *= missileBlastRadiusSqr;
+
+                        return (missile.HasFired && missile.TimeIndex > 1f && approaching &&
+                                    (
+                                        (missile.TargetPosition - (wms.vessel.CoM + (wms.vessel.Velocity() * Time.fixedDeltaTime))).sqrMagnitude < missileBlastRadiusSqr || // Target position is within blast radius of missile.
+                                        wms.vessel.PredictClosestApproachSqrSeparation(missile.vessel, 2f) < missileBlastRadiusSqr || // Closest approach is within blast radius of missile. 
+                                        withinRadarFOV // We are within radar FOV of missile boresight.
+                                    ));
+                    }
+            }
+            return false;
         }
 
         private static float MissDistance(ModuleWeapon threatWeapon, Vessel self) // Returns how far away bullets from enemy are from craft in meters

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -1019,7 +1019,14 @@ namespace BDArmory.UI
                         {
                             if (targetingMeOnly)
                             {
-                                if (Vector3.SqrMagnitude(target.Current.MissileBaseModule.TargetPosition - mf.vessel.CoM) > 60 * 60)
+                                if (!RadarUtils.MissileIsThreat(target.Current.MissileBaseModule, mf))
+                                {
+                                    continue;
+                                }
+                            }
+                            else
+                            {
+                                if (!RadarUtils.MissileIsThreat(target.Current.MissileBaseModule, mf, false))
                                 {
                                     continue;
                                 }
@@ -1031,7 +1038,7 @@ namespace BDArmory.UI
                                 Debug.LogWarning("[BDArmory.BDATargetManager]: checking target missile -  doesn't have missile module");
                         }
 
-                        if (((finalTarget == null && target.Current.NumFriendliesEngaging(mf.Team) < 2) || (finalTarget != null && target.Current.NumFriendliesEngaging(mf.Team) < finalTarget.NumFriendliesEngaging(mf.Team))))
+                        if (((finalTarget == null && target.Current.NumFriendliesEngaging(mf.Team) < 2) || (finalTarget != null && target.Current.NumFriendliesEngaging(mf.Team) < finalTarget.NumFriendliesEngaging(mf.Team) && target.Current.IsCloser(finalTarget, mf))))
                         {
                             finalTarget = target.Current;
                         }
@@ -1047,7 +1054,7 @@ namespace BDArmory.UI
                 {
                     if (target.Current == null) continue;
                     if (BDArmorySettings.MULTI_TARGET_NUM > 1 && mf.targetsAssigned.Contains(target.Current)) continue;
-                    if (target.Current && target.Current.Vessel && mf.CanSeeTarget(target.Current) && target.Current.isMissile && target.Current.isThreat)
+                    if (target.Current && target.Current.Vessel && mf.CanSeeTarget(target.Current) && target.Current.isMissile && RadarUtils.MissileIsThreat(target.Current.MissileBaseModule, mf, false))
                     {
                         if (target.Current.NumFriendliesEngaging(mf.Team) == 0)
                         {

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1057,22 +1057,6 @@ namespace BDArmory.UI
                         ActiveWeaponManager.maxMissilesOnTarget.ToString(), leftLabel);
                     guardLines++;
 
-                    string targetType = Localizer.Format("#LOC_BDArmory_WMWindow_TargetType");//"Target Type: "
-                    if (ActiveWeaponManager.targetMissiles)
-                    {
-                        targetType += Localizer.Format("#LOC_BDArmory_WMWindow_TargetType_Missiles");//"Missiles"
-                    }
-                    else
-                    {
-                        targetType += Localizer.Format("#LOC_BDArmory_WMWindow_TargetType_All");//"All Targets"
-                    }
-
-                    if (GUI.Button(new Rect(leftIndent, (guardLines * entryHeight), contentWidth, entryHeight), targetType,
-                        BDGuiSkin.button))
-                    {
-                        ActiveWeaponManager.ToggleTargetType();
-                    }
-                    guardLines++;
                     GUI.EndGroup();
                     line += 0.1f;
                 }


### PR DESCRIPTION
 - Change targetMissiles value based on whether craft has weapons that can engage missiles. Fully depreciate toggling targetMissiles
- Re-work targeting so that missiles are handled first if a craft has weapons that can target missiles.
- Move missile threat check to its own method so it can be called from targeting method.
- Remove forcing target selection if target priority or FFA targeting was enabled.
- Re-work extending checks to prevent the above from stopping extending.
- Fix extending to get enough distance to fire missiles not working.
- Clarify some targeting debug statements