### PR TITLE
Custom missile/bomb bays

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -692,7 +692,8 @@ Localization
         #LOC_BDArmory_DetonateAtMinimumDistance = Detonate At Min Dist
         #LOC_BDArmory_ProximityTriggerDistance = Warhead Detonation Dist
         #LOC_BDArmory_DropTime = Drop Time
-        #LOC_BDArmory_InCargoBay = In Cargo Bay:\u0020
+        #LOC_BDArmory_InCargoBay = In Stock Cargo Bay:\u0020
+        #LOC_BDArmory_InCustomCargoBay = Custom Bay Toggle:\u0020
         #LOC_BDArmory_DetonationTime = Detonation Time
         #LOC_BDArmory_BallisticOvershootFactor = Ballistic Overshoot factor
         #LOC_BDArmory_BallisticAnglePath = Ballistic Angle path

--- a/BDArmory/Modules/MissileBase.cs
+++ b/BDArmory/Modules/MissileBase.cs
@@ -109,6 +109,49 @@ namespace BDArmory.Modules
             UI_Toggle(disabledText = "#LOC_BDArmory_false", enabledText = "#LOC_BDArmory_true", affectSymCounterparts = UI_Scene.All)]//False--True
         public bool inCargoBay = false;
 
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_InCustomCargoBay"), // In custom/modded "cargo bay"
+            UI_ChooseOption(
+            options = new String[] {
+                "0",
+                "1",
+                "2",
+                "3",
+                "4",
+                "5",
+                "6",
+                "7",
+                "8",
+                "9",
+                "10",
+                "11",
+                "12",
+                "13",
+                "14",
+                "15",
+                "16"
+            },
+            display = new String[] {
+                "Disabled",
+                "AG1",
+                "AG2",
+                "AG3",
+                "AG4",
+                "AG5",
+                "AG6",
+                "AG7",
+                "AG8",
+                "AG9",
+                "AG10",
+                "Lights",
+                "RCS",
+                "SAS",
+                "Brakes",
+                "Abort",
+                "Gear"
+            }
+        )]
+        public string customBayGroup = "0";
+
         [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false, guiName = "#LOC_BDArmory_DetonationTime"),//Detonation Time
             UI_FloatRange(minValue = 2f, maxValue = 30f, stepIncrement = 0.5f, scene = UI_Scene.Editor)]
         public float detonationTime = 2;

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -1583,7 +1583,7 @@ namespace BDArmory.Modules
                 {
                     if (SetCargoBays())
                     {
-                        yield return new WaitForSeconds(1f);
+                        yield return new WaitForSeconds(2f);
                     }
 
                     float attemptLockTime = Time.time;
@@ -1655,7 +1655,7 @@ namespace BDArmory.Modules
 
                     if (SetCargoBays())
                     {
-                        yield return new WaitForSeconds(1f);
+                        yield return new WaitForSeconds(2f);
                     }
 
                     float attemptStartTime = Time.time;
@@ -1758,7 +1758,7 @@ namespace BDArmory.Modules
 
                     if (SetCargoBays())
                     {
-                        yield return new WaitForSeconds(1f);
+                        yield return new WaitForSeconds(2f);
                     }
 
                     float attemptStartTime = Time.time;
@@ -1779,7 +1779,7 @@ namespace BDArmory.Modules
                 {
                     if (SetCargoBays())
                     {
-                        yield return new WaitForSeconds(1f);
+                        yield return new WaitForSeconds(2f);
                     }
 
                     if (targetingPods.Count > 0) //if targeting pods are available, slew them onto target and lock.
@@ -2749,9 +2749,30 @@ namespace BDArmory.Modules
                             }
                         }
                 }
+                else if (uint.Parse(CurrentMissile.customBayGroup) > 0) // Missile uses a custom bay, open it to fire
+                {
+                    uint customBayGroup = uint.Parse(CurrentMissile.customBayGroup);
+                    if (!baysOpened.Contains(customBayGroup)) // We haven't opened this bay yet
+                    {
+                        vessel.ActionGroups.ToggleGroup(BDACompetitionMode.KM_dictAG[(int) customBayGroup]);
+                        openingBays = true;
+                        baysOpened.Add(customBayGroup);
+                    }
+                   else
+                   {
+                        foreach (var bay in baysOpened.Where(e => e <= 16).ToList()) // Close other custom bays that might be open 
+                        {
+                            if ((bay <= 16) && (bay != customBayGroup)) // Only close custom bays
+                            {
+                                vessel.ActionGroups.ToggleGroup(BDACompetitionMode.KM_dictAG[(int)bay]);
+                                baysOpened.Remove(bay); // Bay is no longer open
+                            }
+                        }
+                   }
+                }
                 else
                 {
-                    using (var bay = VesselModuleRegistry.GetModules<ModuleCargoBay>(vessel).GetEnumerator())
+                    using (var bay = VesselModuleRegistry.GetModules<ModuleCargoBay>(vessel).GetEnumerator()) // Close normal bays
                         while (bay.MoveNext())
                         {
                             if (bay.Current == null) continue;
@@ -2768,11 +2789,20 @@ namespace BDArmory.Modules
                                 }
                             }
                         }
+
+                    foreach (var bay in baysOpened.Where(e => e <= 16).ToList()) // Close custom bays
+                    {
+                        if (bay <= 16)// Only close custom bays
+                        {
+                            vessel.ActionGroups.ToggleGroup(BDACompetitionMode.KM_dictAG[(int)bay]);
+                            baysOpened.Remove(bay); // Bay is no longer open
+                        }
+                    }
                 }
             }
             else
             {
-                using (var bay = VesselModuleRegistry.GetModules<ModuleCargoBay>(vessel).GetEnumerator())
+                using (var bay = VesselModuleRegistry.GetModules<ModuleCargoBay>(vessel).GetEnumerator()) // Close normal bays
                     while (bay.MoveNext())
                     {
                         if (bay.Current == null) continue;
@@ -2789,6 +2819,15 @@ namespace BDArmory.Modules
                             }
                         }
                     }
+
+                foreach (var bay in baysOpened.Where(e => e <= 16).ToList()) // Close custom bays
+                {
+                    if (bay <= 16)// Only close custom bays
+                    {
+                        vessel.ActionGroups.ToggleGroup(BDACompetitionMode.KM_dictAG[(int)bay]);
+                        baysOpened.Remove(bay); // Bay is no longer open
+                    }
+                }
             }
 
             return openingBays;


### PR DESCRIPTION
 - Allow custom/modded missile and bomb bays. Set which action group controls the bay toggling on the missile/bomb itself and the AI will automatically open and close the bay when dropping the ordnance.
- Increase wait time after opening a bay from 1 to 2 seconds to ensure enough time for animations to finish.