### PR TITLE
Deployable weapons and other stuff

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -68,7 +68,7 @@ Localization
         #LOC_BDArmory_WMWindow_targetProximity = Target Dist.
         #LOC_BDArmory_WMWindow_targetAngletoTarget = Angle to Tgt.
         #LOC_BDArmory_WMWindow_targetAngleDist = Angle / Dist.
-        #LOC_BDArmory_WMWindow_targetAccel = Target Accel.
+        #LOC_BDArmory_WMWindow_targetAccel = Target TWR
         #LOC_BDArmory_WMWindow_targetClosingTime = Closing Time
         #LOC_BDArmory_WMWindow_targetgunNumber = Weapon Num.
         #LOC_BDArmory_WMWindow_targetMass = Target Mass
@@ -717,6 +717,7 @@ Localization
         #LOC_BDArmory_DropTime = Drop Time
         #LOC_BDArmory_InCargoBay = In Stock Cargo Bay:\u0020
         #LOC_BDArmory_InCustomCargoBay = Custom Bay Toggle:\u0020
+        #LOC_BDArmory_DeployableWeapon = Deploy Wep Toggle:\u0020
         #LOC_BDArmory_DetonationTime = Detonation Time
         #LOC_BDArmory_BallisticOvershootFactor = Ballistic Overshoot factor
         #LOC_BDArmory_BallisticAnglePath = Ballistic Angle path

--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -1734,7 +1734,8 @@ namespace BDArmory.Modules
                 finalMaxSteer *= Mathf.Clamp((maxSteerAtMaxSpeed - maxSteer) / (cornerSpeed - lowSpeedSwitch + 0.001f) * ((float)vessel.srfSpeed - lowSpeedSwitch) + maxSteer, maxSteerAtMaxSpeed, maxSteer); // Linearly varies between two limits, clamped at limit values
             else
                 finalMaxSteer *= Mathf.Clamp((maxSteerAtMaxSpeed - maxSteer) / (cornerSpeed - lowSpeedSwitch + 0.001f) * ((float)vessel.srfSpeed - lowSpeedSwitch) + maxSteer, maxSteer, maxSteerAtMaxSpeed); // Linearly varies between two limits, clamped at limit values
-            finalMaxSteer = Mathf.Max(finalMaxSteer, 0.1f); // added just in case to ensure some input is retained no matter what happens
+            finalMaxSteer *= 1.225f / (float)vessel.atmDensity; // Scale based on atmospheric density relative to sea level Kerbin (since dynamic pressure depends on density)
+            finalMaxSteer = Mathf.Clamp(finalMaxSteer, 0.1f, 1f); // added just in case to ensure some input is retained no matter what happens
 
             //roll
             Vector3 currentRoll = -vesselTransform.forward;

--- a/BDArmory/Modules/ModuleWeapon.cs
+++ b/BDArmory/Modules/ModuleWeapon.cs
@@ -743,6 +743,49 @@ namespace BDArmory.Modules
         [KSPField(guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_Ammo_LoadedAmmo")]//Status
         public string guiAmmoTypeString = Localizer.Format("#LOC_BDArmory_Ammo_Slug");
 
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_DeployableWeapon"), // In custom/modded "cargo bay"
+            UI_ChooseOption(
+            options = new String[] {
+                "0",
+                "1",
+                "2",
+                "3",
+                "4",
+                "5",
+                "6",
+                "7",
+                "8",
+                "9",
+                "10",
+                "11",
+                "12",
+                "13",
+                "14",
+                "15",
+                "16"
+            },
+            display = new String[] {
+                "Disabled",
+                "AG1",
+                "AG2",
+                "AG3",
+                "AG4",
+                "AG5",
+                "AG6",
+                "AG7",
+                "AG8",
+                "AG9",
+                "AG10",
+                "Lights",
+                "RCS",
+                "SAS",
+                "Brakes",
+                "Abort",
+                "Gear"
+            }
+        )]
+        public string deployWepGroup = "0";
+
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true)]
         private bool canHotSwap = false; //for select weapons that it makes sense to be able to swap ammo types while in-flight, like the Abrams turret
 


### PR DESCRIPTION
- Add in option to set an action group toggled for when weapons are selected/deselected (can be used for deploying weapons or for other actions).
- Scale steer limiter based on atmospheric density in order to account how dynamic pressure will vary based on this value.
- Fix localization for target priority on weapons manager.