### PR TITLE
weapon/WM fixes

### DIFF
--- a/BDArmory/Modules/BDAMutator.cs
+++ b/BDArmory/Modules/BDAMutator.cs
@@ -144,11 +144,11 @@ namespace BDArmory.Modules
                 }
                 if (mutatorInfo.Vampirism > 0)
                 {
-                    Vampirism = mutatorInfo.Vampirism;
+                    Vampirism += mutatorInfo.Vampirism;
                 }
                 if (mutatorInfo.Regen != 0)
                 {
-                    Regen = mutatorInfo.Regen;
+                    Regen += mutatorInfo.Regen;
                 }
                 using (List<Part>.Enumerator part = vessel.Parts.GetEnumerator())
                     while (part.MoveNext())
@@ -172,7 +172,7 @@ namespace BDArmory.Modules
                                 {
                                     MM.duration = BDArmorySettings.COMPETITION_DURATION;
                                 }
-                                MM.massMod = mutatorInfo.MassMod / vessel.Parts.Count; //evenly distribute mass change across entire vessel
+                                MM.massMod += mutatorInfo.MassMod / vessel.Parts.Count; //evenly distribute mass change across entire vessel
                             }
                         }
                     }
@@ -251,6 +251,8 @@ namespace BDArmory.Modules
                 {
                     var HPT = part.Current.FindModuleImplementing<HitpointTracker>();
                     HPT.defenseMutator = 1;
+                    var MM = part.Current.FindModuleImplementing<ModuleMassAdjust>();
+                    part.Current.RemoveModule(MM);
                 }
             if (Vengeance)
             {

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -3761,7 +3761,7 @@ namespace BDArmory.Modules
                             {
                                 candidateRPM = BDArmorySettings.FIRE_RATE_OVERRIDE;
                             }
-                            if (targetWeapon != null && (candidateYTraverse > 0 || candidatePTraverse > 0))
+                            if (candidateYTraverse > 0 || candidatePTraverse > 0)
                             {
                                 candidateRPM *= 2.0f; // weight selection towards turrets
                             }
@@ -3803,11 +3803,11 @@ namespace BDArmory.Modules
                             }
                             bool compareRocketRPM = false;
 
-                            if (targetWeapon != null && (candidateYTraverse > 0 || candidatePTraverse > 0))
+                            if (candidateYTraverse > 0 || candidatePTraverse > 0)
                             {
                                 candidateRPM *= 2.0f; // weight selection towards turrets
                             }
-                            if ((targetWeapon != null) && targetRocketAccel < candidateRocketAccel)
+                            if (targetRocketAccel < candidateRocketAccel)
                             {
                                 candidateRPM *= 1.5f; //weight towards faster rockets
                             }
@@ -3835,31 +3835,10 @@ namespace BDArmory.Modules
 
                         if (candidateClass == WeaponClasses.Missile)
                         {
-                            // TODO: for AA, favour higher thrust+turnDPS
-                            MissileLauncher mlauncher = item.Current as MissileLauncher;
-
-                            if (vessel.Splashed && (BDArmorySettings.BULLET_WATER_DRAG && FlightGlobals.getAltitudeAtPos(mlauncher.transform.position) < -2)) continue;
-                            float candidateTDPS = 0f;
-
-                            if (mlauncher != null)
-                            {
-                                candidateTDPS = mlauncher.thrust + mlauncher.maxTurnRateDPS;
-                            }
-                            else
-                            { //is modular missile
-                                BDModularGuidance mm = item.Current as BDModularGuidance;
-                                candidateTDPS = 5000;
-                            }
-                            if ((targetWeapon != null) && ((targetWeapon.GetWeaponClass() == WeaponClasses.Gun) || (targetWeaponTDPS > candidateTDPS)))
-                                continue; //dont replace guns or better missiles
-
-                            targetWeapon = item.Current;
-                            targetWeaponTDPS = candidateTDPS;
-                        }
-                        if (candidateClass == WeaponClasses.Missile)
-                        {
                             if (missilesAway >= maxMissilesOnTarget) continue;// Max missiles are fired, try another weapon
                             MissileLauncher mlauncher = item.Current as MissileLauncher;
+                            float candidateDetDist = ((MissileLauncher)item.Current).DetonationDistance;
+                            float candidateAccel = (((MissileLauncher)item.Current).thrust / ((MissileLauncher)item.Current).part.mass); //for anti-missile, prioritize proxidetonation and accel
                             int candidatePriority = 0;
                             float candidateTDPS = 0f;
 
@@ -3870,26 +3849,26 @@ namespace BDArmory.Modules
 
                                 if (EMP) continue;
                                 if (vessel.Splashed && (BDArmorySettings.BULLET_WATER_DRAG && FlightGlobals.getAltitudeAtPos(mlauncher.transform.position) < 0)) continue;
-
-                                candidateTDPS = mlauncher.thrust + mlauncher.maxTurnRateDPS;
+                                if (targetWeapon != null && targetWeaponPriority > candidatePriority)
+                                    continue; //keep higher priority weapon
+                                if (candidateTDPS > targetWeaponTDPS)
+                                {
+                                    candidateTDPS = candidateDetDist + candidateAccel; // weight selection faster missiles and larger proximity detonations that might catch an incoming missile in the blast
+                                }
                             }
                             else
                             { //is modular missile
-                                BDModularGuidance mm = item.Current as BDModularGuidance;
+                                BDModularGuidance mm = item.Current as BDModularGuidance; //need to work out priority stuff for MMGs
                                 candidateTDPS = 5000;
                             }
                             if (distance < ((EngageableWeapon)item.Current).engageRangeMin)
                                 candidateTDPS *= -1f; // if within min range, negatively weight weapon - allows weapon to still be selected if all others lost/out of ammo
