### PR TITLE
Mutators tweaks

### DIFF
--- a/BDArmory.Core/Module/HitpointTracker.cs
+++ b/BDArmory.Core/Module/HitpointTracker.cs
@@ -687,21 +687,13 @@ namespace BDArmory.Core.Module
         public void AddHealth(float partheal, bool overcharge = false)
         {
             if (isAI) return;
-            double delta;
             if (Hitpoints + partheal < BDArmorySettings.HEART_BLEED_THRESHOLD) //in case of negative regen value (for HP drain)
             {
                 return;
             }
-            if (Hitpoints < (overcharge ? Mathf.Min(previousHitpoints * 2, previousHitpoints + 1000) : previousHitpoints)) //Allow vampirism to overcharge HP
-            {
-                Hitpoints += partheal;
-                if (Hitpoints > (overcharge ? Mathf.Min(previousHitpoints * 2, previousHitpoints + 1000) : previousHitpoints))
-                {
-                    delta = Hitpoints - (overcharge ? Mathf.Min(previousHitpoints * 2, previousHitpoints + 1000) : previousHitpoints);
-                    Hitpoints -= (float)delta; //workaround to clamp HP without resetting HP if regenning after being overcharged from a previous mutator when using Apply_Timer or Apply_kill
-                }
-            }
-            //Hitpoints = Mathf.Clamp(Hitpoints, -1, overcharge ? Mathf.Min(previousHitpoints * 2, previousHitpoints + 1000) : previousHitpoints); //Allow vampirism to overcharge HP
+            Hitpoints += partheal;
+
+            Hitpoints = Mathf.Clamp(Hitpoints, -1, overcharge ? Mathf.Min(previousHitpoints * 2, previousHitpoints + 1000) : previousHitpoints); //Allow vampirism to overcharge HP
         }
 
         public void AddDamageToKerbal(KerbalEVA kerbal, float damage)

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -1154,7 +1154,7 @@ namespace BDArmory.Control
                     readyToLaunch.Add(pilot);
                 }
 
-            if (BDArmorySettings.MUTATOR_MODE)
+            if (BDArmorySettings.MUTATOR_MODE && BDArmorySettings.MUTATOR_LIST.Count > 0)
             {
                 ConfigureMutator();
             }
@@ -1186,7 +1186,7 @@ namespace BDArmory.Control
                     }
                     if (BDArmorySettings.MUTATOR_APPLY_TIMER && !BDArmorySettings.MUTATOR_APPLY_GLOBAL) //mutator applied on a per-craft basis
                     {
-						      MM.EnableMutator(); //random mutator
+                        MM.EnableMutator(); //random mutator
                     }
                 }
             }
@@ -1443,31 +1443,12 @@ namespace BDArmory.Control
         public void ConfigureMutator()
         {
             currentMutator = string.Empty;
-            if (BDArmorySettings.MUTATOR_LIST.Count > 0)
-            {
+
                 if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDArmory.BDACompetitionMode:" + CompetitionID.ToString() + "]: MutatorMode enabled; Mutator count = " + BDArmorySettings.MUTATOR_LIST.Count);
-                for (int r = 0; r < BDArmorySettings.MUTATOR_APPLY_NUM; r++)
-                {
-                    int i = UnityEngine.Random.Range(0, BDArmorySettings.MUTATOR_LIST.Count);
-                    if (!currentMutator.Contains(MutatorInfo.mutators[BDArmorySettings.MUTATOR_LIST[i]].name))
-                    {
-                        currentMutator += MutatorInfo.mutators[BDArmorySettings.MUTATOR_LIST[i]].name;
-                        if (r < BDArmorySettings.MUTATOR_APPLY_NUM - 1 && BDArmorySettings.MUTATOR_LIST.Count > 1)
-                        {
-                            currentMutator += "; ";
-                        }
-                    }
-                    else
-                    {
-                        if (r != 0)
-                        {
-                            r--;
-                        }
-                    }
-                }
-            }
-            else
-                currentMutator = BDArmorySettings.MUTATOR_LIST[0];
+                var indices = Enumerable.Range(0, BDArmorySettings.MUTATOR_LIST.Count).ToList();
+                indices.Shuffle();
+                currentMutator = string.Join("; ", indices.Take(BDArmorySettings.MUTATOR_APPLY_NUM).Select(i => MutatorInfo.mutators[BDArmorySettings.MUTATOR_LIST[i]].name));
+
             if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDArmory.BDACompetitionMode:" + CompetitionID.ToString() + "]: current mutators: " + currentMutator);
             MutatorResetTime = Planetarium.GetUniversalTime();
             if (BDArmorySettings.MUTATOR_APPLY_GLOBAL) //selected mutator applied globally
@@ -1919,7 +1900,7 @@ namespace BDArmory.Control
             double startTime = Planetarium.GetUniversalTime();
             double nextStep = startTime;
 
-            if (BDArmorySettings.MUTATOR_MODE)
+            if (BDArmorySettings.MUTATOR_MODE && BDArmorySettings.MUTATOR_LIST.Count > 0)
             {
                 ConfigureMutator();
             }
@@ -2857,7 +2838,7 @@ namespace BDArmory.Control
                 StopCompetition();
             }
 
