### PR TITLE
fire autoignition checks

### DIFF
--- a/BDArmory/Bullets/PooledRocket.cs
+++ b/BDArmory/Bullets/PooledRocket.cs
@@ -614,7 +614,7 @@ namespace BDArmory.Bullets
                                 float distance = Vector3.Distance(transform.position, hit.point);
                                 if (p != null)
                                 {
-                                    BulletHitFX.AttachFire(hit, p, caliber, sourceVesselName, BDArmorySettings.WEAPON_FX_DURATION * (1 - (distance / blastRadius)), 1, false, true); //else apply fire to occluding part
+                                    BulletHitFX.AttachFire(hit.point, p, caliber, sourceVesselName, BDArmorySettings.WEAPON_FX_DURATION * (1 - (distance / blastRadius)), 1, false, true); //else apply fire to occluding part
                                     if (BDArmorySettings.DRAW_DEBUG_LABELS)
                                         Debug.Log("[BDArmory.Rocket]: Applying fire to " + p.name + " at distance " + distance + "m, for " + BDArmorySettings.WEAPON_FX_DURATION * (1 - (distance / blastRadius)) + " seconds"); ;
                                 }

--- a/BDArmory/FX/BulletHitFX.cs
+++ b/BDArmory/FX/BulletHitFX.cs
@@ -456,7 +456,7 @@ namespace BDArmory.FX
                                 leakcount++;
                             }
                             leak.drainDuration = 0;
-                            AttachFire(hit, hitPart, caliber, sourcevessel, -1, leakcount);
+                            AttachFire(hit.point, hitPart, caliber, sourcevessel, -1, leakcount);
                         }
                     }
                     else
@@ -486,7 +486,7 @@ namespace BDArmory.FX
                 fuelLeak.SetActive(true);
             }
         }
