### PR TITLE
Fix for EngineMult/resourceTax stacking

### DIFF
--- a/BDArmory/Modules/BDAMutator.cs
+++ b/BDArmory/Modules/BDAMutator.cs
@@ -8,6 +8,7 @@ using BDArmory.Core.Module;
 using BDArmory.UI;
 using BDArmory.FX;
 using System.Linq;
+using BDArmory.Bullets;
 
 namespace BDArmory.Modules
 {
@@ -113,6 +114,7 @@ namespace BDArmory.Modules
                             }
                             if (weapon.Current.eWeaponType == ModuleWeapon.WeaponTypes.Laser)
                             {
+                                weapon.Current.projectileColor = BulletInfo.bullets[mutatorInfo.bulletType].projectileColor;
                                 weapon.Current.SetupLaserSpecifics();
                                 weapon.Current.pulseLaser = true;
                             }


### PR DESCRIPTION
Engine mult now properly applies sum enginemult value, and properly resets engine values on mutator expiration
Resource Tax now properly applies resources across multiple mutators with taxes, instead of last in stack
resources now taxed according to tax rate per mutator, so can have e.g. Mutator 1 tax fuel and mutator2 regen ammo, and both will apply correctly.
Fixes laser color assignment