### PR TITLE
Adjust Space Spawn orientation

### DIFF
--- a/BDArmory/Control/VesselSpawner.cs
+++ b/BDArmory/Control/VesselSpawner.cs
@@ -538,7 +538,7 @@ namespace BDArmory.Control
                 // Fix control point orientation by setting the reference transformation to that of the root part.
                 spawnedVessels[vesselName].Item1.SetReferenceTransform(spawnedVessels[vesselName].Item1.rootPart);
 
-                if (!spawnAirborne)
+                if (!spawnAirborne || BDArmorySettings.SF_GRAVITY) //spawn parallel to ground if surface or space spawning
                 {
                     vessel.SetRotation(Quaternion.FromToRotation(shipFacility == EditorFacility.SPH ? -vessel.ReferenceTransform.forward : vessel.ReferenceTransform.up, localSurfaceNormal) * vessel.transform.rotation); // Re-orient the vessel to the terrain normal.
                     vessel.SetRotation(Quaternion.AngleAxis(Vector3.SignedAngle(shipFacility == EditorFacility.SPH ? vessel.ReferenceTransform.up : -vessel.ReferenceTransform.forward, direction, localSurfaceNormal), localSurfaceNormal) * vessel.transform.rotation); // Re-orient the vessel to the right direction.

--- a/BDArmory/FX/FireFX.cs
+++ b/BDArmory/FX/FireFX.cs
@@ -354,7 +354,10 @@ namespace BDArmory.FX
                 enginerestartTime = -1;
             }
             ////////////////////////////////////////////
-
+            if (!FlightGlobals.currentMainBody.atmosphereContainsOxygen && (ox == null && mp == null))
+            {
+                gameObject.SetActive(false); //only fuel+oxy or monoprop fires in vac/non-oxy atmo
+            }
         }
 
         void Detonate()

--- a/BDArmory/Modules/ModuleSpaceFriction.cs
+++ b/BDArmory/Modules/ModuleSpaceFriction.cs
@@ -60,6 +60,16 @@ namespace BDArmory.Modules
                 return SAI;
             }
         }
+        ModuleEngines Engine;
+        public ModuleEngines foundEngine
+        {
+            get
+            {
+                if (Engine) return Engine;
+                Engine = VesselModuleRegistry.GetModuleEngines(vessel).FirstOrDefault();
+                return Engine;
+            }
+        }
         void Start()
         {
             /*
@@ -124,7 +134,7 @@ namespace BDArmory.Modules
                     }
                     if (BDArmorySettings.SF_GRAVITY || AntiGravOverride) //have this disabled if no engines left?
                     {
-                        if ((BDAcraft && (pilot != null || driver != null)) || //have pilotless craft fall
+                        if ((BDAcraft && (pilot != null || driver != null || foundEngine != null)) || //have pilotless/engineless craft fall
                             (!BDAcraft))
                         {
                             for (int i = 0; i < part.vessel.Parts.Count; i++)


### PR DESCRIPTION
Have space spawns start parallel to terrain instead of nose down
-fires auto-extinguish in Vac, unless oxy or monprop present
-engineless craft no longer affected by space battle contragrav setting