### PR TITLE
Proc Wings compatibility fix

### DIFF
--- a/BDArmory.Core/Module/HitpointTracker.cs
+++ b/BDArmory.Core/Module/HitpointTracker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using BDArmory.Core.Extension;
@@ -17,7 +18,7 @@ namespace BDArmory.Core.Module
         public float GetModuleCost(float baseCost, ModifierStagingSituation situation) => armorCost;
         public ModifierChangeWhen GetModuleCostChangeWhen() => ModifierChangeWhen.FIXED;
 
-        [KSPField(isPersistant = false, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_Hitpoints"),//Hitpoints
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_Hitpoints"),//Hitpoints
         UI_ProgressBar(affectSymCounterparts = UI_Scene.None, controlEnabled = false, scene = UI_Scene.All, maxValue = 100000, minValue = 0, requireFullControl = false)]
         public float Hitpoints;
 
@@ -62,7 +63,7 @@ namespace BDArmory.Core.Module
         private bool armorReset = false;
 
         [KSPField(isPersistant = true)]
-        public float maxHitPoints = 0f;
+        public float maxHitPoints = -1f;
 
         [KSPField(isPersistant = true)]
         public float ArmorThickness = 0f;
@@ -121,7 +122,7 @@ namespace BDArmory.Core.Module
 
         private readonly float hitpointMultiplier = BDArmorySettings.HITPOINT_MULTIPLIER;
 
-        private float previousHitpoints;
+        private float previousHitpoints = -1;
         private bool _updateHitpoints = false;
         private bool _forceUpdateHitpointsUI = false;
         private const int HpRounding = 100;
@@ -164,7 +165,7 @@ namespace BDArmory.Core.Module
                             }
                         }
                         else // Use the stock default value.
