### PR TITLE
Resolve Part deformatter conflict with other patches.

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/Localization/part_deformatter.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/part_deformatter.cfg
@@ -1,5 +1,5 @@
 //Replacing all title/manufacturers/descriptions with localization tags
-@PART[bahaGatlingGun]:FINAL
+@PART[bahaGatlingGun]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaGatlingGun_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -7,7 +7,7 @@
 }
 
 
-@PART[bahaTurret]:FINAL
+@PART[bahaTurret]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaTurret_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -15,7 +15,7 @@
 }
 
 
-@PART[bahaABL]:FINAL
+@PART[bahaABL]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaABL_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -23,7 +23,7 @@
 }
 
 
-@PART[bahaAdjustableRail]:FINAL
+@PART[bahaAdjustableRail]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaAdjustableRail_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -31,7 +31,7 @@
 }
 
 
-@PART[bahaAgm86B]:FINAL
+@PART[bahaAgm86B]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaAgm86B_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -39,7 +39,7 @@
 }
 
 
-@PART[bahaAim120]:FINAL
+@PART[bahaAim120]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaAim120_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -47,7 +47,7 @@
 }
 
 
-@PART[bdPilotAI]:FINAL
+@PART[bdPilotAI]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bdPilotAI_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -55,7 +55,7 @@
 }
 
 
-@PART[baha20mmAmmo]:FINAL
+@PART[baha20mmAmmo]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_baha20mmAmmo_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -63,7 +63,7 @@
 }
 
 
-@PART[baha30mmAmmo]:FINAL
+@PART[baha30mmAmmo]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_baha30mmAmmo_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -71,7 +71,7 @@
 }
 
 
-@PART[baha50CalAmmo]:FINAL
+@PART[baha50CalAmmo]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_baha50CalAmmo_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -79,7 +79,7 @@
 }
 
 
-@PART[UniversalAmmoBoxBDA]:FINAL
+@PART[UniversalAmmoBoxBDA]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_UniversalAmmoBoxBDA_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -87,7 +87,7 @@
 }
 
 
-@PART[bahaCannonShellBox]:FINAL
+@PART[bahaCannonShellBox]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaCannonShellBox_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -95,7 +95,7 @@
 }
 
 
-@PART[BD1x1slopeArmor]:FINAL
+@PART[BD1x1slopeArmor]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_BD1x1slopeArmor_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -103,7 +103,7 @@
 }
 
 
-@PART[BD2x1slopeArmor]:FINAL
+@PART[BD2x1slopeArmor]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_BD2x1slopeArmor_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -111,7 +111,7 @@
 }
 
 
-@PART[BD1x1panelArmor]:FINAL
+@PART[BD1x1panelArmor]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_BD1x1panelArmor_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -119,7 +119,7 @@
 }
 
 
-@PART[BD2x1panelArmor]:FINAL
+@PART[BD2x1panelArmor]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_BD2x1panelArmor_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -127,7 +127,7 @@
 }
 
 
-@PART[BD3x1panelArmor]:FINAL
+@PART[BD3x1panelArmor]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_BD3x1panelArmor_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -135,7 +135,7 @@
 }
 
 
-@PART[BD4x1panelArmor]:FINAL
+@PART[BD4x1panelArmor]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_BD4x1panelArmor_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -143,7 +143,7 @@
 }
 
 
-@PART[awacsRadar]:FINAL
+@PART[awacsRadar]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_awacsRadar_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -151,7 +151,7 @@
 }
 
 
-@PART[bdammGuidanceModule]:FINAL
+@PART[bdammGuidanceModule]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bdammGuidanceModule_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -159,7 +159,7 @@
 }
 
 
-@PART[bahaBrowningAnm2]:FINAL
+@PART[bahaBrowningAnm2]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaBrowningAnm2_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -167,7 +167,7 @@
 }
 
 
