### PR TITLE
Armor reset

### DIFF
--- a/BDArmory.Core/BDArmorySettings.cs
+++ b/BDArmory.Core/BDArmorySettings.cs
@@ -57,7 +57,8 @@ namespace BDArmory.Core
         [BDAPersistentSettingsField] public static bool AUTONOMOUS_COMBAT_SEATS = false;          // Enable/disable seats without kerbals.
         [BDAPersistentSettingsField] public static bool DESTROY_UNCONTROLLED_WMS = false;         // Automatically destroy the WM if there's no kerbal or drone core controlling it.
         [BDAPersistentSettingsField] public static bool RESET_HP = false;                         // Automatically reset HP of parts of vessels when they're spawned in flight mode.
-        [BDAPersistentSettingsField] public static bool RESET_ARMOUR = false;                     // Automatically reset Armor/ hull material of parts of vessels when they're spawned in flight mode.
+        [BDAPersistentSettingsField] public static bool RESET_ARMOUR = false;                     // Automatically reset Armor material of parts of vessels when they're spawned in flight mode.
+        [BDAPersistentSettingsField] public static bool RESET_HULL = false;                     // Automatically reset hull material of parts of vessels when they're spawned in flight mode.
         [BDAPersistentSettingsField] public static int KERBAL_SAFETY = 1;                         // Try to save kerbals by ejecting/leaving seats and deploying parachutes.
         [BDAPersistentSettingsField] public static bool TRACE_VESSELS_DURING_COMPETITIONS = false; // Trace vessel positions and rotations during competitions.
         [BDAPersistentSettingsField] public static bool DUMB_IR_SEEKERS = false;                  // IR missiles will go after hottest thing they can see

--- a/BDArmory.Core/Module/HitpointTracker.cs
+++ b/BDArmory.Core/Module/HitpointTracker.cs
@@ -777,14 +777,26 @@ UI_ProgressBar(affectSymCounterparts = UI_Scene.None, controlEnabled = false, sc
                 Debug.Log("[HPTracker] armor mass: " + armorMass + "; mass to reduce: " + (massToReduce * (Density / 1000000000))); //g/m3
             }
             float reduceMass = (massToReduce * (Density / 1000000000)); //g/cm3 conversion to yield tons
-            Armor -= (reduceMass / armorMass) * Armor; //now properly reduces armor thickness
-            if (Armor < 0)
+            if (armorMass > 0)
             {
-                Armor = 0;
-                ArmorRemaining = 0;
+                Armor -= (reduceMass / armorMass) * Armor; //now properly reduces armor thickness
+                if (Armor < 0)
+                {
+                    Armor = 0;
+                    ArmorRemaining = 0;
+                }
+                else ArmorRemaining = Armor / StartingArmor * 100;
+                Armour = Armor;
             }
-            else ArmorRemaining = Armor / StartingArmor * 100;
-            Armour = Armor;
+            else
+            {
+                if (Armor < 0)
+                {
+                    Armor = 0;
+                    ArmorRemaining = 0;
+                    Armour = Armor;
+                }
+            }
             if (ArmorPanel)
             {
                 Hitpoints = ArmorRemaining * armorVolume * 10;
@@ -794,7 +806,7 @@ UI_ProgressBar(affectSymCounterparts = UI_Scene.None, controlEnabled = false, sc
                 }
             }
             armorMass -= reduceMass; //tons
-            if (armorMass < 0)
+            if (armorMass <= 0)
             {
                 armorMass = 0;
             }

