### PR TITLE
SRB BattleDamage and fixed weapon targeting

### DIFF
--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -3354,9 +3354,9 @@ namespace BDArmory.Modules
                                     }
                                 }
                             }
-                            //targetparts = targetparts.OrderBy(w => w.mass).ToList(); //weight target part priority by part mass, also serves as a default 'target heaviest part' in case other options not selected
-                            //targetparts.Reverse(); //Order by mass is lightest to heaviest. We want H>L
-                            targetparts.Shuffle(); //alternitively, increase the random range from maxtargetnum to targetparts.count, otherwise edge cases where lots of one thing (targeting command/mass) will be pulled before lighter things (weapons, maybe engines) if both selected
+                            targetparts = targetparts.OrderBy(w => w.mass).ToList(); //weight target part priority by part mass, also serves as a default 'target heaviest part' in case other options not selected
+                            targetparts.Reverse(); //Order by mass is lightest to heaviest. We want H>L
+                            //targetparts.Shuffle(); //alternitively, increase the random range from maxtargetnum to targetparts.count, otherwise edge cases where lots of one thing (targeting command/mass) will be pulled before lighter things (weapons, maybe engines) if both selected
                             targetID = (int)UnityEngine.Random.Range(0, Mathf.Min(targetparts.Count, weaponManager.multiTargetNum));
                             if (!turret) //make fixed guns all get the same target part
                             {


### PR DESCRIPTION
Per aubrainium's comments, SRBs now have battle damage for extra spiciness
 - SRBs will no longer leak fuel
 - SRBs that are hit by penetrating explosive weapons will catch fire
 - SRBs that are on fire will auto ignite if enough fuel burned
 - SRBs that are on fire will eventually detonate from the extra holes in the casing
 - SRBs that are active and at low health will explode when shot 
 - Fixes intake damage calc, intakes should no longer instantly get shredded
 - Filled Command seats can now extinguish adjacent fires 
 - Fixes fixed guns not firing when using non-CoM targeting options