-@PART[bahaClusterBomb]:FINAL
+@PART[bahaClusterBomb]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaClusterBomb_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -175,7 +175,7 @@
 }
 
 
-@PART[bahaChaffPod]:FINAL
+@PART[bahaChaffPod]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaChaffPod_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -183,7 +183,7 @@
 }
 
 
-@PART[bahaCmPod]:FINAL
+@PART[bahaCmPod]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaCmPod_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -191,7 +191,7 @@
 }
 
 
-@PART[bahaECMJammer]:FINAL
+@PART[bahaECMJammer]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaECMJammer_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -199,7 +199,7 @@
 }
 
 
-@PART[bahaGau-8]:FINAL
+@PART[bahaGau-8]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaGau-8_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -207,7 +207,7 @@
 }
 
 
-@PART[bahaGoalKeeper]:FINAL
+@PART[bahaGoalKeeper]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaGoalKeeper_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -215,7 +215,7 @@
 }
 
 
-@PART[GoalKeeperBDAcMk1]:FINAL
+@PART[GoalKeeperBDAcMk1]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_GoalKeeperBDAcMk1_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -223,7 +223,7 @@
 }
 
 
-@PART[BDAcGKmk2]:FINAL
+@PART[BDAcGKmk2]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_BDAcGKmk2_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -231,7 +231,7 @@
 }
 
 
-@PART[scanLockRadar1]:FINAL
+@PART[scanLockRadar1]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_scanLockRadar1_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -239,7 +239,7 @@
 }
 
 
-@PART[scanLargeRadar]:FINAL
+@PART[scanLargeRadar]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_scanLargeRadar_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -247,7 +247,7 @@
 }
 
 
-@PART[bahaH70Launcher]:FINAL
+@PART[bahaH70Launcher]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaH70Launcher_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -255,7 +255,7 @@
 }
 
 
-@PART[bahaH70Turret]:FINAL
+@PART[bahaH70Turret]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaH70Turret_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -263,7 +263,7 @@
 }
 
 
-@PART[bahaHarm]:FINAL
+@PART[bahaHarm]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaHarm_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -271,7 +271,7 @@
 }
 
 
-@PART[bahaHEKV1]:FINAL
+@PART[bahaHEKV1]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaHEKV1_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -279,7 +279,7 @@
 }
 
 
-@PART[bahaAGM-114]:FINAL
+@PART[bahaAGM-114]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaAGM-114_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -287,7 +287,7 @@
 }
 
 
-@PART[bahaHiddenVulcan]:FINAL
+@PART[bahaHiddenVulcan]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaHiddenVulcan_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -295,7 +295,7 @@
 }
 
 
-@PART[bahaJdamMk83]:FINAL
+@PART[bahaJdamMk83]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaJdamMk83_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -303,7 +303,7 @@
 }
 
 
-@PART[bahaM102Howitzer]:FINAL
+@PART[bahaM102Howitzer]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaM102Howitzer_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -311,7 +311,7 @@
 }
 
 
-@PART[bahaM1Abrams]:FINAL
+@PART[bahaM1Abrams]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaM1Abrams_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -319,7 +319,7 @@
 }
 
 
-@PART[bahaM230ChainGun]:FINAL
+@PART[bahaM230ChainGun]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaM230ChainGun_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -327,7 +327,7 @@
 }
 
 
-@PART[bahaAGM-65]:FINAL
+@PART[bahaAGM-65]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaAGM-65_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -335,7 +335,7 @@
 }
 
 
-@PART[missileTurretTest]:FINAL
+@PART[missileTurretTest]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_missileTurretTest_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -343,7 +343,7 @@
 }
 
 
-@PART[bahaMk82Bomb]:FINAL
+@PART[bahaMk82Bomb]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaMk82Bomb_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -351,7 +351,7 @@
 }
 
 
-@PART[bahaMk82BombBrake]:FINAL
+@PART[bahaMk82BombBrake]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaMk82BombBrake_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -359,7 +359,7 @@
 }
 
 
