### PR TITLE
HP visualizer

### DIFF
--- a/BDArmory.Core/Module/HitpointTracker.cs
+++ b/BDArmory.Core/Module/HitpointTracker.cs
@@ -109,8 +109,8 @@ namespace BDArmory.Core.Module
         AttachNode bottom;
         AttachNode top;
 
-        public string defaultShader;
-        public Color defaultColor;
+        public List<Shader> defaultShader;
+        public List<Color> defaultColor;
 
         #endregion KSP Fields
 
@@ -312,12 +312,14 @@ namespace BDArmory.Core.Module
             {
                 GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship); //will error if called in flightscene
             }
-            var r = part.GetComponentInChildren<Renderer>();
-            if (r != null)
+            var r = part.GetComponentsInChildren<Renderer>();
             {
-                defaultShader = r.material.shader.name;
-                defaultColor = r.material.color;
-                if (BDArmorySettings.DRAW_ARMOR_LABELS) Debug.Log("[ARMOR] part shader is " + r.material.shader.name);
+                for (int i = 0; i < r.Length; i++)
+                {
+                    defaultShader.Add(r[i].material.shader);
+                    if (BDArmorySettings.DRAW_ARMOR_LABELS) Debug.Log("[ARMOR] part shader is " + r[i].material.shader.name);
+                    defaultColor.Add(r[i].material.color);
+                }
             }
             if (HighLogic.LoadedSceneIsFlight)
             {

--- a/BDArmory.Core/Module/HitpointTracker.cs
+++ b/BDArmory.Core/Module/HitpointTracker.cs
@@ -109,6 +109,9 @@ namespace BDArmory.Core.Module
         AttachNode bottom;
         AttachNode top;
 
+        public string defaultShader;
+        public Color defaultColor;
+
         #endregion KSP Fields
 
         #region Heart Bleed
@@ -307,8 +310,15 @@ namespace BDArmory.Core.Module
             HullSetup(null, null); //reaquire hull mass adjust for mass calcs
             if (HighLogic.LoadedSceneIsEditor)
             {
-                GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship); //will error if called in flightscene
-            }           
+                GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
+            }
+            var r = part.GetComponentInChildren<Renderer>();
+            if (r != null)
+            {
+                defaultShader = r.material.shader.name;
+                defaultColor = r.material.color;
+                if (BDArmorySettings.DRAW_ARMOR_LABELS) Debug.Log("[ARMOR] part shader is " + r.material.shader.name);
+            }
             if (HighLogic.LoadedSceneIsFlight)
             {
                 if (BDArmorySettings.DRAW_ARMOR_LABELS) Debug.Log("[ARMOR] part mass is: " + partMass + "; Armor mass is: " + armorMass + "; hull mass adjust: " + HullmassAdjust + "; total: " + part.mass);
@@ -574,17 +584,13 @@ namespace BDArmory.Core.Module
         public void overrideArmorSetFromConfig()
         {
             ArmorSet = true;
-            if (ArmorThickness != 0)
+            if (ArmorThickness > 10) //primarily panels, but any thing that starts with more than default armor
             {
+                startsArmored = true;
                 Armor = ArmorThickness;
-                maxSupportedArmor = ArmorThickness;
-                if (ArmorThickness > 10) //primarily panels, but any thing that starts with more than default armor
-                {
-                    startsArmored = true;
-                    UI_FloatRange armortypes = (UI_FloatRange)Fields["ArmorTypeNum"].uiControlEditor;
-                    armortypes.minValue = 2f; //prevent panels from being switched to "None" armor type
-                    ArmorTypeNum = 2;
-                }
+                UI_FloatRange armortypes = (UI_FloatRange)Fields["ArmorTypeNum"].uiControlEditor;
+                armortypes.minValue = 2f; //prevent panels from being switched to "None" armor type
+                ArmorTypeNum = 2;
             }
             if (maxSupportedArmor < 0) //hasn't been set in cfg
             {

--- a/BDArmory/Control/VesselSpawner.cs
+++ b/BDArmory/Control/VesselSpawner.cs
@@ -538,7 +538,7 @@ namespace BDArmory.Control
                 // Fix control point orientation by setting the reference transformation to that of the root part.
                 spawnedVessels[vesselName].Item1.SetReferenceTransform(spawnedVessels[vesselName].Item1.rootPart);
 
-                if (!spawnAirborne)
+                if (!spawnAirborne || BDArmorySettings.SF_GRAVITY) //spawn parallel to ground if surface or space spawning
                 {
                     vessel.SetRotation(Quaternion.FromToRotation(shipFacility == EditorFacility.SPH ? -vessel.ReferenceTransform.forward : vessel.ReferenceTransform.up, localSurfaceNormal) * vessel.transform.rotation); // Re-orient the vessel to the terrain normal.
                     vessel.SetRotation(Quaternion.AngleAxis(Vector3.SignedAngle(shipFacility == EditorFacility.SPH ? vessel.ReferenceTransform.up : -vessel.ReferenceTransform.forward, direction, localSurfaceNormal), localSurfaceNormal) * vessel.transform.rotation); // Re-orient the vessel to the right direction.
@@ -563,6 +563,14 @@ namespace BDArmory.Control
                     }
                 }
                 vessel.SetPosition(finalSpawnPositions[vesselName]);
+                if (BDArmorySettings.SPACE_HACKS)
+                {
+                    var SF = vessel.rootPart.FindModuleImplementing<ModuleSpaceFriction>();
+                    if (SF == null)
+                    {
+                        SF = (ModuleSpaceFriction)vessel.rootPart.AddModule("ModuleSpaceFriction");
+                    }
+                }
                 Debug.Log("[BDArmory.VesselSpawner]: Vessel " + vessel.vesselName + " spawned!");
             }
             #endregion

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -797,6 +797,7 @@ Localization
         #LOC_BDArmory_ArmorCost = Armor Cost
         #LOC_BDArmory_ArmorCurrent = Current Armor
         #LOC_BDArmory_ArmorVisualizer = Toggle Armor Visualizer
+        #LOC_BDArmory_ArmorHPVisualizer = Toggle HP Visualizer
         #LOC_BDArmory_ArmorSelect = Select Armor Material
         #LOC_BDArmory_ArmorTool = BDA Armor Tool
         #LOC_BDArmory_Armor_HullMat = Current Hull Material

--- a/BDArmory/FX/FireFX.cs
+++ b/BDArmory/FX/FireFX.cs
@@ -354,7 +354,10 @@ namespace BDArmory.FX
                 enginerestartTime = -1;
             }
             ////////////////////////////////////////////