-        public static void AttachFire(RaycastHit hit, Part hitPart, float caliber, string sourcevessel, float burntime = -1, int ignitedLeaks = 1, bool enginefire = false, bool surfaceFire = false)
+        public static void AttachFire(Vector3 hit, Part hitPart, float caliber, string sourcevessel, float burntime = -1, int ignitedLeaks = 1, bool enginefire = false, bool surfaceFire = false)
         {
             if (BDArmorySettings.BATTLEDAMAGE && BDArmorySettings.BD_FIRES_ENABLED)
             {

--- a/BDArmory/FX/FireFX.cs
+++ b/BDArmory/FX/FireFX.cs
@@ -437,7 +437,7 @@ namespace BDArmory.FX
                                         if (p == partHit)
                                         {
                                             if (rb == null) return;
-                                            BulletHitFX.AttachFire(hit, p, 1, SourceVessel, BDArmorySettings.WEAPON_FX_DURATION * (1 - (distToG0.magnitude / blastRadius)), 1, false, true);
+                                            BulletHitFX.AttachFire(hit.point, p, 1, SourceVessel, BDArmorySettings.WEAPON_FX_DURATION * (1 - (distToG0.magnitude / blastRadius)), 1, false, true);
                                             if (BDArmorySettings.DRAW_DEBUG_LABELS)
                                             {
                                                 Debug.Log("[BDArmory.FireFX] " + this.parentPart.name + " hit by burning fuel");
@@ -456,17 +456,18 @@ namespace BDArmory.FX
                 if (tntMassEquivalent > 0) //don't explode if nothing to detonate if called from OnParentDestroy()
                 {
                     ExplosionFx.CreateExplosion(parentPart.transform.position, tntMassEquivalent, explModelPath, explSoundPath, ExplosionSourceType.BattleDamage, 0, null, parentPart.vessel != null ? parentPart.vessel.vesselName : null, "Fuel");
+                    if (tntFuel > 0 || tntMP > 0) parentPart.Destroy();
                 }
             }
             Deactivate();
         }
 
-        public void AttachAt(Part hitPart, RaycastHit hit, Vector3 offset, string sourcevessel, float burnTime = -1)
+        public void AttachAt(Part hitPart, Vector3 hit, Vector3 offset, string sourcevessel, float burnTime = -1)
         {
             if (hitPart == null) return;
             parentPart = hitPart;
             transform.SetParent(hitPart.transform);
-            transform.position = hit.point + offset;
+            transform.position = hit + offset;
             transform.rotation = Quaternion.FromToRotation(Vector3.up, -FlightGlobals.getGeeForceAtPosition(transform.position));
             parentPart.OnJustAboutToDie += OnParentDestroy;
             parentPart.OnJustAboutToBeDestroyed += OnParentDestroy;
@@ -494,6 +495,7 @@ namespace BDArmory.FX
                 {
                     SST.isOnFire = false;
                 }
+                disableTime = -1;
                 parentPart = null;
                 transform.parent = null; // Detach ourselves from the parent transform so we don't get destroyed when it does.
                 gameObject.SetActive(false);

--- a/BDArmory/Misc/BattleDamageHandler.cs
+++ b/BDArmory/Misc/BattleDamageHandler.cs
@@ -33,7 +33,7 @@ namespace BDArmory.Misc
                     {
                         if (alreadyburning != null)
                         {
-                            BulletHitFX.AttachFire(hitLoc, part, caliber, attacker);
+                            BulletHitFX.AttachFire(hitLoc.point, part, caliber, attacker);
                         }
                         else
                         {
@@ -61,7 +61,7 @@ namespace BDArmory.Misc
                         if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDArmory.BattleDamageHandler]: Battery Dice Roll: " + Diceroll);
                         if (Diceroll <= BDArmorySettings.BD_DAMAGE_CHANCE)
                         {
-                            BulletHitFX.AttachFire(hitLoc, part, caliber, attacker);
+                            BulletHitFX.AttachFire(hitLoc.point, part, caliber, attacker);
                         }
                     }
                 }
@@ -76,7 +76,7 @@ namespace BDArmory.Misc
                             if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDArmory.BattleDamageHandler]: Wooded part Dice Roll: " + Diceroll);
                             if (Diceroll <= BDArmorySettings.BD_DAMAGE_CHANCE)
                             {
-                                BulletHitFX.AttachFire(hitLoc, part, caliber, attacker, 90);
+                                BulletHitFX.AttachFire(hitLoc.point, part, caliber, attacker, 90);
                             }
                         }
                     }
@@ -176,14 +176,14 @@ namespace BDArmory.Misc
                             {
                                 if ((explosivedamage || incendiary) && SRBFuelled)
                                 {
-                                    BulletHitFX.AttachFire(hitLoc, part, caliber, attacker);
+                                    BulletHitFX.AttachFire(hitLoc.point, part, caliber, attacker);
                                 }
                             }
                             else
                             {
                                 if (alreadyburning == null)
                                 {
-                                    BulletHitFX.AttachFire(hitLoc, part, caliber, attacker, -1, 1, true);
+                                    BulletHitFX.AttachFire(hitLoc.point, part, caliber, attacker, -1, 1, true);
                                 }
                             }
                         }
@@ -254,7 +254,7 @@ namespace BDArmory.Misc
                             gimbal.gimbalRange = 0;
                             if (incendiary)
                             {
-                                BulletHitFX.AttachFire(hitLoc, part, caliber, attacker, 20);
+                                BulletHitFX.AttachFire(hitLoc.point, part, caliber, attacker, 20);
                             }
                         }
                     }
@@ -309,7 +309,7 @@ namespace BDArmory.Misc
                             aileron.ctrlSurfaceRange = 0;
                             if (incendiary)
                             {
-                                BulletHitFX.AttachFire(hitLoc, part, caliber, attacker, 10);
+                                BulletHitFX.AttachFire(hitLoc.point, part, caliber, attacker, 10);
                             }
                         }
                     }
