### PR TITLE
Bugfixes and missile-multitargeting

### DIFF
--- a/BDArmory.Core/Module/HitpointTracker.cs
+++ b/BDArmory.Core/Module/HitpointTracker.cs
@@ -651,7 +651,7 @@ namespace BDArmory.Core.Module
 
                         var structuralMass = density * structuralVolume; //this just means hp = mass if the density is within the limits.
 
-                        //biger things need more hp; but things that are denser, should also have more hp, so it's a bit mroe complicated than have hp = volume * hp mult
+                        //bigger things need more hp; but things that are denser, should also have more hp, so it's a bit more complicated than have hp = volume * hp mult
                         //hp = (volume * Hp mult) * density mod?
                         //lets take some examples; 3 identical size parts, mk1 cockpit(930kg), mk1 stuct tube (100kg), mk1 LF tank (250kg)
                         //if, say, a Hp mod of 300, so 2.55m3 * 300 = 765 -> 800hp
@@ -674,15 +674,15 @@ namespace BDArmory.Core.Module
                             if (part.Modules.Contains("FARWingAerodynamicModel") || part.Modules.Contains("FARControllableSurface"))
                             {
                                 //procwing hp already modified by mass, because it is mass
-                                //so using base part mass is it can be properly modified my material HP mod below
+                                //so using base part mass is it can be properly modified by material HP mod below
                                 hitpoints = (partMass * 1000f) * 3.5f * hitpointMultiplier * 0.333f; //To account for FAR's Strength-mass Scalar.                                                                                                 //unfortunately the same trick can't be used for FAR wings, so mass hack it is.
-                                armorVolume = (float)Math.Round(hitpoints / hitpointMultiplier / 0.333 / 350, 1); 
+								armorVolume = (float)Math.Round(hitpoints / hitpointMultiplier / 0.333 / 175, 1); //half of HP due to wing's 0.5x area modifier to prevent double armor
                             }
                             else
                             {
                                 //hitpoints = (partMass * 1000f) * 7f * hitpointMultiplier * 0.333f; // since wings are basically a 2d object, lets have mass be our scalar - afterall, 2x the mass will ~= 2x the surfce area
                                 hitpoints = (float)Math.Round(part.Modules.GetModule<ModuleLiftingSurface>().deflectionLiftCoeff, 2) * 700 * hitpointMultiplier * 0.333f; //this yields the same result, but not beholden to mass changes
-                                armorVolume = (float)Math.Round(hitpoints / hitpointMultiplier / 0.333 / 700, 1); //stock is 0.25 lift/m2, so...
+                                armorVolume = (float)Math.Round(hitpoints / hitpointMultiplier / 0.333 / 350, 1); //stock is 0.25 lift/m2, so...
                             } //breaks when pWings are made stupidly thick/large  //should really figure out a fix for that someday
                             ArmorModified(null, null);
                         }

--- a/BDArmory.Core/Module/HitpointTracker.cs
+++ b/BDArmory.Core/Module/HitpointTracker.cs
@@ -675,15 +675,16 @@ namespace BDArmory.Core.Module
                             {
                                 //procwing hp already modified by mass, because it is mass
                                 //so using base part mass is it can be properly modified my material HP mod below
-                                hitpoints = (partMass * 1000f) * 3.5f * hitpointMultiplier * 0.333f; //To account for FAR's Strength-mass Scalar.
-                                //unfortunately the same trick can't be used for FAR wings, so mass hack it is.
+                                hitpoints = (partMass * 1000f) * 3.5f * hitpointMultiplier * 0.333f; //To account for FAR's Strength-mass Scalar.                                                                                                 //unfortunately the same trick can't be used for FAR wings, so mass hack it is.
+                                armorVolume = (float)Math.Round(hitpoints / hitpointMultiplier / 0.333 / 350, 1); 
                             }
                             else
                             {
                                 //hitpoints = (partMass * 1000f) * 7f * hitpointMultiplier * 0.333f; // since wings are basically a 2d object, lets have mass be our scalar - afterall, 2x the mass will ~= 2x the surfce area
                                 hitpoints = (float)Math.Round(part.Modules.GetModule<ModuleLiftingSurface>().deflectionLiftCoeff, 2) * 700 * hitpointMultiplier * 0.333f; //this yields the same result, but not beholden to mass changes
+                                armorVolume = (float)Math.Round(hitpoints / hitpointMultiplier / 0.333 / 700, 1); //stock is 0.25 lift/m2, so...
                             } //breaks when pWings are made stupidly thick/large  //should really figure out a fix for that someday