-                            if (targetWeapon == null)
-                            {
-                                targetWeapon = item.Current;
-                                targetWeaponTDPS = candidateTDPS;
-                                targetWeaponPriority = candidatePriority;
-                            }
-                            if (targetWeapon != null && targetWeaponPriority > candidatePriority)
-                                continue; //keep higher priority weapon
-                            if ((targetWeapon != null) && ((targetWeapon.GetWeaponClass() == WeaponClasses.Gun || targetWeapon.GetWeaponClass() == WeaponClasses.Rocket || targetWeapon.GetWeaponClass() == WeaponClasses.DefenseLaser) || (targetWeaponTDPS > candidateTDPS)))
+
+                            if ((targetWeapon != null) && (((distance < gunRange) && targetWeapon.GetWeaponClass() == WeaponClasses.Gun || targetWeapon.GetWeaponClass() == WeaponClasses.Rocket || targetWeapon.GetWeaponClass() == WeaponClasses.DefenseLaser) || (targetWeaponTDPS > candidateTDPS)))
                                 continue; //dont replace guns or better missiles
+                            targetWeapon = item.Current;
+                            targetWeaponTDPS = candidateTDPS;
+                            targetWeaponPriority = candidatePriority;
                         }
                     }
             }
@@ -3943,12 +3922,12 @@ namespace BDArmory.Modules
                             if (targetWeapon != null && targetWeaponPriority > candidatePriority)
                                 continue; //dont replace a higher priority weapon with a lower priority one
 
-                            if (targetWeapon != null && (candidateYTraverse > 0 || candidatePTraverse > 0))
+                            if (candidateYTraverse > 0 || candidatePTraverse > 0)
                             {
                                 candidateRPM *= 2.0f; // weight selection towards turrets
                             }
 
-                            if ((targetWeapon != null) && targetRocketAccel < candidateRocketAccel)
+                            if (targetRocketAccel < candidateRocketAccel)
                             {
                                 candidateRPM *= 1.5f; //weight towards faster rockets
                             }
@@ -3969,8 +3948,7 @@ namespace BDArmory.Modules
                                 candidateRPM *= .01f; //if within min range massively negatively weight weapon - allows weapon to still be selected if all others lost/out of ammo
                             }
                             candidateRPM /= 2; //halve rocket RPm to de-weight it against guns/lasers
-                            if ((targetWeapon != null) && (targetWeapon.GetWeaponClass() == WeaponClasses.Missile) && (targetWeaponTDPS > 0))
-                                continue; //dont replace missiles within their engage range
+
                             if (targetWeaponPriority < candidatePriority) //use priority gun
                             {
                                 targetWeapon = item.Current;
@@ -4135,47 +4113,59 @@ namespace BDArmory.Modules
                                 }
                             }
                         }