-
+            if (!FlightGlobals.currentMainBody.atmosphereContainsOxygen && (ox == null && mp == null))
+            {
+                gameObject.SetActive(false); //only fuel+oxy or monoprop fires in vac/non-oxy atmo
+            }
         }
 
         void Detonate()

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -980,6 +980,12 @@ namespace BDArmory.Modules
                 AI = VesselModuleRegistry.GetIBDAIControl(vessel, true);
 
                 RefreshModules();
+                var SF = vessel.rootPart.FindModuleImplementing<ModuleSpaceFriction>();
+                if (SF == null)
+                {
+                    SF = (ModuleSpaceFriction)vessel.rootPart.AddModule("ModuleSpaceFriction");
+                }
+                //either have this added on spawn to allow vessels to respond to shace hack settings getting toggled, or have the Spacefirction module it's own separate part
             }
             else if (HighLogic.LoadedSceneIsEditor)
             {

--- a/BDArmory/UI/BDAEditorArmorWindow.cs
+++ b/BDArmory/UI/BDAEditorArmorWindow.cs
@@ -423,6 +423,7 @@ namespace BDArmory.UI
                             {
                                 for (int i = 0; i < r.Length; i++)
                                 {
+                                    if (r[i].material.shader.name.Contains("Alpha")) continue;
                                     r[i].material.shader = Shader.Find("KSP/Unlit");
                                     r[i].material.SetColor("_Color", VisualizerColor);
                                 }
@@ -441,8 +442,15 @@ namespace BDArmory.UI
                         {
                             for (int i = 0; i < r.Length; i++)
                             {
-                                r[i].material.shader = Shader.Find(armor.defaultShader);
-                                r[i].material.SetColor("_Color", armor.defaultColor);
+                                try
+                                {
+                                    r[i].material.shader = armor.defaultShader[i];
+                                    r[i].material.SetColor("_Color", armor.defaultColor[i]);
+                                }
+                                catch
+                                {
+                                    //Debug.Log("[BDAEditorArmorWindow]: material on " + parts.Current.name + "could not find default shader/color");
+                                }
                             }
                         }
                     }

--- a/BDArmory/UI/BDAEditorArmorWindow.cs
+++ b/BDArmory/UI/BDAEditorArmorWindow.cs
@@ -50,8 +50,11 @@ namespace BDArmory.UI
         private float oldThickness = -1;
         private float maxThickness = 60;
         private bool Visualizer = false;
+        private bool HPvisualizer = false;
         private bool oldVisualizer = false;
+        private bool oldHPvisualizer = false;
         private bool refreshVisualizer = false;
+        private bool refreshHPvisualizer = false;
         private float updateTimer = 0;
         private bool isWood = false;
         private bool isSteel = false;
@@ -85,6 +88,7 @@ namespace BDArmory.UI
         {
             CalcArmor = true;
             refreshVisualizer = true;
+            refreshHPvisualizer = true;
         }
 
         private void OnDestroy()
@@ -159,7 +163,8 @@ namespace BDArmory.UI
             else
             {
                 Visualizer = false;
-                VisualizeArmor();
+                HPvisualizer = false;
+                Visualize();
             }
             PreventClickThrough();
         }