-
+                            ArmorModified(null, null);
                         }
 
                         switch (HullTypeNum)

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -34,6 +34,7 @@ Localization
         #LOC_BDArmory_WMWindow_VisualRange = Visual Range
         #LOC_BDArmory_WMWindow_GunsRange = Guns Range
         #LOC_BDArmory_WMWindow_MultiTargetNum = Max Turret Tgts
+        #LOC_BDArmory_WMWindow_MultiMissileNum = Max Missile Tgts
 
         #LOC_BDArmory_WMWindow_MissilesTgt = Missiles/Tgt
         #LOC_BDArmory_WMWindow_TargetType = Target Type: 
@@ -59,6 +60,7 @@ Localization
         #LOC_BDArmory_WMWindow_VisualRange_desc = Visual Range - This is how far the AI can see. Targets that are closer than this value will be seen, and the AI will move in to engage. Targets outside this value will require radar to spot.
         #LOC_BDArmory_WMWindow_GunsRange_desc = Guns Range - This sets the max weapon range for all guns, rockets, or lasers on the vessel. By default, this is set to the longest range non-missile weapon mounted on the craft. The AI will not attempt to fire on vessels outside this range.
         #LOC_BDArmory_WMWindow_MultiTargetNum_desc = Max Turret Tgts - For vessels that have multiple turrets, this sets how many targets the turrets may independently target and engage, allowing the vessel to engage multiple targets simultaneously.
