### PR TITLE
Anti-rad and other missile improvements

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/Parts/harm/harm.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/harm/harm.cfg
@@ -77,6 +77,16 @@ PART
 	terminalGuidanceType = antirad
 	terminalGuidanceDistance = 30000
 
+	antiradTargetTypes = 0,5 // Set to all the radar rwrThreatTypes this missile should target (separated by commas), will default to 0,5 if not set
+	// RWR Threat Types:
+    // 0 = SAM site radar
+    // 1 = Fighter radar (airborne)
+    // 2 = AWACS radar (airborne)
+    // 3, 4 = ACTIVE MISSILE (DO NOT USE UNLESS YOU KNOW WHAT YOU'RE DOING!)
+    // 5 = Detection radar (ground/ship based)
+    // 6 = SONAR (ship/submarine based)
+	// 7, 8 = ACTIVE TORPEDO (DO NOT USE UNLESS YOU KNOW WHAT YOU'RE DOING!)
+
 	maxOffBoresight = 65
 	lockedSensorFOV = 7
 

--- a/BDArmory/Misc/ViewScanResults.cs
+++ b/BDArmory/Misc/ViewScanResults.cs
@@ -10,6 +10,7 @@ namespace BDArmory.Misc
         public bool foundMissile;
         public bool foundHeatMissile;
         public bool foundRadarMissile;
+        public bool foundAntiRadiationMissile;
         public bool foundAGM;
         public List<IncomingMissile> incomingMissiles; // List of incoming missiles sorted by distance.
         #endregion

--- a/BDArmory/Modules/BDModulePilotAI.cs
+++ b/BDArmory/Modules/BDModulePilotAI.cs
@@ -2105,7 +2105,7 @@ namespace BDArmory.Modules
                     AdjustThrottle(targetSpeed, false, useAB);
                 }
 