--- a/BDArmory.Core/Module/HitpointTracker.cs
+++ b/BDArmory.Core/Module/HitpointTracker.cs
@@ -252,16 +252,13 @@ UI_ProgressBar(affectSymCounterparts = UI_Scene.None, controlEnabled = false, sc
             {
                 if (BDArmorySettings.RESET_ARMOUR)
                 {
-                    HullTypeNum = 2;
                     IgnoreForArmorSetup = true;
                     ArmorSetup(null, null);
-                    SetHullMass();
                 }
-                else
+                if (BDArmorySettings.RESET_HULL)
                 {
-                    //UI_FloatRange armorField = (UI_FloatRange)Fields["Armor"].uiControlFlight;
-                    //Once started the max value of the field should be the initial one
-                    //armorField.maxValue = Armor;
+                    HullTypeNum = 2;
+                    SetHullMass();
                 }
                 part.RefreshAssociatedWindows();
             }
@@ -272,7 +269,7 @@ UI_ProgressBar(affectSymCounterparts = UI_Scene.None, controlEnabled = false, sc
                 {
                     typecount++;
                 }
-                if ((part.name == "bdPilotAI" || part.name == "bdShipAI" || part.name == "missileController" || part.name == "bdammGuidanceModule") || BDArmorySettings.LEGACY_ARMOR || BDArmorySettings.RESET_ARMOUR)
+                if (part.name == "bdPilotAI" || part.name == "bdShipAI" || part.name == "missileController" || part.name == "bdammGuidanceModule")
                 {
                     isAI = true;
                     Fields["ArmorTypeNum"].guiActiveEditor = false;
@@ -300,10 +297,19 @@ UI_ProgressBar(affectSymCounterparts = UI_Scene.None, controlEnabled = false, sc
                     Fields["ArmorTypeNum"].guiActiveEditor = false;
                     ATrangeEditor.maxValue = 1;
                 }
+                if (BDArmorySettings.LEGACY_ARMOR || BDArmorySettings.RESET_ARMOUR)
+                {
+                    Fields["ArmorTypeNum"].guiActiveEditor = false;
+                    Fields["guiArmorTypeString"].guiActiveEditor = false;
+                    Fields["guiArmorTypeString"].guiActive = false;
+                    Fields["armorCost"].guiActiveEditor = false;
+                    Fields["armorMass"].guiActiveEditor = false;
+                    ATrangeEditor.maxValue = 1;
+                }
                 UI_FloatRange HTrangeEditor = (UI_FloatRange)Fields["HullTypeNum"].uiControlEditor;
                 HTrangeEditor.onFieldChanged = HullModified;
                 //if part is an engine/fueltank don't allow wood construction/mass reduction
-                if (part.IsMissile() || part.IsWeapon() || isAI)
+                if (part.IsMissile() || part.IsWeapon() || isAI || BDArmorySettings.LEGACY_ARMOR || BDArmorySettings.RESET_HULL)
                 {
                     HullTypeNum = 2;
                     HTrangeEditor.minValue = 2;
@@ -732,6 +738,7 @@ UI_ProgressBar(affectSymCounterparts = UI_Scene.None, controlEnabled = false, sc
             if (isAI) return;
             if (ArmorPanel)
             {
+                if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDArmory.HitPointTracker] AddDamage(), hit part is armor panel, returning");
                 return;
             }
 
@@ -1011,7 +1018,7 @@ UI_ProgressBar(affectSymCounterparts = UI_Scene.None, controlEnabled = false, sc
         public void HullSetup(BaseField field, object obj) //no longer needed for realtime HP calcs, but does need to be updated occasionally to give correct vessel mass
         {
             if (IgnoreForArmorSetup) return;
-            if (isAI) HullTypeNum = 1;
+            if (isAI || BDArmorySettings.RESET_HULL || BDArmorySettings.LEGACY_ARMOR) HullTypeNum = 2;
             if (part.isEngine() && HullTypeNum < 2) //can armor engines, but not make them out of wood.
             {
                 HullTypeNum = 2;

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -163,6 +163,7 @@ Localization
         #LOC_BDArmory_Settings_DisplayCompetitionStatusHiddenUI = Show Status With UI Hidden
         #LOC_BDArmory_Settings_ResetHP = Reset Max HP of Parts
         #LOC_BDArmory_Settings_ResetArmor = Reset Armor of parts
+        #LOC_BDArmory_Settings_ResetHull = Reset Armor of parts
         #LOC_BDArmory_Settings_KerbalSafety = Kerbal Safety
         #LOC_BDArmory_Settings_KerbalSafetyInventory = Kerbal Inventory
         #LOC_BDArmory_Settings_KerbalSafetyInventory_NoChange = No Change

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -2341,7 +2341,8 @@ namespace BDArmory.UI
                     BDArmorySettings.BULLET_WATER_DRAG = GUI.Toggle(SLeftRect(++line), BDArmorySettings.BULLET_WATER_DRAG, Localizer.Format("#LOC_BDArmory_Settings_waterDrag"));// Underwater bullet drag
                     BDArmorySettings.RESET_ARMOUR = GUI.Toggle(SRightRect(line), BDArmorySettings.RESET_ARMOUR, Localizer.Format("#LOC_BDArmory_Settings_ResetArmor"));
                     BDArmorySettings.AUTO_RESUME_TOURNAMENT = GUI.Toggle(SLeftRect(++line), BDArmorySettings.AUTO_RESUME_TOURNAMENT, Localizer.Format("#LOC_BDArmory_Settings_AutoResumeTournaments")); // Auto-Resume Tournaments
-                    BDArmorySettings.VESSEL_RELATIVE_BULLET_CHECKS = GUI.Toggle(SRightRect(line), BDArmorySettings.VESSEL_RELATIVE_BULLET_CHECKS, Localizer.Format("#LOC_BDArmory_Settings_VesselRelativeBulletChecks"));//"Vessel-Relative Bullet Checks"
+                    BDArmorySettings.RESET_HULL = GUI.Toggle(SRightRect(line), BDArmorySettings.RESET_HULL, Localizer.Format("#LOC_BDArmory_Settings_ResetHull")); //Reset Hull
+                    BDArmorySettings.VESSEL_RELATIVE_BULLET_CHECKS = GUI.Toggle(SLeftRect(++line), BDArmorySettings.VESSEL_RELATIVE_BULLET_CHECKS, Localizer.Format("#LOC_BDArmory_Settings_VesselRelativeBulletChecks"));//"Vessel-Relative Bullet Checks"
                     if (BDArmorySettings.AUTO_RESUME_TOURNAMENT)
                     {
                         GUI.Label(SLeftSliderRect(++line), $"{Localizer.Format("#LOC_BDArmory_Settings_AutoQuitMemoryUsage")}:  ({(BDArmorySettings.QUIT_MEMORY_USAGE_THRESHOLD > SystemMaxMemory ? "Off" : $"{BDArmorySettings.QUIT_MEMORY_USAGE_THRESHOLD}GB")})", leftLabel); // Auto-Quit Memory Threshold


### PR DESCRIPTION
-No longer prevents damage while enabled
-Armor reset has been split into Armor Reset and Hull Reset
-Adds New Hull Reset option to BDA settings menu
-Fixes NaN that occurs when trying to reduce armor mass from 0 armor