### PR TITLE
bugfix/tweaks

### DIFF
--- a/BDArmory.Core/BDArmorySettings.cs
+++ b/BDArmory.Core/BDArmorySettings.cs
@@ -195,6 +195,9 @@ namespace BDArmory.Core
         [BDAPersistentSettingsField] public static float BD_FIRE_DAMAGE = 5;            // Do fires do DoT
         [BDAPersistentSettingsField] public static bool BD_FIRE_HEATDMG = true;         // Do fires add heat to parts/are fires able to cook off fuel/ammo?
         [BDAPersistentSettingsField] public static bool BD_INTENSE_FIRES = false;       // Do fuel tank fires DoT get bigger over time?
+        [BDAPersistentSettingsField] public static float BD_FIRE_CHANCE_TRACER = 10;
+        [BDAPersistentSettingsField] public static float BD_FIRE_CHANCE_HE = 25;
+        [BDAPersistentSettingsField] public static float BD_FIRE_CHANCE_INCENDIARY = 90;
         [BDAPersistentSettingsField] public static bool ALLOW_ZOMBIE_BD = false;          // Allow battle damage to proc when using zombie mode?
 
         // Remote logging

--- a/BDArmory/FX/BulletHitFX.cs
+++ b/BDArmory/FX/BulletHitFX.cs
@@ -436,14 +436,14 @@ namespace BDArmory.FX
 
                         if (BDArmorySettings.BD_FIRES_ENABLED && !inertTank)
                         {
-                            int ammoMod = 10; //10% chance of AP rounds starting fires from sparks/tracers/etc
+                            float ammoMod = BDArmorySettings.BD_FIRE_CHANCE_TRACER; //10% chance of AP rounds starting fires from sparks/tracers/etc
                             if (explosive)
                             {
-                                ammoMod = 20; //20% chance of starting fires from HE rounds
+                                ammoMod = BDArmorySettings.BD_FIRE_CHANCE_HE; //20% chance of starting fires from HE rounds
                             }
                             if (incendiary)
                             {
-                                ammoMod = 90; //90% chance of starting fires from inc rounds
+                                ammoMod = BDArmorySettings.BD_FIRE_CHANCE_INCENDIARY; //90% chance of starting fires from inc rounds
                             }
                             double Diceroll = UnityEngine.Random.Range(0, 100);
                             if (Diceroll <= ammoMod)
@@ -455,7 +455,7 @@ namespace BDArmory.FX
                                     leakcount++;
                                 }
                                 leak.drainDuration = 0;
-                                Debug.Log("[BullethitFX] Adding fire. HE? " + explosive + "; Inc? " + incendiary + "; inerttank? " + inertTank);
+                                //Debug.Log("[BullethitFX] Adding fire. HE? " + explosive + "; Inc? " + incendiary + "; inerttank? " + inertTank);
                                 AttachFire(hit.point, hitPart, caliber, sourcevessel, -1, leakcount);
                             }
                         }

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -649,7 +649,7 @@ namespace BDArmory.FX
                     }
                     else return;
                 }
-                Debug.Log("[ExplosionFX] " + part.name + " Within AoE of detonation: " + eventToExecute.withinAngleofEffect);
+                //Debug.Log("[ExplosionFX] " + part.name + " Within AoE of detonation: " + eventToExecute.withinAngleofEffect);
                 // Overly simplistic approach: simply reduce damage by amount of HP/2 and Armor in the way. (HP/2 to simulate weak parts not fully blocking damage.) Does not account for armour reduction or angle of incidence of intermediate parts.
                 // A better approach would be to properly calculate the damage and pressure in CalculatePartBlastEffects due to the series of parts in the way.
                 var damageWithoutIntermediateParts = blastInfo.Damage;

--- a/BDArmory/Modules/BDAdjustableArmor.cs
+++ b/BDArmory/Modules/BDAdjustableArmor.cs
@@ -23,7 +23,6 @@ namespace BDArmory.Modules
         public bool isTriangularPanel = false;
 
         //public bool isCurvedPanel = false;
-
         private float armorthickness = 1;
         private float Oldthickness = 1;
 
@@ -98,6 +97,14 @@ namespace BDArmory.Modules
                 N4Transform = part.FindModelTransform(Node4Name);
                 N4.nodeType = AttachNode.NodeType.Stack;
             }