+        #LOC_BDArmory_WMWindow_MultiMissileTgtNum_desc = Max Missile Tgts - For vessels with multiple missiles, this sets how many different targets the AI will seek to engage with missiles, switching to a new target once the allowed number of missiles have been launched at the current target.
         #LOC_BDArmory_WMWindow_MissilesTgt_desc = Missiles/Tgt - This sets how many missiles the AI will fire a target. Once this number of missiles have been fired, the AI will only fire additional missiles once a previously fired missile hits or is otherwise destroyed.
         #LOC_BDArmory_WMWindow_TargetType_desc = Advanced Targeting Button - This allows setting custom targeting preferences for the AI, allowing it to specifically target weapons, engines, command pods, heaviest parts or some combination of these instead of targeting Center of Mass.
         #LOC_BDArmory_WMWindow_EngageType_desc = Engagement Options Button - This is a toggle to quickly set weapon engagment options - Air, Surface, Missile, or SLW - for all weapons on the vessel at once.

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/AmmoBox/BDAcUniversalAmmoBox.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/AmmoBox/BDAcUniversalAmmoBox.cfg
@@ -55,7 +55,7 @@ maxTemp = 3600
 	MODULE
 	{
 		name = ModuleAmmoSwitch//47
-		resourceNames = Empty; 7.62x39Ammo; 7.7x56Ammo; 7.92x57mmMauser; 9x19mmParaAmmo; 50CalAmmo; 20x21Ammo; 20x102Ammo; 20x163Ammo; 23x115Ammo; 23x152Ammo; 25x137Ammo; 30x165Ammo; 30x173Ammo; 30x173HEAmmo; 37mmFlaKAmmo; 40x53Ammo; 40x53HeAmmo; 40x311Ammo; 54cmMortarShells; 57x438Ammo; TungstenShell; 75x714Ammo; 76x636Ammo; 3inchShells; 90mmShells; 100mmShells; 4p5inchQFShells; 105mmShells; 105mmHEShells; 120mmAmmo; 122mmQFShells; 130Shells;  5/62Shell; 138_140Shells; 152Shells; 155Shells; 180Shells; 203Shells; 12inShells; 356Shells; 356ApAmmo; 380Shells; M65ShellAmmo; 406mmNuclearShells; 16inchShells; 460Shells
+		resourceNames = Empty; 7.62x39Ammo; 7.7x56Ammo; 7.92x57mmMauser; 9x19mmParaAmmo; 50CalAmmo; 20x21Ammo; 20x102Ammo; 20x163Ammo; 23x115Ammo; 23x152Ammo; 25x137Ammo; 30x165Ammo; 30x173Ammo; 30x173HEAmmo; 37mmFlaKAmmo; 40x53Ammo; 40x53HeAmmo; 40x311Ammo; 54cmMortarShells; 57x438Ammo; TungstenShell; 75x714Ammo; 76x636Ammo; 3inchShells; 90mmShells; 100mmShells; 4p5inchQFShells; 105mmShells; 105mmHEShells; 120mmAmmo; 122mmQFShells; 130Shells;  5/62Shell; 138_140Shells; 152Shells; 155Shells; 180Shells; 203Shells; 12inShells; 356Shells; 356ApAmmo; 380Shells; M65ShellAmmo; 406mmNuclearShells; 16inchShells; 460Shells; Rockets
 		resourceAmounts = 0; 500; 500; 500; 500; 400; 400; 400; 350; 350; 350; 350; 300; 300; 300; 300; 300; 300; 300; 200; 200; 200; 40; 40; 40; 30; 30; 30; 30; 30; 25; 25; 25; 20; 15; 15; 15; 15; 10; 8; 8; 8; 6; 4; 4; 4; 4 //47
 		basePartMass = 0.1
 		showInfo = true

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/AmmoBox/UniversalAmmoBoxBDA.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/AmmoBox/UniversalAmmoBoxBDA.cfg
@@ -55,7 +55,7 @@ maxTemp = 3600
 	MODULE
 	{
 		name = FSfuelSwitch//47
-		resourceNames = Empty; 7.62x39Ammo; 7.7x56Ammo; 7.92x57mmMauser; 9x19mmParaAmmo; 50CalAmmo; 20x21Ammo; 20x102Ammo; 20x163Ammo; 23x115Ammo; 23x152Ammo; 25x137Ammo; 30x165Ammo; 30x173Ammo; 30x173HEAmmo; 37mmFlaKAmmo; 40x53Ammo; 40x53HeAmmo; 40x311Ammo; 54cmMortarShells; 57x438Ammo; TungstenShell; 75x714Ammo; 76x636Ammo; 3inchShells; 90mmShells; 100mmShells; 4p5inchQFShells; 105mmShells; 105mmHEShells; 120mmAmmo; 122mmQFShells; 130Shells;  5/62Shell; 138_140Shells; 152Shells; 155Shells; 180Shells; 203Shells; 12inShells; 356Shells; 356ApAmmo; 380Shells; M65ShellAmmo; 406mmNuclearShells; 16inchShells; 460Shells
+		resourceNames = Empty; 7.62x39Ammo; 7.7x56Ammo; 7.92x57mmMauser; 9x19mmParaAmmo; 50CalAmmo; 20x21Ammo; 20x102Ammo; 20x163Ammo; 23x115Ammo; 23x152Ammo; 25x137Ammo; 30x165Ammo; 30x173Ammo; 30x173HEAmmo; 37mmFlaKAmmo; 40x53Ammo; 40x53HeAmmo; 40x311Ammo; 54cmMortarShells; 57x438Ammo; TungstenShell; 75x714Ammo; 76x636Ammo; 3inchShells; 90mmShells; 100mmShells; 4p5inchQFShells; 105mmShells; 105mmHEShells; 120mmAmmo; 122mmQFShells; 130Shells;  5/62Shell; 138_140Shells; 152Shells; 155Shells; 180Shells; 203Shells; 12inShells; 356Shells; 356ApAmmo; 380Shells; M65ShellAmmo; 406mmNuclearShells; 16inchShells; 460Shells; Rockets
 		resourceAmounts = 0; 500; 500; 500; 500; 400; 400; 400; 350; 350; 350; 350; 300; 300; 300; 300; 300; 300; 300; 200; 200; 200; 40; 40; 40; 30; 30; 30; 30; 30; 25; 25; 25; 20; 15; 15; 15; 15; 10; 8; 8; 8; 6; 4; 4; 4; 4 //47
 		basePartMass = 0.1
 		showInfo = true

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/towMissile/towMissile.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/towMissile/towMissile.cfg
@@ -84,7 +84,7 @@ PART
 	  maxStaticLaunchRange = 3750
 	  audioClipPath = BDArmory/Sounds/rocketLoop
 	  boostClipPath = BDArmory/Sounds/rocketLoop
-	  exhaustPrefabPath = BDArmory/Models/exhaust/smallExhaust
+	  //exhaustPrefabPath = BDArmory/Models/exhaust/smallExhaust
 	  boostTransformName = boostTransform
 
 	  engageAir = false

--- a/BDArmory/Modules/MissileBase.cs
+++ b/BDArmory/Modules/MissileBase.cs
@@ -279,7 +279,7 @@ namespace BDArmory.Modules
 
         protected float lockFailTimer = -1;
 
-        public Vessel legacyTargetVessel;
+        public TargetInfo legacyTargetVessel;
 
         public Transform MissileReferenceTransform;
 

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -1282,12 +1282,15 @@ namespace BDArmory.Modules
                             missilesAway.Add(missileBase.legacyTargetVessel, 1);
                         }
                         else
-                        missilesAway[missileBase.legacyTargetVessel]++;
+                        {
+                            missilesAway[missileBase.legacyTargetVessel]++; //tabulate all missiles fired by the vessel at various targets; only need # missiles fired at current target forlaunching, but need all vessels with missiles targeting them for vessel targeting
+                        }
                     }
                 }
             if (currentTarget != null && missilesAway.ContainsKey(currentTarget))
             {
-                firedMissiles = missilesAway[currentTarget];
+				missilesAway.TryGetValue(currentTarget, out int missiles);
+                this.firedMissiles = missiles;
             }
             //this.missilesAway = tempMissilesAway;
         }