-@PART[bahaOMillennium]:FINAL
+@PART[bahaOMillennium]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaOMillennium_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -367,7 +367,7 @@
 }
 
 
-@PART[bahaPac-3]:FINAL
+@PART[bahaPac-3]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaPac-3_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -375,7 +375,7 @@
 }
 
 
-@PART[patriotLauncherTurret]:FINAL
+@PART[patriotLauncherTurret]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_patriotLauncherTurret_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -383,7 +383,7 @@
 }
 
 
-@PART[radarDataReceiver]:FINAL
+@PART[radarDataReceiver]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_radarDataReceiver_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -391,7 +391,7 @@
 }
 
 
-@PART[bdRadome1]:FINAL
+@PART[bdRadome1]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bdRadome1_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -399,7 +399,7 @@
 }
 
 
-@PART[bdRadome1inline]:FINAL
+@PART[bdRadome1inline]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bdRadome1inline_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -407,7 +407,7 @@
 }
 
 
-@PART[bdRadome1snub]:FINAL
+@PART[bdRadome1snub]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bdRadome1snub_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -415,7 +415,7 @@
 }
 
 
-@PART[bahaRBS-15Cruise]:FINAL
+@PART[bahaRBS-15Cruise]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaRBS-15Cruise_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -423,7 +423,7 @@
 }
 
 
-@PART[bdRotBombBay]:FINAL
+@PART[bdRotBombBay]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bdRotBombBay_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -431,7 +431,7 @@
 }
 
 
-@PART[bahaS-8Launcher]:FINAL
+@PART[bahaS-8Launcher]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaS-8Launcher_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -439,7 +439,7 @@
 }
 
 
-@PART[bahaAim9]:FINAL
+@PART[bahaAim9]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaAim9_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -447,7 +447,7 @@
 }
 
 
-@PART[bdWarheadSmall]:FINAL
+@PART[bdWarheadSmall]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bdWarheadSmall_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -455,7 +455,7 @@
 }
 
 
-@PART[bahaSmokeCmPod]:FINAL
+@PART[bahaSmokeCmPod]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaSmokeCmPod_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -463,7 +463,7 @@
 }
 
 
-@PART[bahaFlirBall]:FINAL
+@PART[bahaFlirBall]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaFlirBall_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -471,7 +471,7 @@
 }
 
 
-@PART[bahaCamPod]:FINAL
+@PART[bahaCamPod]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaCamPod_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -479,7 +479,7 @@
 }
 
 
-@PART[towLauncherTurret]:FINAL
+@PART[towLauncherTurret]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_towLauncherTurret_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -487,7 +487,7 @@
 }
 
 
-@PART[bahaTowMissile]:FINAL
+@PART[bahaTowMissile]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_bahaTowMissile_title
     @manufacturer = #loc_BDArmory_part_manufacturer
@@ -495,21 +495,21 @@
 }
 
 
-@PART[missileController]:FINAL
+@PART[missileController]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_missileController_title
     @manufacturer = #loc_BDArmory_part_manufacturer
     @description = #loc_BDArmory_part_missileController_description
 }
 
-@PART[BDAsonarPod1A]:FINAL
+@PART[BDAsonarPod1A]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_BDAsonarPod1A_title
     @manufacturer = #loc_BDArmory_part_manufacturer
     @description = #loc_BDArmory_part_BDAsonarPod1A_description
 }
 
-@PART[StingRayBDATorpedo]:FINAL
+@PART[StingRayBDATorpedo]:AFTER[BDArmory]
 {
     @title = #loc_BDArmory_part_StingRayBDATorpedo_title
     @manufacturer = #loc_BDArmory_part_manufacturer


### PR DESCRIPTION
Changed Part deformatter :FINAL on patches to :AFTER[BDArmory] to allow other mods to modify the descriptions.