+            UpdateThickness();
+        }
+        public override void OnLoad(ConfigNode node)
+        {
+            base.OnLoad(node);
+
+            if (!HighLogic.LoadedSceneIsEditor && !HighLogic.LoadedSceneIsFlight) return;
+            armor = GetComponent<HitpointTracker>();
         }
         private void OnDestroy()
         {
@@ -315,20 +322,29 @@ namespace BDArmory.Modules
         }
         void UpdateThickness()
         {
-            armorthickness = Mathf.Clamp((armor.Armor / 10), 0.1f, 1500);            
-            //if (!isCurvedPanel)
+            if (armor != null && armorTransforms != null)
             {
-                for (int i = 0; i < armorTransforms.Length; i++)
+                armorthickness = Mathf.Clamp((armor.Armor / 10), 0.1f, 1500);
+                //if (!isCurvedPanel)
                 {
-                    armorTransforms[i].localScale = new Vector3(Width, Length, armorthickness);
+                    for (int i = 0; i < armorTransforms.Length; i++)
+                    {
+                        armorTransforms[i].localScale = new Vector3(Width, Length, armorthickness);
+                    }
                 }
+                /*
+                else
+                {
+                    ThicknessTransform.localScale = new Vector3(armorthickness, 1, armorthickness);
+                }
+                */
             }
-            /*
             else
             {
-                ThicknessTransform.localScale = new Vector3(armorthickness, 1, armorthickness);
+                if (armor == null) Debug.Log("[BDAAdjustableArmor] No HitpointTracker found! aborting UpdateThickness()!");
+                if (armorTransforms == null) Debug.Log("[BDAAdjustableArmor] No ArmorTransform found! aborting UpdateThickness()!");
+                return;
             }
-            */
             float ratio = (armorthickness - Oldthickness) / 100;
             foreach (Part p in part.children)
             {

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -772,16 +772,29 @@ namespace BDArmory.Modules
 
         }
 
-        [KSPEvent(active = true, guiActiveEditor = true, guiActive = false)]
-        public void NextTeam()
+        [KSPEvent(active = true, guiActiveEditor = true, guiActive = false)] 
+        public void NextTeam(bool switchneutral = false) 
         {
-            var teamList = new List<string> { "A", "B" };
-            using (var teams = BDArmorySetup.Instance.Teams.GetEnumerator())
-                while (teams.MoveNext())
-                    if (!teamList.Contains(teams.Current.Key) && !teams.Current.Value.Neutral)
-                        teamList.Add(teams.Current.Key);
-            teamList.Sort();
-            SetTeam(BDTeam.Get(teamList[(teamList.IndexOf(Team.Name) + 1) % teamList.Count]));
+            if (!switchneutral) //standard switch behavior; don't switch to a neutral team
+            {
+                var teamList = new List<string> { "A", "B" };
+                using (var teams = BDArmorySetup.Instance.Teams.GetEnumerator())
+                    while (teams.MoveNext())
+                        if (!teamList.Contains(teams.Current.Key) && !teams.Current.Value.Neutral)
+                            teamList.Add(teams.Current.Key);
+                teamList.Sort();
+                SetTeam(BDTeam.Get(teamList[(teamList.IndexOf(Team.Name) + 1) % teamList.Count]));
+            }
+            else// alt-click; switch to first available neutral team
+            {
+                var neutralList = new List<string> { "Neutral" };
+                using (var teams = BDArmorySetup.Instance.Teams.GetEnumerator())
+                    while (teams.MoveNext())
+                        if (!neutralList.Contains(teams.Current.Key) && teams.Current.Value.Neutral)
+                            neutralList.Add(teams.Current.Key);
+                neutralList.Sort();
+                SetTeam(BDTeam.Get(neutralList[(neutralList.IndexOf(Team.Name) + 1) % neutralList.Count]));
+            }
         }
 
 

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -571,6 +571,10 @@ namespace BDArmory.Modules
 
         [KSPField]
         public float tracerLuminance = 1.75f;
+
+        [KSPField]
+        public bool tracerOverrideWidth =false;
+
         int tracerIntervalCounter;
 
         [KSPField]
@@ -885,7 +889,7 @@ namespace BDArmory.Modules
             {
                 Events["ToggleRipple"].guiActiveEditor = false;
                 Fields["useRippleFire"].guiActiveEditor = false;
-		useRippleFire = false;
+		        useRippleFire = false;
             }
 
             if (eWeaponType != WeaponTypes.Rocket)//disable rocket RoF slider for non rockets 
@@ -1310,7 +1314,7 @@ namespace BDArmory.Modules
         public string WeaponStatusdebug()
         {
             string status = "Weapon Type: ";
-
+            /*
             if (eWeaponType == WeaponTypes.Ballistic)
                 status += "Ballistic; BulletType: " + currentType;
             if (eWeaponType == WeaponTypes.Rocket)
@@ -1318,6 +1322,9 @@ namespace BDArmory.Modules
             if (eWeaponType == WeaponTypes.Laser)
                 status += "Laser";
             status += "; RoF: " + roundsPerMinute + "; deviation: " + maxDeviation + "; instagib = " + instagib;
+            */
+            status += "-Lead Offset: " + GetLeadOffset() + "; FinalAimTgt: " + finalAimTarget + "; tgt Pos: " + targetPosition + "; pointingAtSelf: " + pointingAtSelf + "; tgt CosAngle " + targetCosAngle + "; wpn CosAngle " + targetAdjustedMaxCosAngle + "; Wpn Autofire " + autoFire;
+
             return status;
         }
         void Update()
@@ -4565,9 +4572,12 @@ namespace BDArmory.Modules
                 ParseBulletDragType();
                 ParseBulletFuzeType(bulletInfo.fuzeType);
                 tntMass = bulletInfo.tntMass;
-                tracerStartWidth = caliber / 300;
-                tracerEndWidth = caliber / 750;
-                nonTracerWidth = caliber / 500;
+                if (!tracerOverrideWidth)
+                {
+                    tracerStartWidth = caliber / 300;
+                    tracerEndWidth = caliber / 750;
+                    nonTracerWidth = caliber / 500;
+                }
                 if (((((bulletMass * 1000) / ((caliber * caliber * Mathf.PI / 400) * 19) + 1) * 10) > caliber * 4))
                 {
                     SabotRound = true;

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1020,8 +1020,7 @@ namespace BDArmory.UI
                 }
 
                 GUIStyle teamButtonStyle = BDGuiSkin.box;
-                string teamText = Localizer.Format("#LOC_BDArmory_WMWindow_TeamText") + ": " + ActiveWeaponManager.Team.Name + (ActiveWeaponManager.Team.Neutral ? "(N)" : "");//Team
-
+                string teamText = Localizer.Format("#LOC_BDArmory_WMWindow_TeamText") + ": " + ActiveWeaponManager.Team.Name + (ActiveWeaponManager.Team.Neutral ? (ActiveWeaponManager.Team.Name != "Neutral" ? "(N)" : "") : "");//Team
                 if (GUI.Button(new Rect(leftIndent + (contentWidth / 2), contentTop + (line * entryHeight), contentWidth / 2, entryHeight), teamText, teamButtonStyle))
                 {
                     if (Event.current.button == 1)

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1020,7 +1020,7 @@ namespace BDArmory.UI
                 }
 
                 GUIStyle teamButtonStyle = BDGuiSkin.box;
-                string teamText = $"{Localizer.Format("#LOC_BDArmory_WMWindow_TeamText")}: {ActiveWeaponManager.Team.Name}";//Team
+                string teamText = Localizer.Format("#LOC_BDArmory_WMWindow_TeamText") + ": " + ActiveWeaponManager.Team.Name + (ActiveWeaponManager.Team.Neutral ? "(N)" : "");//Team
 
                 if (GUI.Button(new Rect(leftIndent + (contentWidth / 2), contentTop + (line * entryHeight), contentWidth / 2, entryHeight), teamText, teamButtonStyle))
                 {

--- a/BDArmory/UI/BDTeamSelector.cs
+++ b/BDArmory/UI/BDTeamSelector.cs
@@ -77,12 +77,19 @@ namespace BDArmory.UI
                     Rect buttonRect = new Rect(margin, height, width - 2 * margin, buttonHeight);
                     GUIStyle buttonStyle = (teams.Current == targetWeaponManager.Team) ? BDArmorySetup.BDGuiSkin.box : BDArmorySetup.BDGuiSkin.button;
 
-                    if (GUI.Button(buttonRect, teams.Current.Name, buttonStyle))
+                    if (GUI.Button(buttonRect, teams.Current.Name + (teams.Current.Neutral ? "(Neutral)" : ""), buttonStyle))
                     {
-                        targetWeaponManager.SetTeam(teams.Current);
-                        open = false;
+                        switch (Event.current.button)
+                        {
+                            case 1: // right click
+                                teams.Current.Neutral = !teams.Current.Neutral;
+                                break;
+                            default:
+                                targetWeaponManager.SetTeam(teams.Current);
+                                open = false;
+                                break;
+                        }
                     }
-
                     height += buttonHeight;
                 }
 

--- a/BDArmory/UI/BDTeamSelector.cs
+++ b/BDArmory/UI/BDTeamSelector.cs
@@ -77,7 +77,7 @@ namespace BDArmory.UI
                     Rect buttonRect = new Rect(margin, height, width - 2 * margin, buttonHeight);
                     GUIStyle buttonStyle = (teams.Current == targetWeaponManager.Team) ? BDArmorySetup.BDGuiSkin.box : BDArmorySetup.BDGuiSkin.button;
 
-                    if (GUI.Button(buttonRect, teams.Current.Name + (teams.Current.Neutral ? "(Neutral)" : ""), buttonStyle))
+                    if (GUI.Button(buttonRect, teams.Current.Name + (teams.Current.Neutral ? (teams.Current.Name != "Neutral" ? "(Neutral)" : "") : ""), buttonStyle))
                     {
                         switch (Event.current.button)
                         {

--- a/BDArmory/UI/BDTeamSelector.cs
+++ b/BDArmory/UI/BDTeamSelector.cs
@@ -82,6 +82,7 @@ namespace BDArmory.UI
                         switch (Event.current.button)
                         {
                             case 1: // right click
+                                if (teams.Current.Name != "Neutral" && teams.Current.Name != "A" && teams.Current.Name != "B")
                                 teams.Current.Neutral = !teams.Current.Neutral;
                                 break;
                             default:

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -763,7 +763,8 @@ namespace BDArmory.UI
                 else if (Event.current.button == 2)
                 {
                     //wm.SetTeam(BDTeam.Get("Neutral"));
-                    wm.Team.Neutral = !wm.Team.Neutral;
+                    //if (wm.Team.Name != "Neutral" && wm.Team.Name != "A" && wm.Team.Name != "B") wm.Team.Neutral = !wm.Team.Neutral;
+                    wm.NextTeam(true);
                 }
                 else
                 {
@@ -890,6 +891,7 @@ namespace BDArmory.UI
                 {
                     Debug.Log("[BDArmory.LoadedVesselSwitcher]: Vessel " + craftName + " was not specified to be part of a team, but is active. Assigning to team " + T.ToString() + ".");
                     weaponManagersByName[craftName].SetTeam(BDTeam.Get(T.ToString())); // Assign anyone who wasn't specified to a separate team.
+                    weaponManagersByName[craftName].Team.Neutral = false;
                 }
                 return;
             }
@@ -906,6 +908,7 @@ namespace BDArmory.UI
                         ++T;
                     }
                     weaponManager.SetTeam(BDTeam.Get(T.ToString())); // Otherwise, assign them to team T.
+                    weaponManager.Team.Neutral = false;
                     ++count;
                 }
                 return;

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -447,8 +447,9 @@ namespace BDArmory.UI
                                 if (BDTISetup.Instance.ColorAssignments.ContainsKey(teamManager.Item1))
                                 {
                                     BDTISetup.TILabel.normal.textColor = BDTISetup.Instance.ColorAssignments[teamManager.Item1];
-                                }
-                                GUI.Label(new Rect(_margin, height, BDArmorySettings.VESSEL_SWITCHER_WINDOW_WIDTH - 2 * _margin, _buttonHeight), $"{teamManager.Item1}:" + (teamManager.Item1 != "Neutral" ? (weaponManager.Team.Neutral ? "(Neutral)" : ""): ""), BDTISetup.TILabel);
+                                }                                                                                                                                          
+                                GUI.Label(new Rect(_margin, height, BDArmorySettings.VESSEL_SWITCHER_WINDOW_WIDTH - 2 * _margin, _buttonHeight), $"{teamManager.Item1}:" + (weaponManager.Team.Neutral ? (weaponManager.Team.Name != "Neutral" ? "(Neutral)" : "") : ""), BDTISetup.TILabel);
+
                                 teamNameShowing = true;
                                 height += _buttonHeight + _buttonGap;
                             }
