### PR TITLE
Near Surface targeting

### DIFF
--- a/BDArmory/Bullets/PooledBullet.cs
+++ b/BDArmory/Bullets/PooledBullet.cs
@@ -333,9 +333,12 @@ namespace BDArmory.Bullets
             // Full-timestep position change (leapfrog integrator)
             transform.position += currentVelocity * period; //move bullet
             distanceTraveled += currentVelocity.magnitude * period; // calculate flight distance for achievement purposes
-            if (BDArmorySettings.BULLET_WATER_DRAG) // Check if the bullet is now underwater.
-                underwater = FlightGlobals.getAltitudeAtPos(transform.position) <= 0;
-
+            //if (BDArmorySettings.BULLET_WATER_DRAG) // Check if the bullet is now underwater.
+            if (FlightGlobals.getAltitudeAtPos(transform.position) <= 0 && !underwater)
+            {
+                underwater = true;
+                FXMonger.Splash(transform.position, caliber);
+            }
             // Second half-timestep velocity change (leapfrog integrator) (should be identical code-wise to the initial half-step)
             LeapfrogVelocityHalfStep(0.5f * period);
         }

--- a/BDArmory/Bullets/PooledRocket.cs
+++ b/BDArmory/Bullets/PooledRocket.cs
@@ -473,10 +473,12 @@ namespace BDArmory.Bullets
                 if (FlightGlobals.getAltitudeAtPos(transform.position) > 0 && startUnderwater)
                 {
                     startUnderwater = false;
+                    FXMonger.Splash(transform.position, caliber);
                 }
                 if (FlightGlobals.getAltitudeAtPos(transform.position) <= 0 && !startUnderwater)
                 {
                     Detonate(transform.position, false);
+                    FXMonger.Splash(transform.position, caliber);
                 }
             }
             prevPosition = currPosition;

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -4322,7 +4322,7 @@ namespace BDArmory.Modules
                                     candidateRPM = BDArmorySettings.FIRE_RATE_OVERRIDE;
                                 }
 
-                                if (electrolaser = true && target.isDebilitated) continue; // don't select EMP weapons if craft already disabled
+                                if (electrolaser) continue; // don't use lightning guns underwater
 
                                 if (targetWeapon != null && targetWeaponPriority > candidatePriority)
                                     continue; //keep higher priority weapon

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -2859,7 +2859,16 @@ namespace BDArmory.Modules
                         }
                     }
                 }
-
+                if (BDArmorySettings.BULLET_WATER_DRAG)
+                {
+                    if ((FlightGlobals.getAltitudeAtPos(targetPosition) < 0) && (FlightGlobals.getAltitudeAtPos(targetPosition) + targetRadius >0)) //vessel not completely submerged
+                        {
+                        if (caliber < 75)
+                        {
+                            targetPosition += (VectorUtils.GetUpDirection(targetPosition) * Mathf.Abs(FlightGlobals.getAltitudeAtPos(targetPosition))); //set targetposition to surface directly above target
+                        }
+                    }
+                }
                 //aim assist
                 Vector3 originalTarget = targetPosition;
                 targetDistance = Vector3.Distance(targetPosition, fireTransform.parent.position);


### PR DESCRIPTION
-guns will no longer fire when muzzle is underwater
-Expand underwater > underwater engagements to allow lasers (at reduced range)
-weapons targeting nearly fully submerged targets will target water surface immediately above target when water drag enabled
-Add splashFX for bullets/rockets when they hit water