-                if ((weaponManager.isChaffing || weaponManager.isFlaring) && weaponManager.incomingMissileVessel != null) // Missile evasion
+                if (weaponManager.incomingMissileVessel != null && (weaponManager.ThreatClosingTime(weaponManager.incomingMissileVessel) <= weaponManager.cmThreshold)) // Missile evasion
                 {
                     if ((weaponManager.ThreatClosingTime(weaponManager.incomingMissileVessel) <= 1.5f) && (!weaponManager.isChaffing)) // Missile is about to impact, pull a hard turn
                     {

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -1407,9 +1407,10 @@ namespace BDArmory.Modules
                     {
                         if (rwr && rwr.rwrEnabled && rwr.displayRWR)
                         {
+                            MissileLauncher ml = CurrentMissile as MissileLauncher;
                             for (int i = 0; i < rwr.pingsData.Length; i++)
                             {
-                                if (rwr.pingsData[i].exists && (rwr.pingsData[i].signalStrength == (float)RadarWarningReceiver.RWRThreatTypes.SAM || rwr.pingsData[i].signalStrength == (float)RadarWarningReceiver.RWRThreatTypes.Detection) && Vector3.Dot(rwr.pingWorldPositions[i] - missile.transform.position, missile.GetForwardTransform()) > 0)
+                                if (rwr.pingsData[i].exists && (ml.antiradTargets.Contains(rwr.pingsData[i].signalStrength)) && Vector3.Dot(rwr.pingWorldPositions[i] - missile.transform.position, missile.GetForwardTransform()) > 0)
                                 {
                                     BDGUIUtils.DrawTextureOnWorldPos(rwr.pingWorldPositions[i], BDArmorySetup.Instance.greenDiamondTexture, new Vector2(22, 22), 0);
                                 }
@@ -4569,7 +4570,7 @@ namespace BDArmory.Modules
                             {// make it so this only selects antirad when hostile radar
                                 for (int i = 0; i < rwr.pingsData.Length; i++)
                                 {
-                                    if (rwr.pingsData[i].signalStrength == (float)RadarWarningReceiver.RWRThreatTypes.SAM || rwr.pingsData[i].signalStrength == (float)RadarWarningReceiver.RWRThreatTypes.Detection)
+                                    if (Missile.antiradTargets.Contains(rwr.pingsData[i].signalStrength))
                                     {
                                         if ((rwr.pingWorldPositions[i] - guardTarget.CoM).sqrMagnitude < 20 * 20) //is current target a hostile radar source?
                                         {
@@ -5077,9 +5078,11 @@ namespace BDArmory.Modules
 
                 if (missile.TargetingMode != MissileBase.TargetingModes.AntiRad) return;
 
+                MissileLauncher ml = CurrentMissile as MissileLauncher;
+
                 for (int i = 0; i < rwr.pingsData.Length; i++)
                 {
-                    if (rwr.pingsData[i].exists && (rwr.pingsData[i].signalStrength == (float)RadarWarningReceiver.RWRThreatTypes.SAM || rwr.pingsData[i].signalStrength == (float)RadarWarningReceiver.RWRThreatTypes.Detection))
+                    if (rwr.pingsData[i].exists && (ml.antiradTargets.Contains(rwr.pingsData[i].signalStrength)))
                     {
                         float angle = Vector3.Angle(rwr.pingWorldPositions[i] - missile.transform.position, missile.GetForwardTransform());
 

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -4911,13 +4911,15 @@ namespace BDArmory.Modules
                         if (distanceToTarget < engageableWeapon.GetEngagementRangeMin()) return false;
                         // lock radar if needed
                         if (ml.TargetingMode == MissileBase.TargetingModes.Radar)
+                        {
+                            if (results.foundAntiRadiationMissile) return false; // Don't try to fire radar missiles while we have an incoming anti-rad missile
                             using (List<ModuleRadar>.Enumerator rd = radars.GetEnumerator())
                                 while (rd.MoveNext())
                                 {
                                     if (rd.Current != null || rd.Current.canLock)
                                         rd.Current.EnableRadar();
                                 }
-
+                        }
                         // check DLZ
                         MissileLaunchParams dlz = MissileLaunchParams.GetDynamicLaunchParams(ml, guardTarget.Velocity(), guardTarget.transform.position);
                         if (vessel.srfSpeed > ml.minLaunchSpeed && distanceToTarget < dlz.maxLaunchRange && distanceToTarget > dlz.minLaunchRange)
@@ -5418,6 +5420,19 @@ namespace BDArmory.Modules
                         //targetScanTimer = Mathf.Min(targetScanInterval, Time.time - targetScanInterval + 0.5f);
                         targetScanTimer -= targetScanInterval / 2;
                     }
+                }
+
+                if (results.foundAntiRadiationMissile)
+                {
+                    StartCoroutine(UnderAttackRoutine());
+
+                    // Turn off the radars
+                    using (List<ModuleRadar>.Enumerator rd = radars.GetEnumerator())
+                        while (rd.MoveNext())
+                        {
+                            if (rd.Current != null || rd.Current.canLock)
+                                rd.Current.DisableRadar();
+                        }
                 }
             }
             else

--- a/BDArmory/Modules/MissileLauncher.cs
+++ b/BDArmory/Modules/MissileLauncher.cs
@@ -27,6 +27,10 @@ namespace BDArmory.Modules
         [KSPField]
         public string targetingType = "none";
 
+        [KSPField]
+        public string antiradTargetTypes = "0,5";
+        public float[] antiradTargets;
+
         public MissileTurret missileTurret = null;
         public BDRotaryRail rotaryRail = null;
         public BDDeployableRail deployableRail = null;
@@ -384,6 +388,7 @@ namespace BDArmory.Modules
             }
 
             ParseModes();
+            ParseAntiRadTargetTypes();
             // extension for feature_engagementenvelope
             InitializeEngagementRange(minStaticLaunchRange, maxStaticLaunchRange);
 
@@ -2046,6 +2051,11 @@ namespace BDArmory.Modules
             float AoA = Vector3.Angle(part.transform.forward, vessel.Velocity());
             AoA /= 20;
             part.rb.AddTorque(AoA * simpleStableTorque * dragMagnitude * torqueAxis);
+        }
+
+        void ParseAntiRadTargetTypes()
+        {
+            antiradTargets = Utils.ParseToFloatArray(antiradTargetTypes);
         }
 
         void ParseModes()

--- a/BDArmory/Modules/RadarWarningReceiver.cs
+++ b/BDArmory/Modules/RadarWarningReceiver.cs
@@ -210,6 +210,7 @@ namespace BDArmory.Modules
             if (weaponManager == null) return;
 
             float sqrDist = (part.transform.position - source).sqrMagnitude;
+            if ((weaponManager && weaponManager.guardMode) && (sqrDist > (weaponManager.guardRange * weaponManager.guardRange))) return;
             if (sqrDist < BDArmorySettings.MAX_ENGAGEMENT_RANGE * BDArmorySettings.MAX_ENGAGEMENT_RANGE && sqrDist > 10000f && Vector3.Angle(direction, part.transform.position - source) < 15f)
             {
                 StartCoroutine(

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -1208,6 +1208,7 @@ namespace BDArmory.Radar
                 foundMissile = false,
                 foundHeatMissile = false,
                 foundRadarMissile = false,
+                foundAntiRadiationMissile = false,
                 foundAGM = false,
                 firingAtMe = false,
                 missDistance = float.MaxValue,
@@ -1279,6 +1280,9 @@ namespace BDArmory.Radar
                                             case MissileBase.TargetingModes.Laser:
                                                 results.foundAGM = true;
                                                 break;
+                                            case MissileBase.TargetingModes.AntiRad:
+                                                results.foundAntiRadiationMissile = true;
+                                                break;
                                         }
                                     }
                                 }
@@ -1333,12 +1337,13 @@ namespace BDArmory.Radar
         public static bool MissileIsThreat(MissileBase missile, MissileFire mf, bool threatToMeOnly = true)
         {
             if (missile == null || missile.part == null) return false;
+            Vector3 vectorFromMissile = mf.vessel.CoM - missile.part.transform.position;
+            if ((vectorFromMissile.sqrMagnitude > (mf.guardRange * mf.guardRange)) && (missile.TargetingMode != MissileBase.TargetingModes.Radar)) return false;
             if (threatToMeOnly)
             {
-                Vector3 vectorFromMissile = mf.vessel.CoM - missile.part.transform.position;
                 Vector3 relV = missile.vessel.Velocity() - mf.vessel.Velocity();
                 bool approaching = Vector3.Dot(relV, vectorFromMissile) > 0;
-                bool withinRadarFOV = (missile.TargetingMode == MissileBase.TargetingModes.Radar || missile.TargetingModeTerminal == MissileBase.TargetingModes.Radar) ?
+                bool withinRadarFOV = (missile.TargetingMode == MissileBase.TargetingModes.Radar) ?
                     (Vector3.Angle(missile.GetForwardTransform(), vectorFromMissile) <= Mathf.Clamp(missile.lockedSensorFOV, 40f, 90f) / 2f) : false;
                 var missileBlastRadiusSqr = 3f * missile.GetBlastRadius();
                 missileBlastRadiusSqr *= missileBlastRadiusSqr;
@@ -1362,10 +1367,9 @@ namespace BDArmory.Radar
                         if (wms == null || wms.Team != mf.Team)
                             continue;
 
-                        Vector3 vectorFromMissile = wms.vessel.CoM - missile.part.transform.position;
                         Vector3 relV = missile.vessel.Velocity() - wms.vessel.Velocity();
                         bool approaching = Vector3.Dot(relV, vectorFromMissile) > 0;
-                        bool withinRadarFOV = (missile.TargetingMode == MissileBase.TargetingModes.Radar || missile.TargetingModeTerminal == MissileBase.TargetingModes.Radar) ?
+                        bool withinRadarFOV = (missile.TargetingMode == MissileBase.TargetingModes.Radar) ?
                             (Vector3.Angle(missile.GetForwardTransform(), vectorFromMissile) <= Mathf.Clamp(missile.lockedSensorFOV, 40f, 90f) / 2f) : false;
                         var missileBlastRadiusSqr = 3f * missile.GetBlastRadius();
                         missileBlastRadiusSqr *= missileBlastRadiusSqr;


### PR DESCRIPTION
 - Create new antiradTargetTypes variable for missiles that allows you to specify the RWR Threat Type that the anti-radiation missile should target. Default is 0,5 (SAM,Detection).
 - Remove reference to TargetingModeTerminal since TargetingMode is updated to be equal to TargetingModeTerminal once terminal guidance activates.
- Don't treat passive (non-radar-guided) missiles outside visual range as incoming missile threats until they enter visual range.
- Don't warn targets in guard mode about missile launches outside their visual range.
- Craft in guard mode will turn off their radars if they have an incoming anti-radiation missile within visual range.