@@ -918,6 +919,7 @@ namespace BDArmory.UI
             {
                 if (BDArmorySettings.DRAW_DEBUG_LABELS) Debug.Log("[BDArmory.LoadedVesselSwitcher]: assigning " + weaponManager.vessel.GetDisplayName() + " to team " + T.ToString());
                 weaponManager.SetTeam(BDTeam.Get(T.ToString()));
+                weaponManager.Team.Neutral = false;
                 if (separateTeams) T++;
             }
         }

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -448,7 +448,7 @@ namespace BDArmory.UI
                                 {
                                     BDTISetup.TILabel.normal.textColor = BDTISetup.Instance.ColorAssignments[teamManager.Item1];
                                 }
-                                GUI.Label(new Rect(_margin, height, BDArmorySettings.VESSEL_SWITCHER_WINDOW_WIDTH - 2 * _margin, _buttonHeight), $"{teamManager.Item1}:", BDTISetup.TILabel);
+                                GUI.Label(new Rect(_margin, height, BDArmorySettings.VESSEL_SWITCHER_WINDOW_WIDTH - 2 * _margin, _buttonHeight), $"{teamManager.Item1}:" + (teamManager.Item1 != "Neutral" ? (weaponManager.Team.Neutral ? "(Neutral)" : ""): ""), BDTISetup.TILabel);
                                 teamNameShowing = true;
                                 height += _buttonHeight + _buttonGap;
                             }
