### PR TITLE
add ammotypes to weapons

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Bullets.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Bullets.cfg
@@ -131,7 +131,7 @@ BULLET
 	explosive = False
 	incendiary = True
 	tntMass = 0
-	apBulletMod = 1
+	apBulletMod = 1.2
 	bulletDragTypeName = AnalyticEstimate
 	subProjectileCount = 1
 	fuzeType = None 
@@ -145,11 +145,11 @@ BULLET
     name = 12.7mmHEBullet
 	caliber = 12.7
 	bulletVelocity = 890
-	bulletMass = .16
+	bulletMass = .052
 	//HE Bullet Values
 	explosive = True
 	incendiary = False
-	tntMass = .14
+	tntMass = .008
 	apBulletMod = 0.8
 	bulletDragTypeName = AnalyticEstimate
 	subProjectileCount = 1

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/20mmVulcan/vulcanTurret.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/20mmVulcan/vulcanTurret.cfg
@@ -84,7 +84,7 @@ PART
 		maxTargetingRange = 5000
 
 		ammoName = 20x102Ammo
-		bulletType = 20x102mmHEBullet
+		bulletType = 20x102mmHEBullet; 20x102mmBullet
 		requestResourceAmount = 1
 
 		hasRecoil = true

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/50CalTurret/50cal.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/50CalTurret/50cal.cfg
@@ -80,7 +80,7 @@ PART
 
 		weaponType = ballistic
 		ammoName = 50CalAmmo
-		bulletType = 12.7mmBullet
+		bulletType = 12.7mmBullet; 12.7mmAPIBullet
 		requestResourceAmount = 1
 		shellScale = 0.463
 		bulletDmgMult = 1.3

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/browninganm2/browninganm2.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/browninganm2/browninganm2.cfg
@@ -59,7 +59,7 @@ MODULE
 		maxTargetingRange = 4000
 
 		weaponType = ballistic
-		bulletType = 12.7mmBullet
+		bulletType = 12.7mmBullet; 12.7mmAPIBullet
 		ammoName = 50CalAmmo
 	
 		requestResourceAmount = 1

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/gau-8/gau8.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/gau-8/gau8.cfg
@@ -63,7 +63,7 @@ PART
 
 		weaponType = ballistic
 		ammoName = 30x173Ammo
-		bulletType = 30x173HEBullet
+		bulletType = 30x173HEBullet; 30x173Bullet
 
 		requestResourceAmount = 1
 

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/hiddenVulcan/hiddenVulcan.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/hiddenVulcan/hiddenVulcan.cfg
@@ -58,7 +58,7 @@ MODULE
 	maxTargetingRange = 5000
 
 	ammoName = 20x102Ammo
-	bulletType = 20x102mmHEBullet
+	bulletType = 20x102mmHEBullet; 20x102mmBullet
 	requestResourceAmount = 1
 
 	hasRecoil = true

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/m230ChainGun/m230.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/m230ChainGun/m230.cfg
@@ -81,7 +81,7 @@ MODULE
 	maxTargetingRange = 5000
 
 	ammoName = 30x173Ammo
-	bulletType = 30x173HEBullet
+	bulletType = 30x173HEBullet; 30x173Bullet
 	requestResourceAmount = 1
 	shellScale = 0.66
 

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/oMillennium/oMillennium.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/oMillennium/oMillennium.cfg
@@ -91,7 +91,7 @@ PART
 
 		weaponType = ballistic
 		ammoName = 30x173Ammo
-		bulletType = 35x228HEBullet 
+		bulletType = 35x228HEBullet; 35x228AHEADBullet
 		requestResourceAmount = 1
 
 		hasRecoil = true


### PR DESCRIPTION
If ammo belts are now implemented, would probably make sense to have stock BDA weapons that can take advantage/show off this feature;
 - Adds API ammo option to Vulcans, .50 cals, GAU, and M230.
 -Adds 35x228AHEADBullet ammo option to Oerlikon Millennium turret