@@ -3332,9 +3335,13 @@ namespace BDArmory.Modules
 
             string targetDebugText = "";
 
-            if (multiTargetNum > 1 && BDATargetManager.TargetList(Team).Count > 1) //if there are multiple potential targets, see how many can be fired at with missiles
+            if (firedMissiles >= maxMissilesOnTarget && (multiTargetNum > 1 && BDATargetManager.TargetList(Team).Count > 1)) //if there are multiple potential targets, see how many can be fired at with missiles
             {
                 Debug.Log("[MissileFire] max missiles on target; switching to new target!");
+				heatTarget = TargetSignatureData.noTarget; //clear holdover targets when switching targets
+				antiRadTargetAcquired = false;
+                //vesselRadarData.UnlockCurrentTarget(); // this one will take some work; don't want to unlock current target if it's a radar missile slaved to ship radar guidance, not missile radar
+
                 using (List<TargetInfo>.Enumerator target = BDATargetManager.TargetList(Team).GetEnumerator())
                 {
                     while (target.MoveNext())

--- a/BDArmory/Modules/MissileFire.cs
+++ b/BDArmory/Modules/MissileFire.cs
@@ -463,6 +463,10 @@ namespace BDArmory.Modules
          UI_FloatRange(minValue = 1, maxValue = 10, stepIncrement = 1, scene = UI_Scene.All)]
         public float multiTargetNum = 1;
 
+        [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "#LOC_BDArmory_WMWindow_MultiMissileNum"),//Max Turret Targets
+ UI_FloatRange(minValue = 1, maxValue = 10, stepIncrement = 1, scene = UI_Scene.All)]
+        public float multiMissileTgtNum = 1;
+
         public const float maxAllowableMissilesOnTarget = 18f;
 
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_MissilesORTarget"), UI_FloatRange(minValue = 1f, maxValue = maxAllowableMissilesOnTarget, stepIncrement = 1f, scene = UI_Scene.All)]//Missiles/Target
@@ -3337,7 +3341,7 @@ namespace BDArmory.Modules
             engagedTargets = 0;
             string targetDebugText = "";
 