@@ -181,12 +186,26 @@ namespace BDArmory.UI
             float line = 1.5f;
 
             style.fontStyle = FontStyle.Normal;
+            HPvisualizer = GUI.Toggle(new Rect(10, line * lineHeight, 280, lineHeight), HPvisualizer, Localizer.Format("#LOC_BDArmory_ArmorHPVisualizer"), HPvisualizer ? BDArmorySetup.BDGuiSkin.box : BDArmorySetup.BDGuiSkin.button);
+            line += 1.5f;
+
             Visualizer = GUI.Toggle(new Rect(10, line * lineHeight, 280, lineHeight), Visualizer, Localizer.Format("#LOC_BDArmory_ArmorVisualizer"), Visualizer ? BDArmorySetup.BDGuiSkin.box : BDArmorySetup.BDGuiSkin.button);
-            if (refreshVisualizer || Visualizer != oldVisualizer)
-            {
-                VisualizeArmor();
-            }
             line += 2;
+            if (Visualizer && HPvisualizer && !oldVisualizer && oldHPvisualizer)
+            {
+                HPvisualizer = false;
+                oldHPvisualizer = false;
+            }
+            if (Visualizer && HPvisualizer && oldVisualizer && !oldHPvisualizer)
+            {
+                Visualizer = false;
+                oldVisualizer = false;
+            }
+            if ((refreshHPvisualizer || HPvisualizer != oldHPvisualizer) || (refreshVisualizer || Visualizer != oldVisualizer))
+            {
+                Visualize();
+            }
+
             GUI.Label(new Rect(10, line * lineHeight, 300, lineHeight), Localizer.Format("#LOC_BDArmory_ArmorTotalMass") + ": " + totalArmorMass.ToString("0.00"), style);
             line++;
             GUI.Label(new Rect(10, line * lineHeight, 300, lineHeight), Localizer.Format("#LOC_BDArmory_ArmorTotalCost") + ": " + Mathf.Round(totalArmorCost), style);
@@ -197,13 +216,13 @@ namespace BDArmory.UI
             Thickness /= 5;
             Thickness = Mathf.Round(Thickness);
             Thickness *= 5;
-            line ++;
+            line++;
             if (Thickness != oldThickness)
             {
                 oldThickness = Thickness;
                 SetThickness = true;
                 maxThickness = 10;
-                CalculateArmorMass();                
+                CalculateArmorMass();
             }
             GUI.Label(new Rect(40, line * lineHeight, 300, lineHeight), Localizer.Format("#LOC_BDArmory_ArmorSelect"), style);
             line++;
@@ -253,13 +272,13 @@ namespace BDArmory.UI
                     //StatLines++;
                     GUI.Label(new Rect(135, (line + armorLines + StatLines) * lineHeight, 260, lineHeight), Localizer.Format("#LOC_BDArmory_ArmorDensity") + " " + ArmorDensity + " kg/m3", style);
                     StatLines++;
-                    GUI.Label(new Rect(15, (line + armorLines + StatLines) * lineHeight, 260, lineHeight), Localizer.Format("#LOC_BDArmory_ArmorCost") + " " + ArmorCost + "/m3", style);
+                    GUI.Label(new Rect(15, (line + armorLines + StatLines) * lineHeight, 120, lineHeight), Localizer.Format("#LOC_BDArmory_ArmorCost") + " " + ArmorCost + "/m3", style);
                     StatLines++;
                 }
             }
             line += 0.5f;
             float HullLines = 0;