-                            maxHitPoints = 0f;
+                            maxHitPoints = -1f;
                     }
                     else // Don't.
                     {
@@ -196,6 +197,7 @@ namespace BDArmory.Core.Module
                 if (!ArmorSet) overrideArmorSetFromConfig();
 
                 previousHitpoints = maxHitPoints_;
+                part.RefreshAssociatedWindows();
             }
             else
             {
@@ -207,7 +209,7 @@ namespace BDArmory.Core.Module
         {
             isEnabled = true;
 
-            //if (part != null) _updateHitpoints = true; //this just calls Setupprefab, already directly called later in OnStart
+            //if (part != null) _updateHitpoints = true; 
             partMass = 0; //null these before part.mass is taken for HP calcs to ensure proper part mass recorded as original value
             HullmassAdjust = 0;
             if (HighLogic.LoadedSceneIsFlight)
@@ -458,7 +460,7 @@ namespace BDArmory.Core.Module
                 hitpoints = structuralMass * hitpointMultiplier * 0.333f;
                 //hitpoints = (structuralVolume * Mathf.Pow(density, .333f) * Mathf.Clamp(80 - (structuralVolume / 2), 80 / 4, 80)) * hitpointMultiplier * 0.333f; //volume * cuberoot of density * HP mult scaled by size
 
-                if (hitpoints > 10 * (part.mass - armorMass) * 1000f  * hitpointMultiplier * 0.333f || hitpoints < 0.1f * (part.mass - armorMass) * 1000f * hitpointMultiplier * 0.333f)
+                if (hitpoints > 10 * partMass * 1000f  * hitpointMultiplier * 0.333f || hitpoints < 0.1f * partMass * 1000f * hitpointMultiplier * 0.333f)
                 {
                     if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log($"[BDArmory.HitpointTracker]: Clamping hitpoints for part {part.name}");
                     hitpoints = hitpointMultiplier * (part.mass - armorMass) * 333f;
@@ -469,18 +471,18 @@ namespace BDArmory.Core.Module
                 {
                     if (part.Modules.Contains("FARWingAerodynamicModel") || part.Modules.Contains("FARControllableSurface"))
                     {
-                        hitpoints = ((part.mass - armorMass) * 1000f) * 3.5f * hitpointMultiplier * 0.333f; //To account for FAR's Strength-mass Scalar.     
+                        hitpoints = (partMass * 1000f) * 3.5f * hitpointMultiplier * 0.333f; //To account for FAR's Strength-mass Scalar.     
                     }
                     else
                     {
-                        hitpoints = ((part.mass - armorMass) * 1000f) * 7f * hitpointMultiplier * 0.333f; // since wings are basically a 2d object, lets have mass be our scalar - afterall, 2x the mass will ~= 2x the surfce area
+                        hitpoints = (partMass * 1000f) * 7f * hitpointMultiplier * 0.333f; // since wings are basically a 2d object, lets have mass be our scalar - afterall, 2x the mass will ~= 2x the surfce area
                     } //breaks when pWings are made stupidly thick
                 }
                 if (HullTypeNum == 1)
                 {
                     hitpoints /= 4;
                 }
-                else if (HullTypeNum == 3)
+                if (HullTypeNum == 3)
                 {
                     hitpoints *= 1.75f;
                 }
@@ -494,16 +496,19 @@ namespace BDArmory.Core.Module
             }
 
             //override based on part configuration for custom parts
-            if (maxHitPoints != 0)
+            if (maxHitPoints > 0)
             {
-                hitpoints = maxHitPoints;
                 if (HullTypeNum == 1)
                 {
-                    hitpoints /= 4;
+                    hitpoints = maxHitPoints / 4;
                 }
                 else if (HullTypeNum == 3)
                 {
-                    hitpoints *= 1.75f;
+                    hitpoints = maxHitPoints * 1.75f;
+                }
+                else
+                {
+                    hitpoints = maxHitPoints;
                 }
             }
 
@@ -735,26 +740,51 @@ namespace BDArmory.Core.Module
         public void HullSetup(BaseField field, object obj)
         {
             if (IgnoreForArmorSetup) return;
+            HullmassAdjust = 0;
+            if (part.name.Contains("B9.Aero.Wing.Procedural"))
+            {
+                StartCoroutine(WaitForProcWings());
+                return;
+            }
+            else
+            {
+                SetHullMass();
+            }
+        }
+        IEnumerator WaitForProcWings()
+        {
+            yield return new WaitForSeconds(0.2f); //wait for the IPartMassMod in Pwings to reset
+            partMass = ((part.mass - armorMass) - HullmassAdjust); 
+            Debug.Log("[HP]: zeroing values; " + part.name + "; PartMass= " + partMass + " armour mass= " + armorMass + "; hull mass adjust= " + HullmassAdjust + "; final part mass = " + part.mass);
+            SetHullMass();
+        }
+        void SetHullMass()
+        {
             if (HullTypeNum == 1)
             {
-                HullmassAdjust = ((part.mass - armorMass) / 3) - (part.mass - armorMass);
+                HullmassAdjust = ((partMass) / 3) - (partMass);
                 guiHullTypeString = Localizer.Format("#LOC_BDArmory_Wood");
                 part.maxTemp = 770;
+                Debug.Log("[HP]: setting wood; " + part.name + "; PartMass= " + partMass + " armour mass= " + armorMass + "; hull mass adjust= " + HullmassAdjust + "; final part mass = " + part.mass);
             }
             else if (HullTypeNum == 2)
             {
-                HullmassAdjust = 0;
                 guiHullTypeString = Localizer.Format("#LOC_BDArmory_Aluminium");
                 part.maxTemp = 1000;
+                Debug.Log("[HP]: setting aluminium; " + part.name + "; PartMass= " + partMass + " armour mass= " + armorMass + "; hull mass adjust= " + HullmassAdjust + "; final part mass = " + part.mass);
             }
             else //hulltype 3
             {
-                HullmassAdjust = partMass;
+                HullmassAdjust = (partMass);
                 guiHullTypeString = Localizer.Format("#LOC_BDArmory_Steel");
                 part.maxTemp = 2000;
+                Debug.Log("[HP]: setting steel; " + part.name + "; PartMass= " + partMass + " armour mass= " + armorMass + "; hull mass adjust= " + HullmassAdjust + "; final part mass = " + part.mass);
             }
-            //GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
-            CalculateTotalHitpoints();
+            if (HighLogic.LoadedSceneIsEditor)
+            {
+                GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
+            }
+            SetupPrefab();
         }
         #endregion Armour
     }

--- a/BDArmory.Core/Module/HitpointTracker.cs
+++ b/BDArmory.Core/Module/HitpointTracker.cs
@@ -755,7 +755,7 @@ namespace BDArmory.Core.Module
         {
             yield return new WaitForSeconds(0.2f); //wait for the IPartMassMod in Pwings to reset
             partMass = ((part.mass - armorMass) - HullmassAdjust); 
-            Debug.Log("[HP]: zeroing values; " + part.name + "; PartMass= " + partMass + " armour mass= " + armorMass + "; hull mass adjust= " + HullmassAdjust + "; final part mass = " + part.mass);
+            //Debug.Log("[HP]: zeroing values; " + part.name + "; PartMass= " + partMass + " armour mass= " + armorMass + "; hull mass adjust= " + HullmassAdjust + "; final part mass = " + part.mass);
             SetHullMass();
         }
         void SetHullMass()
@@ -765,20 +765,20 @@ namespace BDArmory.Core.Module
                 HullmassAdjust = ((partMass) / 3) - (partMass);
                 guiHullTypeString = Localizer.Format("#LOC_BDArmory_Wood");
                 part.maxTemp = 770;
-                Debug.Log("[HP]: setting wood; " + part.name + "; PartMass= " + partMass + " armour mass= " + armorMass + "; hull mass adjust= " + HullmassAdjust + "; final part mass = " + part.mass);
+                //Debug.Log("[HP]: setting wood; " + part.name + "; PartMass= " + partMass + " armour mass= " + armorMass + "; hull mass adjust= " + HullmassAdjust + "; final part mass = " + part.mass);
             }
             else if (HullTypeNum == 2)
             {
                 guiHullTypeString = Localizer.Format("#LOC_BDArmory_Aluminium");
                 part.maxTemp = 1000;
-                Debug.Log("[HP]: setting aluminium; " + part.name + "; PartMass= " + partMass + " armour mass= " + armorMass + "; hull mass adjust= " + HullmassAdjust + "; final part mass = " + part.mass);
+                //Debug.Log("[HP]: setting aluminium; " + part.name + "; PartMass= " + partMass + " armour mass= " + armorMass + "; hull mass adjust= " + HullmassAdjust + "; final part mass = " + part.mass);
             }
             else //hulltype 3
             {
                 HullmassAdjust = (partMass);
                 guiHullTypeString = Localizer.Format("#LOC_BDArmory_Steel");
                 part.maxTemp = 2000;
-                Debug.Log("[HP]: setting steel; " + part.name + "; PartMass= " + partMass + " armour mass= " + armorMass + "; hull mass adjust= " + HullmassAdjust + "; final part mass = " + part.mass);
+                //Debug.Log("[HP]: setting steel; " + part.name + "; PartMass= " + partMass + " armour mass= " + armorMass + "; hull mass adjust= " + HullmassAdjust + "; final part mass = " + part.mass);
             }
             if (HighLogic.LoadedSceneIsEditor)
             {

--- a/BDArmory/Distribution/GameData/BDArmory/MMPatches/000000_HitpointModule_PartFixes.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/MMPatches/000000_HitpointModule_PartFixes.cfg
@@ -3046,7 +3046,7 @@
 
 // Nobody knows what this next thing is HA
 // So sad makes me want to cry oh well
-@PART[B9.Aero.Wing.Procedural.TypeB] //defunct or non-stock??
+@PART[B9.Aero.Wing.Procedural.TypeB] //defunct or non-stock?? //neither, this is the proc crtl surface
 {
 	%MODULE[HitpointTracker]
 	{
@@ -3063,6 +3063,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 400 //nerf
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3073,6 +3074,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 450 //nerf
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3083,6 +3085,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 400 //nerf
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3093,6 +3096,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 400 //nerf
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3113,6 +3117,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 3000 //nerf
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3133,6 +3138,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 2400 //buff, scale FAT-455 Aeroplane Tail Fin
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3143,6 +3149,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 700 //buff, scale Wing Connector Type C
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3153,6 +3160,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 1400 //buff, match Wing Connector type A
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3163,6 +3171,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 400 //buff, scale Wing Connector Type C
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3173,6 +3182,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 700 //buff, match Wing Connector type C
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3183,6 +3193,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 700 //buff, match Wing Connector type C
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3193,6 +3204,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 400 //buff, match Wing Connector type D
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3203,6 +3215,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 200 //buff, scale Wing Connector type D
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3213,6 +3226,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 700 //buff, match Wing Connector type C
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3233,6 +3247,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 350 //buff, match Wing Connector type D
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3243,6 +3258,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 200 //buff
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3253,6 +3269,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 200 //buff
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 
@@ -3263,6 +3280,7 @@
 		ArmorThickness = 10
 		maxHitPoints = 2000 //Buff, original was 800, it's bloody massive and only had 800!?
 		ExplodeMode = Never
+		IsTrangularPanel = true
 	}
 }
 


### PR DESCRIPTION
Proc wings now have proper HP entering flight scene
Proc wings now have proper mass/HP when switching hull material
Fixes procwing HP not adjusting as wing shape modified
Removes irrelevant GUI elements from not-applicable parts (AIs/missiles/etc)
Allows Engines to use steel hull type