### PR TITLE
Fixes for battle damage:

### DIFF
--- a/BDArmory/FX/FireFX.cs
+++ b/BDArmory/FX/FireFX.cs
@@ -190,7 +190,7 @@ namespace BDArmory.FX
                                 hasFuel = false;
                             }
                             solid = parentPart.Resources.Where(pr => pr.resourceName == "SolidFuel").FirstOrDefault();
-                            if (solid != null)
+                            if (solid != null && solid.amount > 0)
                             {
                                 if (solid.amount < solid.maxAmount * 0.66f)
                                 {

--- a/BDArmory/FX/FireFX.cs
+++ b/BDArmory/FX/FireFX.cs
@@ -381,11 +381,11 @@ namespace BDArmory.FX
                 PartResource fuel = parentPart.Resources.Where(pr => pr.resourceName == "LiquidFuel").FirstOrDefault();
                 PartResource ox = parentPart.Resources.Where(pr => pr.resourceName == "Oxidizer").FirstOrDefault();
                 float tntFuel = 0, tntOx = 0, tntMP = 0, tntEC = 0;
-                if (fuel != null)
+                if (fuel != null && fuel.amount > 0)
                 {
                     tntFuel = (Mathf.Clamp((float)fuel.amount, ((float)fuel.maxAmount * 0.05f), ((float)fuel.maxAmount * 0.2f)) / 2);
                     tntMassEquivalent += tntFuel;
-                    if (fuel != null && ox != null)
+                    if (fuel != null && (ox != null && ox.amount > 0))
                     {
                         tntOx = (Mathf.Clamp((float)ox.amount, ((float)ox.maxAmount * 0.1f), ((float)ox.maxAmount * 0.3f)) / 2);
                         tntMassEquivalent += tntOx;
@@ -397,7 +397,7 @@ namespace BDArmory.FX
                     }
                 }
                 PartResource mp = parentPart.Resources.Where(pr => pr.resourceName == "MonoPropellant").FirstOrDefault();
-                if (mp != null)
+                if (mp != null && mp.amount > 0)
                 {
                     tntMP = (Mathf.Clamp((float)mp.amount, ((float)mp.maxAmount * 0.1f), ((float)mp.maxAmount * 0.3f)) / 3);
                     tntMassEquivalent += tntMP;
@@ -408,7 +408,7 @@ namespace BDArmory.FX
                 }
                 tntMassEquivalent /= 6f; //make this not have a 1 to 1 ratio of fuelmass -> tntmass
                 PartResource ec = parentPart.Resources.Where(pr => pr.resourceName == "ElectricCharge").FirstOrDefault();
-                if (ec != null)
+                if (ec != null && ec.amount > 0)
                 {
                     tntEC = ((float)ec.maxAmount / 5000); //fix for cockpit batteries weighing a tonne+
                     tntMassEquivalent += tntEC;

--- a/BDArmory/Misc/BattleDamageHandler.cs
+++ b/BDArmory/Misc/BattleDamageHandler.cs
@@ -118,7 +118,7 @@ namespace BDArmory.Misc
                     }
                 }
             }
-            //Propulsaion Damage
+            //Propulsion Damage
             if (BDArmorySettings.BD_PROPULSION)
             {
                 BattleDamageTracker tracker = part.gameObject.AddOrGetComponent<BattleDamageTracker>();
@@ -189,10 +189,13 @@ namespace BDArmory.Misc
                             {
                                 if (tracker.isSRB) //SRB is lit, and casing integrity fails due to damage; boom
                                 {
-                                    var Rupture = part.GetComponent<ModuleCASE>();
-                                    if (Rupture == null) Rupture = (ModuleCASE)part.AddModule("ModuleCASE");
-                                    Rupture.CASELevel = 0;
-                                    Rupture.DetonateIfPossible();
+                                    if (tracker.SRBFuelled)
+                                    {
+                                        var Rupture = part.GetComponent<ModuleCASE>();
+                                        if (Rupture == null) Rupture = (ModuleCASE)part.AddModule("ModuleCASE");
+                                        Rupture.CASELevel = 0;
+                                        Rupture.DetonateIfPossible();
+                                    }
                                 }
                                 else
                                 {

--- a/BDArmory/Modules/ModuleCASE.cs
+++ b/BDArmory/Modules/ModuleCASE.cs
@@ -149,6 +149,7 @@ namespace BDArmory.Modules
             var vesselName = vessel != null ? vessel.vesselName : null;
             Vector3 direction = default(Vector3);
             GetBlastRadius();
+            if (ammoExplosionYield <= 0) return;
             if (CASELevel != 2) //a considerable quantity of explosives and propellants just detonated inside your ship
             {
                 if (CASELevel == 0)

--- a/BDArmory/Modules/ModuleSelfSealingTank.cs
+++ b/BDArmory/Modules/ModuleSelfSealingTank.cs
@@ -89,7 +89,7 @@ namespace BDArmory.Modules
             if (engine != null)
             {
                 Events["ToggleTankOption"].guiActiveEditor = false;
-                if (solid != null && engine.throttleLocked && !engine.allowShutdown)
+                if (solid != null && solid.amount > 4 && engine.throttleLocked && !engine.allowShutdown)
                 {
                     part.RemoveModule(this); //don't add firebottles to SRBs
                 }


### PR DESCRIPTION
- SRBs exploding when empty
- tntMass being used when associated resource is empty
- Explosion yield <= 0 causing explosions