@@ -387,7 +387,7 @@ namespace BDArmory.Misc
                     {
                         if (incendiary)
                         {
-                            BulletHitFX.AttachFire(hitLoc, part, caliber, attacker, 20);
+                            BulletHitFX.AttachFire(hitLoc.point, part, caliber, attacker, 20);
                         }
                     }
                 }

--- a/BDArmory/Modules/ModuleCASE.cs
+++ b/BDArmory/Modules/ModuleCASE.cs
@@ -291,9 +291,12 @@ namespace BDArmory.Modules
         {
             if (HighLogic.LoadedSceneIsFlight && FlightGlobals.ready && !vessel.packed)
             {
-                if (this.part.temperature > 900) //ammo cooks off, part is too hot
+                if (BDArmorySettings.BD_FIRES_ENABLED && BDArmorySettings.BD_FIRE_HEATDMG)
                 {
-                    DetonateIfPossible();
+                    if (this.part.temperature > 900) //ammo cooks off, part is too hot
+                    {
+                        DetonateIfPossible();
+                    }
                 }
             }
         }

--- a/BDArmory/Modules/ModuleSelfSealingTank.cs
+++ b/BDArmory/Modules/ModuleSelfSealingTank.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 using BDArmory.Core.Utils;
 using BDArmory.FX;
 using BDArmory.UI;
+using BDArmory.Core;
 
 namespace BDArmory.Modules
 {
@@ -162,29 +163,26 @@ namespace BDArmory.Modules
         {
             if (HighLogic.LoadedSceneIsFlight && FlightGlobals.ready && vessel != null && !vessel.packed && !BDArmorySetup.GameIsPaused)
             {
-                if (((fuel != null && fuel.amount > 0) && part.temperature > 493) || ((solid != null && solid.amount > 0) && part.temperature > 600)) //autoignition temp of kerosene is 220 c
+                if (BDArmorySettings.BD_FIRES_ENABLED && BDArmorySettings.BD_FIRE_HEATDMG)
                 {
-                    if (!isOnFire)
+                    if (((fuel != null && fuel.amount > 0) && part.temperature > 493) || ((solid != null && solid.amount > 0) && part.temperature > 600)) //autoignition temp of kerosene is 220 c
                     {
-                        string fireStarter;
-                        var vesselFire = part.vessel.GetComponentInChildren<FireFX>();
-                        if (vesselFire != null)
+                        if (!isOnFire)
                         {
-                            fireStarter = vesselFire.SourceVessel;
+                            string fireStarter;
+                            var vesselFire = part.vessel.GetComponentInChildren<FireFX>();
+                            if (vesselFire != null)
+                            {
+                                fireStarter = vesselFire.SourceVessel;
+                            }
+                            else
+                            {
+                                fireStarter = part.vessel.GetName();
+                            }
+                            BulletHitFX.AttachFire(transform.position, part, 50, fireStarter);
+                            Debug.Log("[SelfSealingTank] Fuel auto-ignition! " + part.name + " is on fire! Fuel quantity: " + fuel.amount + "; temperature: " + part.temperature);
+                            isOnFire = true;
                         }
-                        else
-                        {
-                            fireStarter = part.vessel.GetName();
-                        }
-                        Vector3 firePosition = part.transform.up * 10;
-                        Ray LoSRay = new Ray(transform.position, (transform.position + firePosition) - transform.position);
-                        RaycastHit hit;
-                        if (Physics.Raycast(LoSRay, out hit, 10, 9076737)) 
-                        {
-                            BulletHitFX.AttachFire(hit, part, 50, fireStarter);
-                        }
-                        //Debug.Log("[SelfSealingTank] Fuel auto-ignition! " + part.name + " is on fire!");
-                        isOnFire = true;
                     }
                 }
             }


### PR DESCRIPTION
issue 7EpicDragon had was already fixed commit e9a6e10

-Add additional check for 'Fires Enabled' and 'Fires Add Heat' BD toggles for fuel/ammo ignition
-Detonating fuel tanks now properly destroy part again