@@ -475,7 +475,11 @@ namespace BDArmory.UI
                         if (weaponManager == null) continue;
                         if (BDArmorySettings.VESSEL_SWITCHER_WINDOW_OLD_DISPLAY_STYLE && !teamNameShowing)
                         {
-                            GUI.Label(new Rect(_margin, height, BDArmorySettings.VESSEL_SWITCHER_WINDOW_WIDTH - 2 * _margin, _buttonHeight), $"{teamManagers.Key}:", BDArmorySetup.BDGuiSkin.label);
+                            if (BDTISetup.Instance.ColorAssignments.ContainsKey(teamManagers.Key))
+                            {
+                                BDTISetup.TILabel.normal.textColor = BDTISetup.Instance.ColorAssignments[teamManagers.Key];
+                            }
+                            GUI.Label(new Rect(_margin, height, BDArmorySettings.VESSEL_SWITCHER_WINDOW_WIDTH - 2 * _margin, _buttonHeight), $"{teamManagers.Key}:" + (weaponManager.team != "Neutral" ? (weaponManager.Team.Neutral ? "(Neutral)" : "") : ""), BDTISetup.TILabel);
                             teamNameShowing = true;
                             height += _buttonHeight + _buttonGap;
                         }
@@ -758,7 +762,8 @@ namespace BDArmory.UI
                 }
                 else if (Event.current.button == 2)
                 {
-                    wm.SetTeam(BDTeam.Get("Neutral"));
+                    //wm.SetTeam(BDTeam.Get("Neutral"));
+                    wm.Team.Neutral = !wm.Team.Neutral;
                 }
                 else
                 {


### PR DESCRIPTION
Proc armor NRE fix and some FJRT requests
-Restores ability to set custom tracer stats in weapon.cfg. Use "tracerOverrideWidth = true" in the cfg to use override values instead of dynamically determined tracer settings 
-BattleDamage fire chance on hit now editable in the settings config
-Fixes NRE with proc armor parts on loading a craft
-Adds ability to set teams to neutral in team selector/VesselSwitcher/WM. Right clicking on the team button in the Team Selector/WM will toggle non-default teams (A, B, Neutral) neutral status. Right clicking on the [t] button to the right of a vessel button in the VS will open the Team Selector. Left click will switch to next combat team, mouse-3 will switch to next neutral team