-            showHullMenu = GUI.Toggle(new Rect(10, (line + armorLines + StatLines) *lineHeight, 280, lineHeight),
+            showHullMenu = GUI.Toggle(new Rect(10, (line + armorLines + StatLines) * lineHeight, 280, lineHeight),
                 showHullMenu, Localizer.Format("#LOC_BDArmory_Armor_HullMat"), showHullMenu ? BDArmorySetup.BDGuiSkin.box : BDArmorySetup.BDGuiSkin.button);
             HullLines += 1.15f;
 
@@ -315,9 +334,6 @@ namespace BDArmory.UI
             if (EditorLogic.RootPart == null)
                 return;
 
-            // Encapsulate editor ShipConstruct into a vessel:
-            //Vessel v = new Vessel();
-            //v.parts = EditorLogic.fetch.ship.Parts;
             totalArmorMass = 0;
             totalArmorCost = 0;
             using (List<Part>.Enumerator parts = EditorLogic.fetch.ship.Parts.GetEnumerator())
@@ -386,14 +402,11 @@ namespace BDArmory.UI
             ArmorStrength = ArmorInfo.armors[(ArmorInfo.armors.FindIndex(t => t.name == selectedArmor))].Strength;
             GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
         }
-        void VisualizeArmor()
+        void Visualize()
         {
             if (EditorLogic.RootPart == null)
                 return;
-            // Encapsulate editor ShipConstruct into a vessel:
-            //Vessel v = new Vessel();
-            //v.parts = EditorLogic.fetch.ship.Parts;
-            if (Visualizer)
+            if (Visualizer || HPvisualizer)
             {
                 using (List<Part>.Enumerator parts = EditorLogic.fetch.ship.Parts.GetEnumerator())
                     while (parts.MoveNext())
@@ -401,29 +414,45 @@ namespace BDArmory.UI
                         HitpointTracker a = parts.Current.GetComponent<HitpointTracker>();
                         if (a != null)
                         {
-                            parts.Current.SetHighlightColor(Color.HSVToRGB((a.ArmorTypeNum / (ArmorInfo.armors.Count + 1)), ((a.Armor / a.maxSupportedArmor) * 2), 1f));
-                            parts.Current.SetHighlight(true, false);
-                            parts.Current.highlightType = Part.HighlightType.AlwaysOn;
+                            Color VisualizerColor = Color.HSVToRGB((Mathf.Clamp(a.Hitpoints, 100, 1600) / 1600) / 3, 1, 1);
+                            if (Visualizer)
+                            {
+                                VisualizerColor = Color.HSVToRGB(a.ArmorTypeNum / (ArmorInfo.armors.Count + 1), (a.Armor / maxThickness), 1f);
+                            }
+                            var r = parts.Current.GetComponentsInChildren<Renderer>();
+                            {
+                                for (int i = 0; i < r.Length; i++)
+                                {
+                                    r[i].material.shader = Shader.Find("KSP/Unlit");
+                                    r[i].material.SetColor("_Color", VisualizerColor);
+                                }
+                            }
                         }
                     }
             }
-            else
+            if (!Visualizer && !HPvisualizer)
             {
                 using (List<Part>.Enumerator parts = EditorLogic.fetch.ship.Parts.GetEnumerator())
                     while (parts.MoveNext())
                     {
                         HitpointTracker armor = parts.Current.GetComponent<HitpointTracker>();
-                        if (armor != null)
+
+                        var r = parts.Current.GetComponentsInChildren<Renderer>();
                         {
-                            parts.Current.highlightType = Part.HighlightType.OnMouseOver;
-                            parts.Current.SetHighlightColor(Part.defaultHighlightPart);
-                            parts.Current.SetHighlight(false, false);
+                            for (int i = 0; i < r.Length; i++)
+                            {
+                                r[i].material.shader = Shader.Find(armor.defaultShader);
+                                r[i].material.SetColor("_Color", armor.defaultColor);
+                            }
                         }
                     }
             }
             oldVisualizer = Visualizer;
+            oldHPvisualizer = HPvisualizer;
             refreshVisualizer = false;
+            refreshHPvisualizer = false;
         }
+
         /// <summary>
         /// Lock the model if our own window is shown and has cursor focus to prevent click-through.
         /// Code adapted from FAR Editor GUI
@@ -459,5 +488,5 @@ namespace BDArmory.UI
             mousePos.y = Screen.height - mousePos.y;
             return mousePos;
         }
-    } 
+    }
 }


### PR DESCRIPTION
- Adds HP visualizer to armor widget
   -  Fixes graphical glitch with landing gears

patch 7 space hack tweaks got folded into this branch
- Have space spawns start parallel to terrain instead of nose down
- fires auto-extinguish in Vac, unless oxy or monprop present
- engineless craft no longer affected by space battle contragrav setting
- ModuleSpaceFriction now added automagically instead of via MM patch
