### PR TITLE
Fixes to BattleDamage Fires

### DIFF
--- a/BDArmory/Bullets/PooledRocket.cs
+++ b/BDArmory/Bullets/PooledRocket.cs
@@ -670,7 +670,7 @@ namespace BDArmory.Bullets
                                 float distance = Vector3.Distance(transform.position, hit.point);
                                 if (p != null)
                                 {
-                                    BulletHitFX.AttachFire(hit.point, p, caliber, sourceVesselName, BDArmorySettings.WEAPON_FX_DURATION * (1 - (distance / blastRadius)), 1, false, true); //else apply fire to occluding part
+                                    BulletHitFX.AttachFire(hit.point, p, caliber, sourceVesselName, BDArmorySettings.WEAPON_FX_DURATION * (1 - (distance / blastRadius)), 1, true); //else apply fire to occluding part
                                     if (BDArmorySettings.DRAW_DEBUG_LABELS)
                                         Debug.Log("[BDArmory.Rocket]: Applying fire to " + p.name + " at distance " + distance + "m, for " + BDArmorySettings.WEAPON_FX_DURATION * (1 - (distance / blastRadius)) + " seconds"); ;
                                 }

--- a/BDArmory/Distribution/GameData/BDArmory/MMPatches/BDA_battledamage.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/MMPatches/BDA_battledamage.cfg
@@ -1,3 +1,10 @@
+@PART[BDAcUniversalAmmoBox]
+{
+	%MODULE[ModuleCASE]
+	{
+		%CASELevel = 0
+	}
+}
 @PART[bahaM102Howitzer]
 {
 	%MODULE[ModuleCASE]
@@ -19,6 +26,13 @@
 	{
 	}
 }
+@PART[B9_Aero_Wing_Procedural_TypeA]
+{
+	%MODULE[ModuleSelfSealingTank]
+	{
+	}
+}
+
 @PART[*]:HAS[@MODULE[ModuleEngines]]
 {
 	%MODULE[ModuleSelfSealingTank]
@@ -26,12 +40,6 @@
 	}
 }
 @PART[*]:HAS[@MODULE[ModuleEnginesFX]]
-{
-	%MODULE[ModuleSelfSealingTank]
-	{
-	}
-}
-@PART[*]:HAS[@MODULE[ModuleCommand]]
 {
 	%MODULE[ModuleSelfSealingTank]
 	{

--- a/BDArmory/FX/BulletHitFX.cs
+++ b/BDArmory/FX/BulletHitFX.cs
@@ -416,7 +416,6 @@ namespace BDArmory.FX
         }
 
         public static void AttachLeak(RaycastHit hit, Part hitPart, float caliber, bool explosive, bool incendiary, string sourcevessel)
-
         {
             if (BDArmorySettings.BATTLEDAMAGE && BDArmorySettings.BD_TANKS && hitPart.Modules.GetModule<HitpointTracker>().Hitpoints > 0)
             {
@@ -479,7 +478,7 @@ namespace BDArmory.FX
                 fuelLeak.SetActive(true);
             }
         }
-        public static void AttachFire(Vector3 hit, Part hitPart, float caliber, string sourcevessel, float burntime = -1, int ignitedLeaks = 1, bool enginefire = false, bool surfaceFire = false)
+        public static void AttachFire(Vector3 hit, Part hitPart, float caliber, string sourcevessel, float burntime = -1, int ignitedLeaks = 1, bool surfaceFire = false)
         {
             if (BDArmorySettings.BATTLEDAMAGE && BDArmorySettings.BD_FIRES_ENABLED && hitPart.Modules.GetModule<HitpointTracker>().Hitpoints > 0)
             {
@@ -487,6 +486,7 @@ namespace BDArmory.FX
                     FireFXPool = FireFX.CreateFireFXPool("BDArmory/FX/FireFX/model");
                 var fire = FireFXPool.GetPooledObject();
                 var fireFX = fire.GetComponentInChildren<FireFX>();
+                fireFX.burnTime = burntime; //this apparently never got implemented... !?
                 fireFX.AttachAt(hitPart, hit, new Vector3(0.25f, 0f, 0f), sourcevessel);
                 fireFX.burnRate = (((caliber / 50) * BDArmorySettings.BD_TANK_LEAK_RATE) * ignitedLeaks);
                 fireFX.surfaceFire = surfaceFire;

--- a/BDArmory/FX/FireFX.cs
+++ b/BDArmory/FX/FireFX.cs
@@ -164,6 +164,7 @@ namespace BDArmory.FX
             ox = null;
             ec = null;
             mp = null;
+            tntMassEquivalent = 0;
             fireIntensity = 1;
         }
 
@@ -253,7 +254,7 @@ namespace BDArmory.FX
                             }
                         }
                         ox = parentPart.Resources.Where(pr => pr.resourceName == "Oxidizer").FirstOrDefault();
-                        if (ox != null)
+                        if (ox != null && fuel != null)
                         {
                             if (ox.amount > 0)
                             {
@@ -451,7 +452,7 @@ namespace BDArmory.FX
                                         Part p = eva ? eva.part : hit.collider.gameObject.GetComponentInParent<Part>();
                                         if (p == partHit)
                                         {
-                                            BulletHitFX.AttachFire(hit.point, p, 1, SourceVessel, BDArmorySettings.WEAPON_FX_DURATION * (1 - (distToG0.magnitude / blastRadius)), 1, false, true);
+                                            BulletHitFX.AttachFire(hit.point, p, 1, SourceVessel, BDArmorySettings.WEAPON_FX_DURATION * (1 - (distToG0.magnitude / blastRadius)), 1, true);
                                             if (BDArmorySettings.DRAW_DEBUG_LABELS)
                                             {
                                                 Debug.Log("[BDArmory.FireFX] " + this.parentPart.name + " hit by burning fuel");
@@ -483,7 +484,7 @@ namespace BDArmory.FX
             Deactivate();
         }
 
-        public void AttachAt(Part hitPart, Vector3 hit, Vector3 offset, string sourcevessel, float burnTime = -1)
+        public void AttachAt(Part hitPart, Vector3 hit, Vector3 offset, string sourcevessel)
         {
             if (hitPart == null) return;
             parentPart = hitPart;

--- a/BDArmory/Misc/BattleDamageHandler.cs
+++ b/BDArmory/Misc/BattleDamageHandler.cs
@@ -180,7 +180,7 @@ namespace BDArmory.Misc
                             {
                                 if (alreadyburning == null)
                                 {
-                                    BulletHitFX.AttachFire(hitLoc.point, part, caliber, attacker, -1, 1, true);
+                                    BulletHitFX.AttachFire(hitLoc.point, part, caliber, attacker, -1, 1);
                                 }
                             }
                         }

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -1417,7 +1417,7 @@ namespace BDArmory.Modules
                         if (weaponHeatDebugStrings.Count > 0)
                         {
 							debugString.AppendLine("Weapon Heat:\n" + string.Join("\n", weaponHeatDebugStrings));
-                            debugString.AppendLine("laser debugging:\n" + string.Join("\n", weaponLaserDebugStrings));
+                            debugString.AppendLine("Aim debugging:\n" + string.Join("\n", weaponLaserDebugStrings));
                         }
                     }
                     GUI.Label(new Rect(200, Screen.height - 500, 600, 200), debugString.ToString());


### PR DESCRIPTION
-Fixes non-fueltank fires not burning out and extinguishing after a period of time
-Adds ProcWings support - can now add Firebottles/SelfSealing/Inerted tanks to Pwing fueltanks; Pwings with fuel can now catch on fire when shot
Edit - now properly pointing at dev
