### PR TITLE
Fix AI not using Anti-Rad missiles

### DIFF
--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -1275,7 +1275,7 @@ namespace BDArmory.Modules
                             for (int i = 0; i < weaponManager.rwr.pingsData.Length; i++)
                             {
                                 TargetSignatureData threat = weaponManager.rwr.pingsData[i];
-                                if (threat.exists && threat.signalStrength == 4)
+                                if (threat.exists && threat.signalStrength == (float)RadarWarningReceiver.RWRThreatTypes.MissileLock)
                                 {
                                     missileThreatDetected = true;
                                     float dist = (weaponManager.rwr.pingWorldPositions[i] - vesselTransform.position).sqrMagnitude;

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -1409,7 +1409,7 @@ namespace BDArmory.Modules
                         {
                             for (int i = 0; i < rwr.pingsData.Length; i++)
                             {
-                                if (rwr.pingsData[i].exists && (rwr.pingsData[i].signalStrength == 0 || rwr.pingsData[i].signalStrength == 5) && Vector3.Dot(rwr.pingWorldPositions[i] - missile.transform.position, missile.GetForwardTransform()) > 0)
+                                if (rwr.pingsData[i].exists && (rwr.pingsData[i].signalStrength == (float)RadarWarningReceiver.RWRThreatTypes.SAM || rwr.pingsData[i].signalStrength == (float)RadarWarningReceiver.RWRThreatTypes.Detection) && Vector3.Dot(rwr.pingWorldPositions[i] - missile.transform.position, missile.GetForwardTransform()) > 0)
                                 {
                                     BDGUIUtils.DrawTextureOnWorldPos(rwr.pingWorldPositions[i], BDArmorySetup.Instance.greenDiamondTexture, new Vector2(22, 22), 0);
                                 }
@@ -4569,7 +4569,7 @@ namespace BDArmory.Modules
                             {// make it so this only selects antirad when hostile radar
                                 for (int i = 0; i < rwr.pingsData.Length; i++)
                                 {
-                                    if (rwr.pingsData[i].signalStrength == 0 || rwr.pingsData[i].signalStrength == 5)
+                                    if (rwr.pingsData[i].signalStrength == (float)RadarWarningReceiver.RWRThreatTypes.SAM || rwr.pingsData[i].signalStrength == (float)RadarWarningReceiver.RWRThreatTypes.Detection)
                                     {
                                         if ((rwr.pingWorldPositions[i] - guardTarget.CoM).sqrMagnitude < 20 * 20) //is current target a hostile radar source?
                                         {
@@ -5079,7 +5079,7 @@ namespace BDArmory.Modules
 
                 for (int i = 0; i < rwr.pingsData.Length; i++)
                 {
-                    if (rwr.pingsData[i].exists && (rwr.pingsData[i].signalStrength == 0 || rwr.pingsData[i].signalStrength == 5))
+                    if (rwr.pingsData[i].exists && (rwr.pingsData[i].signalStrength == (float)RadarWarningReceiver.RWRThreatTypes.SAM || rwr.pingsData[i].signalStrength == (float)RadarWarningReceiver.RWRThreatTypes.Detection))
                     {
                         float angle = Vector3.Angle(rwr.pingWorldPositions[i] - missile.transform.position, missile.GetForwardTransform());
 

--- a/BDArmory/Targeting/TargetSignatureData.cs
+++ b/BDArmory/Targeting/TargetSignatureData.cs
@@ -178,7 +178,7 @@ namespace BDArmory.Targeting
         {
             get
             {
-                return new TargetSignatureData(Vector3.zero, Vector3.zero, Vector3.zero, false, 0);
+                return new TargetSignatureData(Vector3.zero, Vector3.zero, Vector3.zero, false, -1f);
             }
         }
 


### PR DESCRIPTION
- Replace hard-coded RWR threat types with RWRThreatType reference.
- Don't set noTarget to have a signal strength of 0 (gets interpreted as valid SAM RWR detection). Looks like this fixed Anti-Rad missiles not working properly.