-                        //projectile weapon selected, any missiles that take precedence?                       
+                        //projectile weapon selected, any missiles that take precedence?
                         if (candidateClass == WeaponClasses.Missile)
                         {
                             if (missilesAway >= maxMissilesOnTarget) continue;// Max missiles are fired, try another weapon
                             MissileLauncher mlauncher = item.Current as MissileLauncher;
-                            int candidatePriority = 0;
+                            float candidateDetDist = ((MissileLauncher)item.Current).DetonationDistance;
+                            float candidateTurning = ((MissileLauncher)item.Current).maxTurnRateDPS; //for anti-aircraft, prioritize detonation dist and turn capability
+                            int candidatePriority = Mathf.RoundToInt(((MissileLauncher)item.Current).priority);
                             float candidateTDPS = 0f;
 
                             if (mlauncher != null)
                             {
                                 bool EMP = ((MissileLauncher)item.Current).EMP;
-                                candidatePriority = Mathf.RoundToInt(((MissileLauncher)item.Current).priority);
+
+                                if (EMP) continue;
+                                if (vessel.Splashed && (BDArmorySettings.BULLET_WATER_DRAG && FlightGlobals.getAltitudeAtPos(mlauncher.transform.position) < 0)) continue;
                                 if (targetWeapon != null && targetWeaponPriority > candidatePriority)
                                     continue; //keep higher priority weapon
 
-                                if (EMP && target.isDebilitated) continue;
-                                if (vessel.Splashed && (BDArmorySettings.BULLET_WATER_DRAG && FlightGlobals.getAltitudeAtPos(mlauncher.transform.position) < 0)) continue;
-
-                                candidateTDPS = mlauncher.thrust + mlauncher.maxTurnRateDPS;
+                                if (candidateTurning > targetWeaponTDPS)
+                                {
+                                    candidateTDPS = candidateTurning; // weight selection towards more maneuverable missiles
+                                }
+                                if (candidateDetDist > 0)
+                                {
+                                    candidateTDPS += candidateDetDist; // weight selection towards misiles with proximity warheads
+                                }
                             }
                             else
                             { //is modular missile
-                                BDModularGuidance mm = item.Current as BDModularGuidance;
+                                BDModularGuidance mm = item.Current as BDModularGuidance; //need to work out priority stuff for MMGs
                                 candidateTDPS = 5000;
                             }
                             if (distance < ((EngageableWeapon)item.Current).engageRangeMin)
                                 candidateTDPS *= -1f; // if within min range, negatively weight weapon - allows weapon to still be selected if all others lost/out of ammo
-                            if (targetWeapon == null)
-                            {
-                                targetWeapon = item.Current;
-                                targetWeaponTDPS = candidateTDPS;
-                                targetWeaponPriority = candidatePriority;
-                            }
-                            else if ((!vessel.LandedOrSplashed) || ((distance > gunRange) && (vessel.LandedOrSplashed))) // If we're not airborne, we want to prioritize guns
-                            {
-                                if (targetWeaponTDPS > candidateTDPS)
-                                    continue; //don't replace better missiles
 
-                                targetWeapon = item.Current;
-                                targetWeaponTDPS = candidateTDPS;
-                                targetWeaponPriority = candidatePriority;
+                            if ((!vessel.LandedOrSplashed) || ((distance > gunRange) && (vessel.LandedOrSplashed))) // If we're not airborne, we want to prioritize guns
+                            {
+                                if (targetWeaponPriority < candidatePriority) //use priority gun
+                                {
+                                    targetWeapon = item.Current;
+                                    targetWeaponTDPS = candidateTDPS;
+                                    targetWeaponPriority = candidatePriority;
+                                }
+                                else //if equal priority, use standard weighting
+                                {
+                                    if (targetWeaponTDPS < candidateTDPS)
+                                    {
+                                        targetWeapon = item.Current;
+                                        targetWeaponTDPS = candidateTDPS;
+                                        targetWeaponPriority = candidatePriority;
+                                    }
+                                }
                             }
                         }
                     }
@@ -4397,6 +4387,7 @@ namespace BDArmory.Modules
                             // - Antiradiation
                             // - guided missiles
                             // - by blast strength
+                            // - add code to choose optimal missile based on target profile - i.e. use bigger bombs on large landcruisers, smaller bombs on small Vees that don't warrant that sort of overkill?
                             if (vessel.Splashed && FlightGlobals.getAltitudeAtPos(item.Current.GetPart().transform.position) < -2) continue;
                             if (missilesAway >= maxMissilesOnTarget) continue;// Max missiles are fired, try another weapon
                             float candidateYield = ((MissileBase)item.Current).GetBlastRadius();

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -915,6 +915,16 @@ namespace BDArmory.Modules
                 Events["ToggleRipple"].guiActiveEditor = false;
                 Fields["useRippleFire"].guiActiveEditor = false;
                 useRippleFire = false;