-            if (firedMissiles >= maxMissilesOnTarget && (multiTargetNum > 1 && BDATargetManager.TargetList(Team).Count > 1)) //if there are multiple potential targets, see how many can be fired at with missiles
+            if (firedMissiles >= maxMissilesOnTarget && (multiMissileTgtNum > 1 && BDATargetManager.TargetList(Team).Count > 1)) //if there are multiple potential targets, see how many can be fired at with missiles
             {
                 Debug.Log("[MissileFire] max missiles on target; switching to new target!");
 				heatTarget = TargetSignatureData.noTarget; //clear holdover targets when switching targets
@@ -5334,7 +5338,7 @@ namespace BDArmory.Modules
             {
                 targetScanTimer = Time.time;
 
-                if (!guardFiringMissile || (firedMissiles >= maxMissilesOnTarget && multiTargetNum > 1 && BDATargetManager.TargetList(Team).Count > 1)) //grab new target, if possible
+                if (!guardFiringMissile || (firedMissiles >= maxMissilesOnTarget && multiMissileTgtNum > 1 && BDATargetManager.TargetList(Team).Count > 1)) //grab new target, if possible
                 {
                     SmartFindTarget();
 

--- a/BDArmory/Modules/MissileLauncher.cs
+++ b/BDArmory/Modules/MissileLauncher.cs
@@ -863,7 +863,7 @@ namespace BDArmory.Modules
         {
             if (!HasFired)
             {
-                legacyTargetVessel = v;
+                legacyTargetVessel = v.gameObject.GetComponent<TargetInfo>();
                 FireMissile();
             }
         }
@@ -1077,11 +1077,11 @@ namespace BDArmory.Modules
                 {
                     WarnTarget();
 
-                    if (legacyTargetVessel && legacyTargetVessel.loaded)
-                    {
-                        Vector3 targetCoMPos = legacyTargetVessel.CoM;
-                        TargetPosition = targetCoMPos + legacyTargetVessel.Velocity() * Time.fixedDeltaTime;
-                    }
+                    //if (legacyTargetVessel && legacyTargetVessel.loaded)
+                    //{
+                    //   Vector3 targetCoMPos = legacyTargetVessel.CoM;
+                    //    TargetPosition = targetCoMPos + legacyTargetVessel.Velocity() * Time.fixedDeltaTime;
+                    //}
 
                     //increaseTurnRate after launch
                     float turnRateDPS = Mathf.Clamp(((TimeIndex - dropTime) / boostTime) * maxTurnRateDPS * 25f, 0, maxTurnRateDPS);
@@ -1859,17 +1859,17 @@ namespace BDArmory.Modules
 
             BDArmorySetup.numberOfParticleEmitters--;
             HasExploded = true;
-
+            /*
             if (legacyTargetVessel != null)
             {
                 using (var wpm = VesselModuleRegistry.GetModules<MissileFire>(legacyTargetVessel).GetEnumerator())
                     while (wpm.MoveNext())
                     {
                         if (wpm.Current == null) continue;
-                        wpm.Current.missileIsIncoming = false;
+                        wpm.Current.missileIsIncoming = false; //handled by attacked vessel
                     }
             }
-
+            */
             if (SourceVessel == null) SourceVessel = vessel;
 
             if (part.FindModuleImplementing<BDExplosivePart>() != null)
@@ -1930,7 +1930,7 @@ namespace BDArmory.Modules
         void WarnTarget()
         {
             if (legacyTargetVessel == null) return;
-            var wpm = VesselModuleRegistry.GetMissileFire(legacyTargetVessel, true);
+            var wpm = VesselModuleRegistry.GetMissileFire(legacyTargetVessel.Vessel, true);
             if (wpm != null) wpm.MissileWarning(Vector3.Distance(transform.position, legacyTargetVessel.transform.position), this);
         }
 

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -238,7 +238,7 @@ namespace BDArmory.Targeting
             if (radarMassAtUpdate > 0)
             {
                 float massPercentageDifference = (radarMassAtUpdate - vessel.GetTotalMass()) / radarMassAtUpdate;
-                if ((massPercentageDifference > 0.025f) && (weaponManager) && (weaponManager.missilesAway == 0) && !weaponManager.guardFiringMissile)
+                if ((massPercentageDifference > 0.025f) && (weaponManager) && (weaponManager.missilesAway[weaponManager.currentTarget] == 0) && !weaponManager.guardFiringMissile)
                 {
                     alreadyScheduledRCSUpdate = true;
                     yield return new WaitForSeconds(1.0f);    // Wait for any explosions to finish

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -238,7 +238,7 @@ namespace BDArmory.Targeting
             if (radarMassAtUpdate > 0)
             {
                 float massPercentageDifference = (radarMassAtUpdate - vessel.GetTotalMass()) / radarMassAtUpdate;
-                if ((massPercentageDifference > 0.025f) && (weaponManager) && (weaponManager.missilesAway[weaponManager.currentTarget] == 0) && !weaponManager.guardFiringMissile)
+                if ((massPercentageDifference > 0.025f) && (weaponManager) && (weaponManager.missilesAway.Count == 0) && !weaponManager.guardFiringMissile)
                 {
                     alreadyScheduledRCSUpdate = true;
                     yield return new WaitForSeconds(1.0f);    // Wait for any explosions to finish

--- a/BDArmory/UI/BDArmoryAIGUI.cs
+++ b/BDArmory/UI/BDArmoryAIGUI.cs
@@ -972,6 +972,8 @@ namespace BDArmory.UI
 
                                 if (ActivePilot.dynamicDampingPitch)
                                 {
+                                    GUI.Label(SettinglabelRect(leftIndent, pidLines + dynPidLines), Localizer.Format("#LOC_BDArmory_DynamicDampingPitch") + ": " + ActivePilot.dynSteerDampingPitchValue.ToString(), Label);//"dynamic damp pitch"
+                                    dynPidLines++;
                                     if (!NumFieldsEnabled)
                                     {
                                         ActivePilot.DynamicDampingPitchMin =
@@ -1038,6 +1040,8 @@ namespace BDArmory.UI
                                 dynPidLines += 1.25f;
                                 if (ActivePilot.dynamicDampingYaw)
                                 {
+                                    GUI.Label(SettinglabelRect(leftIndent, pidLines + dynPidLines), Localizer.Format("#LOC_BDArmory_DynamicDampingYaw") + ": " + ActivePilot.dynSteerDampingYawValue.ToString(), Label);//"dynamic damp yaw"
+                                    dynPidLines++;
                                     if (!NumFieldsEnabled)
                                     {
                                         ActivePilot.DynamicDampingYawMin =
@@ -1105,6 +1109,8 @@ namespace BDArmory.UI
                                 dynPidLines += 1.25f;
                                 if (ActivePilot.dynamicDampingRoll)
                                 {
+                                    GUI.Label(SettinglabelRect(leftIndent, pidLines + dynPidLines), Localizer.Format("#LOC_BDArmory_DynamicDampingRoll") + ": " + ActivePilot.dynSteerDampingRollValue.ToString(), Label);//"dynamic damp roll"
+                                    dynPidLines++;
                                     if (!NumFieldsEnabled)
                                     {
                                         ActivePilot.DynamicDampingRollMin =
@@ -1191,7 +1197,7 @@ namespace BDArmory.UI
                             ActivePilot.defaultAltitude =
                                 GUI.HorizontalSlider(SettingSliderRect(leftIndent, altLines, contentWidth),
                                     ActivePilot.defaultAltitude, 100, ActivePilot.UpToEleven ? 100000 : 15000);
-                            ActivePilot.defaultAltitude = Mathf.Round(ActivePilot.defaultAltitude / 25) * 25;
+                            ActivePilot.defaultAltitude = Mathf.Round(ActivePilot.defaultAltitude / 50) * 50;
                         }
                         else
                         {
@@ -1217,7 +1223,7 @@ namespace BDArmory.UI
                             ActivePilot.minAltitude =
                                 GUI.HorizontalSlider(SettingSliderRect(leftIndent, altLines, contentWidth),
                                     ActivePilot.minAltitude, 25, ActivePilot.UpToEleven ? 60000 : 6000);
-                            ActivePilot.minAltitude = Mathf.Round(ActivePilot.minAltitude / 25) * 25;
+                            ActivePilot.minAltitude = Mathf.Round(ActivePilot.minAltitude / 10) * 10;
                         }
                         else
                         {
@@ -1250,7 +1256,7 @@ namespace BDArmory.UI
                                 ActivePilot.maxAltitude =
                                     GUI.HorizontalSlider(SettingSliderRect(leftIndent, altLines, contentWidth),
                                         ActivePilot.maxAltitude, 100, ActivePilot.UpToEleven ? 100000 : 15000);
-                                ActivePilot.maxAltitude = Mathf.Round(ActivePilot.maxAltitude / 25) * 25;
+                                ActivePilot.maxAltitude = Mathf.Round(ActivePilot.maxAltitude / 100) * 100;
                             }
                             else
                             {
@@ -1288,7 +1294,7 @@ namespace BDArmory.UI
                         if (!NumFieldsEnabled)
                         {
                             ActivePilot.maxSpeed = GUI.HorizontalSlider(SettingSliderRect(leftIndent, ++spdLines, contentWidth), ActivePilot.maxSpeed, 20, ActivePilot.UpToEleven ? 3000 : 800);
-                            ActivePilot.maxSpeed = Mathf.Round(ActivePilot.maxSpeed);
+                            ActivePilot.maxSpeed = Mathf.Round(ActivePilot.maxSpeed / 5) * 5;
                         }
                         else
                         {
@@ -1725,7 +1731,7 @@ namespace BDArmory.UI
                                 ActivePilot.extendDistanceAirToAir =
                                     GUI.HorizontalSlider(SettingSliderRect(leftIndent, evadeLines, contentWidth),
                                         ActivePilot.extendDistanceAirToAir, 0, ActivePilot.UpToEleven ? 20000 : 2000);
-                                ActivePilot.extendDistanceAirToAir = Utils.RoundToUnit(ActivePilot.extendDistanceAirToAir, 50f);
+                                ActivePilot.extendDistanceAirToAir = Utils.RoundToUnit(ActivePilot.extendDistanceAirToAir, 10);
                             }
                             else
                             {
@@ -1745,7 +1751,7 @@ namespace BDArmory.UI
                                 ActivePilot.extendDistanceAirToGroundGuns =
                                     GUI.HorizontalSlider(SettingSliderRect(leftIndent, evadeLines, contentWidth),
                                         ActivePilot.extendDistanceAirToGroundGuns, 0, ActivePilot.UpToEleven ? 20000 : 5000);
-                                ActivePilot.extendDistanceAirToGroundGuns = Utils.RoundToUnit(ActivePilot.extendDistanceAirToGroundGuns, 100f);
+                                ActivePilot.extendDistanceAirToGroundGuns = Utils.RoundToUnit(ActivePilot.extendDistanceAirToGroundGuns, 50);
                             }
                             else
                             {
@@ -1765,7 +1771,7 @@ namespace BDArmory.UI
                                 ActivePilot.extendDistanceAirToGround =
                                     GUI.HorizontalSlider(SettingSliderRect(leftIndent, evadeLines, contentWidth),
                                         ActivePilot.extendDistanceAirToGround, 0, ActivePilot.UpToEleven ? 20000 : 5000);
-                                ActivePilot.extendDistanceAirToGround = Utils.RoundToUnit(ActivePilot.extendDistanceAirToGround, 100f);
+                                ActivePilot.extendDistanceAirToGround = Utils.RoundToUnit(ActivePilot.extendDistanceAirToGround, 50);
                             }
                             else
                             {

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -749,6 +749,7 @@ namespace BDArmory.UI
                 { "guardRange", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.guardRange, 100, BDArmorySettings.MAX_GUARD_VISUAL_RANGE) },
                 { "gunRange", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.gunRange, 0, ActiveWeaponManager.maxGunRange) },
                 { "multiTargetNum", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.multiTargetNum, 1, 10) },
+                { "multiMissileTgtNum", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.multiMissileTgtNum, 1, 10) },
                 { "maxMissilesOnTarget", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.maxMissilesOnTarget, 1, MissileFire.maxAllowableMissilesOnTarget) },
 
                 { "targetBias", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.targetBias, -10, 10) },
@@ -1360,6 +1361,24 @@ namespace BDArmory.UI
                     }
                     GUI.Label(new Rect(leftIndent + (contentWidth - 35), (guardLines * entryHeight), 35, entryHeight),
                         ActiveWeaponManager.multiTargetNum.ToString(), leftLabel);
+                    guardLines++;
+
+                    GUI.Label(new Rect(leftIndent, (guardLines * entryHeight), 85, entryHeight), Localizer.Format("#LOC_BDArmory_WMWindow_MultiMissileNum"), leftLabel);//"Max Turret targets "
+                    if (!NumFieldsEnabled)
+                    {
+                        ActiveWeaponManager.multiMissileTgtNum =
+                            GUI.HorizontalSlider(
+                                new Rect(leftIndent + 90, (guardLines * entryHeight), contentWidth - 90 - 38, entryHeight),
+                                ActiveWeaponManager.multiMissileTgtNum, 1, 10);
+                        ActiveWeaponManager.multiMissileTgtNum = Mathf.Round(ActiveWeaponManager.multiMissileTgtNum);
+                    }
+                    else
+                    {
+                        textNumFields["multiMissileTgtNum"].tryParseValue(GUI.TextField(new Rect(leftIndent + (90), (guardLines * entryHeight), contentWidth - 90 - 38, entryHeight), textNumFields["multiMissileTgtNum"].possibleValue, 2));
+                        ActiveWeaponManager.multiMissileTgtNum = (float)textNumFields["multiMissileTgtNum"].currentValue;
+                    }
+                    GUI.Label(new Rect(leftIndent + (contentWidth - 35), (guardLines * entryHeight), 35, entryHeight),
+                        ActiveWeaponManager.multiMissileTgtNum.ToString(), leftLabel);
                     guardLines++;
 
                     GUI.Label(new Rect(leftIndent, (guardLines * entryHeight), 85, entryHeight), Localizer.Format("#LOC_BDArmory_WMWindow_MissilesTgt"), leftLabel);//"Missiles/Tgt"
@@ -1978,6 +1997,7 @@ namespace BDArmory.UI
                             GUILayout.Label(Localizer.Format("#LOC_BDArmory_WMWindow_VisualRange_desc"), infoLinkStyle, GUILayout.Width(columnWidth - (leftIndent * 4) - 20)); //guard range desc
                             GUILayout.Label(Localizer.Format("#LOC_BDArmory_WMWindow_GunsRange_desc"), infoLinkStyle, GUILayout.Width(columnWidth - (leftIndent * 4) - 20)); //weapon range desc
                             GUILayout.Label(Localizer.Format("#LOC_BDArmory_WMWindow_MultiTargetNum_desc"), infoLinkStyle, GUILayout.Width(columnWidth - (leftIndent * 4) - 20)); //multiturrets desc
+                            GUILayout.Label(Localizer.Format("#LOC_BDArmory_WMWindow_MultiMissileTgtNum_desc"), infoLinkStyle, GUILayout.Width(columnWidth - (leftIndent * 4) - 20)); //multiturrets desc
                             GUILayout.Label(Localizer.Format("#LOC_BDArmory_WMWindow_MissilesTgt_desc"), infoLinkStyle, GUILayout.Width(columnWidth - (leftIndent * 4) - 20)); //multimissiles desc
                             GUILayout.Label(Localizer.Format("#LOC_BDArmory_WMWindow_TargetType_desc"), infoLinkStyle, GUILayout.Width(columnWidth - (leftIndent * 4) - 20)); //subsection targeting desc
                             GUILayout.Label(Localizer.Format("#LOC_BDArmory_WMWindow_EngageType_desc"), infoLinkStyle, GUILayout.Width(columnWidth - (leftIndent * 4) - 20)); //engagement toggles desc


### PR DESCRIPTION
-Fix AI GUI slider increments to match AI PAW.
-Add Dynamic Damping P/Y/R readouts to AI GUI.
-Fix ATG missiles not respecting maxMissilesPerTarget.
-Add Missile multi-targeting.
-Adds new Max Missile Tgts setting in WM to set max targets to engage with missiles.
-craft now once again get alarm SFX when incoming missiles. (might want to re-comment this out, idk)
-Fix ProcWing armor calculations.
-Adds missing FFAR rocket ammo to universal ammo boxes.
-Fix TOW missile FX.

Missile multi-targeting is working well enough I think it can see light of day; not noticing any remaining issues in my testing, though I'd like to have Josue/kurgan put it through the ringer with mod missiles to see what sort of edge cases there are/areas to improve.





