### PR TITLE
Water/Armor/Missile fixes

### DIFF
--- a/BDArmory/Bullets/PooledBullet.cs
+++ b/BDArmory/Bullets/PooledBullet.cs
@@ -336,7 +336,24 @@ namespace BDArmory.Bullets
             //if (BDArmorySettings.BULLET_WATER_DRAG) // Check if the bullet is now underwater.
             if (FlightGlobals.getAltitudeAtPos(transform.position) <= 0 && !underwater)
             {
-                underwater = true;
+                float hitAngle = Vector3.Angle(GetDragAdjustedVelocity(), -VectorUtils.GetUpDirection(transform.position));
+                if (RicochetScenery(hitAngle))
+                {
+                    tracerStartWidth /= 2;
+                    tracerEndWidth /= 2;
+
+                    currentVelocity = Vector3.Reflect(currentVelocity, VectorUtils.GetUpDirection(transform.position));
+                    currentVelocity = (hitAngle / 150) * currentVelocity * 0.65f;
+
+                    Vector3 randomDirection = UnityEngine.Random.rotation * Vector3.one;
+
+                    currentVelocity = Vector3.RotateTowards(currentVelocity, randomDirection,
+                        UnityEngine.Random.Range(0f, 5f) * Mathf.Deg2Rad, 0);
+                }
+                else
+                {
+                    underwater = true;
+                }
                 FXMonger.Splash(transform.position, caliber);
             }
             // Second half-timestep velocity change (leapfrog integrator) (should be identical code-wise to the initial half-step)

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -657,6 +657,7 @@ Localization
         #LOC_BDArmory_MaxOffBoresight = Max Off Boresight
         #LOC_BDArmory_DetonationDistanceOverride = Detonation Distance Override
         #LOC_BDArmory_DetonateAtMinimumDistance = Detonate At Min Dist
+        #LOC_BDArmory_ProximityTriggerDistance = Warhead Detonation Dist
         #LOC_BDArmory_DropTime = Drop Time
         #LOC_BDArmory_InCargoBay = In Cargo Bay:\u0020
         #LOC_BDArmory_DetonationTime = Detonation Time

--- a/BDArmory/Modules/BDExplosivePart.cs
+++ b/BDArmory/Modules/BDExplosivePart.cs
@@ -24,7 +24,7 @@ namespace BDArmory.Modules
          UI_Label(affectSymCounterparts = UI_Scene.All, controlEnabled = true, scene = UI_Scene.All)]
         public float blastRadius = 10;
 
-        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false, guiName = "#LOC_BDArmory_ProximityFuzeRadius"), UI_FloatRange(minValue = 0f, maxValue = 100f, stepIncrement = 1f, scene = UI_Scene.Editor, affectSymCounterparts = UI_Scene.All)]//Proximity Fuze Radius
+        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false, guiName = "#LOC_BDArmory_ProximityTriggerDistance"), UI_FloatRange(minValue = 0f, maxValue = 100f, stepIncrement = 1f, scene = UI_Scene.Editor, affectSymCounterparts = UI_Scene.All)]//Proximity Fuze Radius
         public float detonationRange = -1f; // give ability to set proximity range
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_DetonateAtMinimumDistance"), UI_Toggle(disabledText = "#LOC_BDArmory_false", enabledText = "#LOC_BDArmory_true", scene = UI_Scene.All, affectSymCounterparts = UI_Scene.All)] // Detonate At Minumum Distance
         public bool detonateAtMinimumDistance = false;

--- a/BDArmory/Modules/MissileBase.cs
+++ b/BDArmory/Modules/MissileBase.cs
@@ -188,6 +188,8 @@ namespace BDArmory.Modules
 
         public int clusterbomb { get; set; } = 1;
 
+        public bool EMP { get; set; } = false;
+
         protected IGuidance _guidance;
 
         private double _lastVerticalSpeed;
@@ -324,10 +326,11 @@ namespace BDArmory.Modules
             var explosive = p.FindModuleImplementing<BDExplosivePart>();
             if (explosive != null)
             {
-                p.FindModuleImplementing<BDExplosivePart>().Armed = true;
+                explosive.Armed = true;
+                explosive.detonateAtMinimumDistance = DetonateAtMinimumDistance;
                 if (GuidanceMode == GuidanceModes.AGM || GuidanceMode == GuidanceModes.AGMBallistic)
                 {
-                    p.FindModuleImplementing<BDExplosivePart>().Shaped = true;
+                    explosive.Shaped = true;
                 }
             }
         }

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -3955,6 +3955,8 @@ namespace BDArmory.Modules
                         //projectile weapon selected, any missiles that take precedence?
                         if (candidateClass != WeaponClasses.Missile) continue;
                         MissileLauncher mlauncher = item.Current as MissileLauncher;
+                        bool EMP = ((MissileLauncher)item.Current).EMP;
+                        if (EMP && target.isDebilitated) continue;
 
                         if (vessel.Splashed && (FlightGlobals.getAltitudeAtPos(mlauncher.transform.position) < 0 && BDArmorySettings.BULLET_WATER_DRAG)) continue;
                         float candidateTDPS = 0f;

--- a/BDArmory/Modules/MissileLauncher.cs
+++ b/BDArmory/Modules/MissileLauncher.cs
@@ -602,6 +602,14 @@ namespace BDArmory.Modules
                 break;
             }
             cluster.Dispose();
+            List<ModuleEMP>.Enumerator emp = part.FindModulesImplementing<ModuleEMP>().GetEnumerator();
+            while (emp.MoveNext())
+            {
+                if (emp.Current == null) continue;
+                EMP = emp.Current;
+                break;
+            }
+            emp.Dispose();
         }
 
         /// <summary>

--- a/BDArmory/UI/BDAEditorArmorWindow.cs
+++ b/BDArmory/UI/BDAEditorArmorWindow.cs
@@ -44,7 +44,7 @@ namespace BDArmory.UI
         private float ArmorCost = 0;
         private bool armorslist = false;
         private float Thickness = 10;
-        private float oldThickness = -1;
+        private float oldThickness = 10;
         private float maxThickness = 60;
         private bool Visualizer = false;
         private bool HPvisualizer = false;
@@ -152,6 +152,7 @@ namespace BDArmory.UI
         public void ShowToolbarGUI()
         {
             showArmorWindow = true;
+            CalculateArmorMass();
         }
 
         public void HideToolbarGUI()
@@ -358,6 +359,10 @@ namespace BDArmory.UI
                     {
                         if (!vesselmass)
                         {
+                            if (armor.maxSupportedArmor > maxThickness)
+                            {
+                                maxThickness = armor.maxSupportedArmor;
+                            }
                             if (SetType || SetThickness)
                             {
                                 if (SetThickness)
@@ -365,10 +370,6 @@ namespace BDArmory.UI
                                     if (armor.ArmorTypeNum > 1)
                                     {
                                         armor.Armor = Mathf.Clamp(Thickness, 0, armor.maxSupportedArmor);
-                                        if (armor.maxSupportedArmor > maxThickness)
-                                        {
-                                            maxThickness = armor.maxSupportedArmor;
-                                        }
                                     }
                                 }
                                 if (SetType)


### PR DESCRIPTION
-Bullets can now ricochet off water
-Armor Tool GUI no longer resets thickness to 10 when opened
-AI won't use EMP missiles against targets that are currently EMP'ed
-Missiles now set BDExplosivePart detonationAtMinimumDistance bool
-Renames BDExplosivePart's detonateAtMinimumDistance label to Warhead Trigger Distance, to avoid confusion when using warheads on Modular Missiles