+                using (List<Part>.Enumerator craftPart = vessel.parts.GetEnumerator()) //set other weapons in the group to ripple = false if the group contains a weapon with RPM > 1500, should fix the brownings+GAU WG, GAU no longer overheats exploit
+                {
+                    using (var weapon = VesselModuleRegistry.GetModules<ModuleWeapon>(vessel).GetEnumerator())
+                        while (weapon.MoveNext())
+                        {
+                            if (weapon.Current == null) continue;
+                            if (weapon.Current.GetShortName() != this.GetShortName()) continue;
+                            weapon.Current.useRippleFire = false;
+                        }
+                }
             }
 
             if (!(isChaingun || eWeaponType == WeaponTypes.Rocket))//disable rocket RoF slider for non rockets 

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -1407,7 +1407,10 @@ namespace BDArmory.Modules
                 }
                 else
                 {
-                    audioSource.Stop();
+                    if (!oneShotSound)
+                    {
+                        audioSource.Stop();
+                    }
                     autoFire = false;
                 }
 
@@ -1428,17 +1431,16 @@ namespace BDArmory.Modules
 
                     if (showReloadMeter)
                     {
-                        if (isReloading)
-                        {
-                            gauge.UpdateReloadMeter(ReloadTimer);
-                        }
-                        else
                         {
                             if (BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.RUNWAY_PROJECT_ROUND == 41)
                                 gauge.UpdateReloadMeter((Time.time - timeFired) * BDArmorySettings.FIRE_RATE_OVERRIDE / 60);
                             else
                                 gauge.UpdateReloadMeter((Time.time - timeFired) * roundsPerMinute / 60);
                         }
+                    }
+                    if (isReloading)
+                    {
+                        gauge.UpdateReloadMeter(ReloadTimer);
                     }
                     gauge.UpdateHeatMeter(heat / maxHeat);
                 }
@@ -1471,7 +1473,7 @@ namespace BDArmory.Modules
                     {
                         laserRenderers[i].enabled = false;
                     }
-                    audioSource.Stop();
+                    //audioSource.Stop();
                 }
                 vessel.GetConnectedResourceTotals(AmmoID, out double ammoCurrent, out double ammoMax); //ammo count was originally updating only for active vessel, while reload can be called by any loaded vessel, and needs current ammo count
                 ammoCount = ammoCurrent;
@@ -3794,7 +3796,7 @@ namespace BDArmory.Modules
             {
                 isOverheated = true;
                 autoFire = false;
-                audioSource.Stop();
+                if (!oneShotSound) audioSource.Stop();
                 wasFiring = false;
                 audioSource2.PlayOneShot(overheatSound);
                 weaponManager.ResetGuardInterval();
@@ -3825,7 +3827,7 @@ namespace BDArmory.Modules
                 {
                     laserRenderers[i].enabled = false;
                 }
-                audioSource.Stop();
+                if (!oneShotSound) audioSource.Stop();
                 wasFiring = false;
                 weaponManager.ResetGuardInterval();
                 showReloadMeter = true;

--- a/BDArmory/UI/BDAmmoSelector.cs
+++ b/BDArmory/UI/BDAmmoSelector.cs
@@ -157,7 +157,7 @@ namespace BDArmory.UI
                 string ammoname = String.IsNullOrEmpty(BulletInfo.bullets[AList[i]].DisplayName) ? BulletInfo.bullets[AList[i]].name : BulletInfo.bullets[AList[i]].DisplayName;
                 if (GUI.Button(new Rect(margin * 2, (line + labelLines + ammolines) * buttonHeight, (width - 4 * margin), buttonHeight), ammoname, BDArmorySetup.BDGuiSkin.button))
                 {
-                    beltString += ammoname;
+                    beltString += BulletInfo.bullets[AList[i]].name;
                     beltString += "; ";
                     if (lastGUIstring != ammoname)
                     {


### PR DESCRIPTION
-Fix ammobelts
-Fix weapons with DrainECPerShot not consuming ammo
-Fix weapons using oneShotSound having the weapon SFX getting cut off the moment the weapon stops firing
-Fix reload meters not appearing in some cases
-Fix heterogeneous weapon groups slowing rapid fire weapons' overheating
-Expands missile selection logic
  - Missiles targeting missiles will now  prioritize blast radius and acceleration
  - Missiles targeting aerial targets will now prioritize blast radius and turn rate