-            if ((BDArmorySettings.MUTATOR_MODE && BDArmorySettings.MUTATOR_APPLY_TIMER) && BDArmorySettings.MUTATOR_DURATION > 0 && now - MutatorResetTime >= BDArmorySettings.MUTATOR_DURATION * 60d)
+            if ((BDArmorySettings.MUTATOR_MODE && BDArmorySettings.MUTATOR_APPLY_TIMER) && BDArmorySettings.MUTATOR_DURATION > 0 && now - MutatorResetTime >= BDArmorySettings.MUTATOR_DURATION * 60d && BDArmorySettings.MUTATOR_LIST.Count > 0)
             {
 
                 ScreenMessages.PostScreenMessage(Localizer.Format("#LOC_BDArmory_UI_MutatorShuffle"), 5, ScreenMessageStyle.UPPER_CENTER);

--- a/BDArmory/Control/BDACompetitionMode.cs
+++ b/BDArmory/Control/BDACompetitionMode.cs
@@ -2751,7 +2751,7 @@ namespace BDArmory.Control
                                                 MM = (BDAMutator)loadedVessels.Current.rootPart.AddModule("BDAMutator");
                                             }
                                             MM.EnableMutator(); //random mutator    
-                                            competitionStatus.Add(Scores.ScoreData[player].lastPersonWhoDamagedMe + " gains " + MM.mutatorName + (BDArmorySettings.MUTATOR_DURATION > 0 ? " for " + BDArmorySettings.MUTATOR_DURATION * 60 + "seconds!" : "!"));
+                                            competitionStatus.Add(Scores.ScoreData[player].lastPersonWhoDamagedMe + " gains " + MM.mutatorName + (BDArmorySettings.MUTATOR_DURATION > 0 ? " for " + BDArmorySettings.MUTATOR_DURATION * 60 + " seconds!" : "!"));
                                             
                                         }
                                     }

--- a/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Mutators.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Mutators.cfg
@@ -185,8 +185,8 @@ MUTATOR
 	MaxDeviation = -1
 	laserDamage = -1 
 	instaGib = false
-	Vampirism = 5
-	Regen = -10
+	Vampirism = 10
+	Regen = -25
 	EngineMult = -1
 	Strength = -1
 	Defense = -1

--- a/BDArmory/Modules/BDAMutator.cs
+++ b/BDArmory/Modules/BDAMutator.cs
@@ -7,6 +7,7 @@ using BDArmory.Core.Extension;
 using BDArmory.Core.Module;
 using BDArmory.UI;
 using BDArmory.FX;
+using System.Linq;
 
 namespace BDArmory.Modules
 {
@@ -56,25 +57,9 @@ namespace BDArmory.Modules
             }
             if (name == "def") //mutator not specified, randomly choose from selected mutators
             {
-                if (BDArmorySettings.MUTATOR_LIST.Count > 0)
-                {
-                    name = string.Empty;
-                    for (int d = 0; d < BDArmorySettings.MUTATOR_APPLY_NUM; d++)
-                    {
-                        int i = UnityEngine.Random.Range(0, BDArmorySettings.MUTATOR_LIST.Count);
-                        if (!name.Contains(MutatorInfo.mutators[BDArmorySettings.MUTATOR_LIST[i]].name))
-                        {
-                            name +=(MutatorInfo.mutators[BDArmorySettings.MUTATOR_LIST[i]].name + "; ");
-                        }
-                        else
-                        {
-                            if (d != 0)
-                            {
-                                d--;
-                            }
-                        }
-                    }
-                }
+                var indices = Enumerable.Range(0, BDArmorySettings.MUTATOR_LIST.Count).ToList();
+                indices.Shuffle();
+                name = string.Join("; ", indices.Take(BDArmorySettings.MUTATOR_APPLY_NUM).Select(i => MutatorInfo.mutators[BDArmorySettings.MUTATOR_LIST[i]].name));
                 if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDAMutator] random mutator list built: " + name + " on " + part.vessel.GetName());
             }
             mutatorName = name;

--- a/BDArmory/Modules/BDAMutator.cs
+++ b/BDArmory/Modules/BDAMutator.cs
@@ -273,7 +273,7 @@ namespace BDArmory.Modules
                         {
                             if (Regen != 0 && Accumulator > 5) //Add regen HP every 5 seconds
                             {
-                                part.Current.AddHealth(Regen);
+                                part.Current.AddHealth(Regen, Vampirism > 0); //don't clamp HP to default if vampirism also enabled to prevent regen resetting gained HP from vampirism
                             }
                             if (Vampirism > 0 && applyVampirism)
                             {

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -2379,6 +2379,10 @@ namespace BDArmory.UI
                         {
                             BDArmorySettings.MUTATOR_APPLY_NUM = BDArmorySettings.MUTATOR_LIST.Count;
                         }
+                        if (BDArmorySettings.MUTATOR_LIST.Count > 0 && BDArmorySettings.MUTATOR_APPLY_NUM < 1)
+                        {
+                            BDArmorySettings.MUTATOR_APPLY_NUM = 1;
+                        }
                         BDArmorySettings.MUTATOR_ICONS = GUI.Toggle(SLeftRect(++line, 1f), BDArmorySettings.MUTATOR_ICONS, Localizer.Format("#LOC_BDArmory_Settings_MutatorIcons"));
                     }
                 }


### PR DESCRIPTION
Changes the configureMutator indexing to an indices.shuffle method
Adds checks against applying mutators when mutator list size is 0
Adds check to insure mutator apply num resets to 1 if mutator list reset to 0, then re-populated
fix regen effect overwriting HP gains from vampirism