### PR TITLE
Bug fixes

### DIFF
--- a/BDArmory/Control/BDAirspeedControl.cs
+++ b/BDArmory/Control/BDAirspeedControl.cs
@@ -163,7 +163,7 @@ namespace BDArmory.Control
             dragAccel = accelError;
 
             possibleAccel += accel; // This assumes that the acceleration from engines is in the same direction as the original possibleAccel.
-            forceAfterburner = (afterburnerPriority == 100f);
+            forceAfterburner = forceAfterburner || (afterburnerPriority == 100f);
             allowAfterburner = allowAfterburner && (afterburnerPriority != 0f);
 
             //use multimode afterburner for extra accel if lacking

--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -2849,7 +2849,8 @@ namespace BDArmory.Modules
             }
             else if (command == PilotCommands.Attack)
             {
-                if ((BDArmorySettings.RUNWAY_PROJECT) && (targetVessel != null) && ((targetVessel.vesselTransform.position - vessel.vesselTransform.position).sqrMagnitude <= (weaponManager.guardRange * weaponManager.guardRange))) // If the vessel has a target within range, let it fight!
+                if ((targetVessel != null) && ((BDArmorySettings.RUNWAY_PROJECT) || ((targetVessel.vesselTransform.position - vessel.vesselTransform.position).sqrMagnitude <= (weaponManager.gunRange * weaponManager.gunRange))) 
+                    && ((targetVessel.vesselTransform.position - vessel.vesselTransform.position).sqrMagnitude <= (weaponManager.gunRange * weaponManager.guardRange))) // If the vessel has a target within visual range, let it fight!
                 {
                     ReleaseCommand();
                     return;


### PR DESCRIPTION
 - Release pilot AI from attack command if they have a target within gun range (fixes bug with very long-range guns not engaging targets at competition start), regardless of whether RWP toggle is on.
- Don't override forceAfterburner with afterburnerPriority