### PR TITLE
AI Target Permanence

### DIFF
--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -1321,7 +1321,7 @@ namespace BDArmory.Control
             yield return new WaitForFixedUpdate();
             typeof(BDModulePilotAI).GetField(name).SetValue(this, value);
         }
-        float timer = 0;
+        float targetStalenessTimer = 0;
         void FixedUpdate()
         {
             //floating origin and velocity offloading corrections
@@ -1331,19 +1331,19 @@ namespace BDArmory.Control
             }
             if (weaponManager.detectedTargetTimeout > weaponManager.targetScanInterval)
             {
-                timer += Time.fixedDeltaTime;
-                if (timer >= 50) //add some error to the predicted position every second
+                targetStalenessTimer += Time.fixedDeltaTime;
+                if (targetStalenessTimer >= 50) //add some error to the predicted position every second
                 {
-                    Vector3 staleTarget = new Vector3();
-                    staleTarget.x = UnityEngine.Random.Range(0f, (float)lastKnownVector.magnitude / 10);
-                    staleTarget.y = UnityEngine.Random.Range(0f, (float)lastKnownVector.magnitude / 10);
-                    staleTarget.z = UnityEngine.Random.Range(0f, (float)lastKnownVector.magnitude / 20);
-                    timer = 0;
+                    Vector3 staleTargetPosition = new Vector3();
+                    staleTargetPosition.x = UnityEngine.Random.Range(0f, (float)staleTargetVelocity.magnitude / 2);
+                    staleTargetPosition.y = UnityEngine.Random.Range(0f, (float)staleTargetVelocity.magnitude / 2);
+                    staleTargetPosition.z = UnityEngine.Random.Range((float)staleTargetVelocity.magnitude * 0.75f, (float)staleTargetVelocity.magnitude * 1.25f);
+                    targetStalenessTimer = 0;
                 }
             }
             else
             {
-                if (timer != 0) timer = 0;
+                if (targetStalenessTimer != 0) targetStalenessTimer = 0;
             }
         }
 
@@ -1689,8 +1689,8 @@ namespace BDArmory.Control
             return true;
         }
 
-        Vector3 staleTarget = Vector3.zero;
-        Vector3 lastKnownVector = Vector3.zero;
+        Vector3 staleTargetPosition = Vector3.zero;
+        Vector3 staleTargetVelocity = Vector3.zero;
         void FlyToTargetVessel(FlightCtrlState s, Vessel v)
         {
             Vector3 target = AIUtils.PredictPosition(v, TimeWarp.fixedDeltaTime);//v.CoM;
@@ -1704,7 +1704,7 @@ namespace BDArmory.Control
            
             if (weaponManager)
             {
-                if (weaponManager.detectedTargetTimeout <= weaponManager.targetScanInterval) lastKnownVector = Vector3.zero; //if actively tracking target, reset last known velocity vector
+                if (weaponManager.detectedTargetTimeout <= weaponManager.targetScanInterval) staleTargetVelocity = Vector3.zero; //if actively tracking target, reset last known velocity vector
                 missile = weaponManager.CurrentMissile;
                 if (missile != null)
                 {
@@ -1820,8 +1820,8 @@ namespace BDArmory.Control
                 }
                 if (weaponManager.detectedTargetTimeout > weaponManager.targetScanInterval) //lost track of target, but know it's in general area, simulate location estimate precision decay over time
                 {
-                    if (lastKnownVector == Vector3.zero) lastKnownVector = v.Velocity(); //if lost target, follow last known velocity vector
-                    target += (lastKnownVector * weaponManager.detectedTargetTimeout) + (staleTarget * weaponManager.detectedTargetTimeout);
+                    if (staleTargetVelocity == Vector3.zero) staleTargetVelocity = v.Velocity(); //if lost target, follow last known velocity vector
+                    target += (staleTargetVelocity * weaponManager.detectedTargetTimeout) + (staleTargetPosition * weaponManager.detectedTargetTimeout);
                 }
             }
 

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2515,8 +2515,9 @@ namespace BDArmory.Control
                 }
                 if (ml.warheadType == MissileBase.WarheadTypes.EMP || ml.warheadType == MissileBase.WarheadTypes.Nuke)
                 {
-                    float timeToImpact;
-                    MissileGuidance.GetAirToAirTarget(currentTarget.position, currentTarget.velocity, currentTarget.Vessel.acceleration_immediate, vessel, out timeToImpact);
+					MissileLauncher cm = missile as MissileLauncher;
+                    float thrust = cm == null ? 30 : cm.thrust;
+                    float timeToImpact = AIUtils.ClosestTimeToCPA(guardTarget, vessel.CoM, vessel.Velocity(), (thrust / missile.part.mass) * missile.GetForwardTransform(), 16);
                     if (ml.StandOffDistance > 0 && Vector3.Distance(transform.position + (vessel.Velocity() * timeToImpact), currentTarget.position + currentTarget.velocity) > ml.StandOffDistance) //if predicted craft position will be within blast radius when missile arrives, break off
                     {
                         DisengageAfterFiring = true;
@@ -4394,7 +4395,7 @@ namespace BDArmory.Control
                                 candidatePriority = Mathf.RoundToInt(mlauncher.priority);
                                 bool EMP = mlauncher.warheadType == MissileBase.WarheadTypes.EMP;
 
-                                if (EMP) continue;
+                                if (EMP && target.isDebilitated) continue;
                                 if (vessel.Splashed && (BDArmorySettings.BULLET_WATER_DRAG && FlightGlobals.getAltitudeAtPos(mlauncher.transform.position) < 0)) continue;
                                 if (targetWeapon != null && targetWeaponPriority > candidatePriority)
                                     continue; //keep higher priority weapon
@@ -4636,7 +4637,7 @@ namespace BDArmory.Control
                             int candidatePriority = Mathf.RoundToInt(Bomb.priority);
                             double srfSpeed = currentTarget.Vessel.horizontalSrfSpeed;
 
-                            if (EMP) continue;
+                            if (EMP && target.isDebilitated) continue;
                             if (targetWeapon != null && targetWeaponPriority > candidatePriority)
                                 continue; //keep higher priority weapon
                             if (distance < candidateYield)

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -731,6 +731,7 @@ namespace BDArmory.Damage
                             } //breaks when pWings are made stupidly large. Clamp HP to a maximum?
                             ArmorModified(null, null);
                         }
+                        if (isProcPart || isProcWing) hitpoints = Mathf.Clamp(hitpoints, 100, BDArmorySettings.MAX_PWING_HP);
 
                         switch (HullTypeNum)
                         {

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -169,6 +169,7 @@ Localization
         #LOC_BDArmory_Settings_TerrainAlertFrequency = Terrain Check Frequency
         #LOC_BDArmory_Settings_CameraSwitchFrequency = Camera Switch Frequency
         #LOC_BDArmory_Settings_DeathCameraInhibitPeriod = Death Camera Inhibit Period
+        #LOC_BDArmory_Settings_Max_PWing_HP = Max PWing HP
         #LOC_BDArmory_Settings_DisableRamming = Disable Ramming
         #LOC_BDArmory_Settings_DefaultFFATargeting = Default FFA Targeting
         #LOC_BDArmory_Settings_TagMode = Tag Mode

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -169,7 +169,7 @@ Localization
         #LOC_BDArmory_Settings_TerrainAlertFrequency = Terrain Check Frequency
         #LOC_BDArmory_Settings_CameraSwitchFrequency = Camera Switch Frequency
         #LOC_BDArmory_Settings_DeathCameraInhibitPeriod = Death Camera Inhibit Period
-        #LOC_BDArmory_Settings_Max_PWing_HP = Max PWing HP
+        #LOC_BDArmory_Settings_Max_PWing_HP = Max ProcPart HP
         #LOC_BDArmory_Settings_DisableRamming = Disable Ramming
         #LOC_BDArmory_Settings_DefaultFFATargeting = Default FFA Targeting
         #LOC_BDArmory_Settings_TagMode = Tag Mode

--- a/BDArmory/Radar/ModuleRadar.cs
+++ b/BDArmory/Radar/ModuleRadar.cs
@@ -330,6 +330,11 @@ namespace BDArmory.Radar
                 vrd.Current.UnlinkDisabledRadar(this);
             }
             vrd.Dispose();
+            using (var loadedvessels = BDATargetManager.LoadedVessels.GetEnumerator())
+                while (loadedvessels.MoveNext())
+                {
+                    BDATargetManager.ClearRadarReport(loadedvessels.Current, weaponManager); //reset radar contact status
+                }
         }
 
         void OnDestroy()

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -1034,6 +1034,7 @@ namespace BDArmory.Radar
                         // evaluate range
                         float distance = (loadedvessels.Current.CoM - position).magnitude / 1000f;                                      //TODO: Performance! better if we could switch to sqrMagnitude...
 
+                        BDATargetManager.ClearRadarReport(loadedvessels.Current, myWpnManager);
                         if (modeTryLock)    // LOCK/TRACK TARGET:
                         {
                             //evaluate if we can lock/track such a signature at that range
@@ -1049,7 +1050,7 @@ namespace BDArmory.Radar
                                     // detected by radar
                                     if (myWpnManager != null)
                                     {
-                                        BDATargetManager.ReportVessel(loadedvessels.Current, myWpnManager);
+                                        BDATargetManager.ReportVessel(loadedvessels.Current, myWpnManager, true);
                                     }
 
                                     // fill attempted locks array for locking later:
@@ -1090,7 +1091,7 @@ namespace BDArmory.Radar
                                     // detected by radar
                                     if (myWpnManager != null)
                                     {
-                                        BDATargetManager.ReportVessel(loadedvessels.Current, myWpnManager);
+                                        BDATargetManager.ReportVessel(loadedvessels.Current, myWpnManager, true);
                                     }
 
                                     // report scanned targets only
@@ -1241,6 +1242,8 @@ namespace BDArmory.Radar
                     Vector3 vesselDirection = loadedvessels.Current.transform.position - position;
 
                     float vesselDistance = (loadedvessels.Current.transform.position - position).sqrMagnitude;
+                    //BDATargetManager.ClearRadarReport(loadedvessels.Current, myWpnManager); //reset radar contact status
+
                     if (vesselDistance < maxDistance * maxDistance && Vector3.Angle(vesselProjectedDirection, lookDirection) < fov / 2f && Vector3.Angle(loadedvessels.Current.transform.position - position, -myWpnManager.transform.forward) < myWpnManager.guardAngle / 2f)
                     {
                         if (TerrainCheck(referenceTransform.position, loadedvessels.Current.transform.position))

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -126,7 +126,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_SPREAD = 5f;
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_BIAS = 0.16f;
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_HIT_MULTIPLIER = 2f;
-
+        [BDAPersistentSettingsField] public static float MAX_PWING_HP = 2500f;
         // Physics constants
         [BDAPersistentSettingsField] public static float GLOBAL_LIFT_MULTIPLIER = 0.25f;
         [BDAPersistentSettingsField] public static float GLOBAL_DRAG_MULTIPLIER = 6f;

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -22,6 +22,7 @@ namespace BDArmory.Targeting
         public MissileBase MissileBaseModule;
         public MissileFire weaponManager;
         Dictionary<BDTeam, List<MissileFire>> friendliesEngaging = new Dictionary<BDTeam, List<MissileFire>>();
+        public Dictionary<BDTeam, bool> detected = new Dictionary<BDTeam, bool>();
         public Dictionary<BDTeam, float> detectedTime = new Dictionary<BDTeam, float>();
 
         public float radarBaseSignature = -1;

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -687,7 +687,7 @@ namespace BDArmory.UI
                     db.Current.Value.Remove(target);
         }
 
-        public static void ReportVessel(Vessel v, MissileFire reporter)
+        public static void ReportVessel(Vessel v, MissileFire reporter, bool radar = false)
         {
             if (!v) return;
             if (!reporter) return;
@@ -703,6 +703,10 @@ namespace BDArmory.UI
                         {
                             info = v.gameObject.AddComponent<TargetInfo>();
                             info.detectedTime[reporter.Team] = Time.time;
+                            if (radar)
+                            {
+                                info.detected[reporter.Team] = true;
+                            }
                             break;
                         }
                     }
@@ -717,6 +721,10 @@ namespace BDArmory.UI
                             {
                                 info = v.gameObject.AddComponent<TargetInfo>();
                                 info.detectedTime[reporter.Team] = Time.time;
+                                if (radar)
+                                {
+                                    info.detected[reporter.Team] = true;
+                                }
                                 break;
                             }
                         }
@@ -727,7 +735,24 @@ namespace BDArmory.UI
             if (info && reporter.Team.IsEnemy(info.Team))
             {
                 AddTarget(info, reporter.Team);
-                info.detectedTime[reporter.Team] = Time.time;
+                info.detectedTime[reporter.Team] = Time.time; //time since last detected
+                if (radar)
+                {
+                    info.detected[reporter.Team] = true; //target is under radar detection
+                }
+            }
+        }
+
+        public static void ClearRadarReport(Vessel v, MissileFire reporter)
+        {
+            if (!v) return;
+            if (!reporter) return;
+
+            TargetInfo info = v.gameObject.GetComponent<TargetInfo>();
+
+            if (info && reporter.Team.IsEnemy(info.Team))
+            {
+                info.detected[reporter.Team] = false;
             }
         }
 

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -780,6 +780,7 @@ namespace BDArmory.UI
 
                 { "targetBias", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.targetBias, -10, 10) },
                 { "targetWeightRange", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.targetWeightRange, -10, 10) },
+                { "targetWeightAirPreference", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.targetWeightAirPreference, -10, 10) },
                 { "targetWeightATA", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.targetWeightATA, -10, 10) },
                 { "targetWeightAoD", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.targetWeightAoD, -10, 10) },
                 { "targetWeightAccel", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.targetWeightAccel,-10, 10) },

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1645,11 +1645,11 @@ namespace BDArmory.UI
                     }
                     else
                     {
-                        textNumFields["targetWeightRange"].tryParseValue(GUI.TextField(new Rect(leftIndent + (90), (priorityLines * entryHeight), contentWidth - 90 - 38, entryHeight), textNumFields["targetWeightRange"].possibleValue, 4));
-                        ActiveWeaponManager.targetWeightAirPreference = (float)textNumFields["targetWeightRange"].currentValue;
+                        textNumFields["targetWeightAirPreference"].tryParseValue(GUI.TextField(new Rect(leftIndent + (90), (priorityLines * entryHeight), contentWidth - 90 - 38, entryHeight), textNumFields["targetWeightAirPreference"].possibleValue, 4));
+                        ActiveWeaponManager.targetWeightAirPreference = (float)textNumFields["targetWeightAirPreference"].currentValue;
                     }
                     GUI.Label(new Rect(leftIndent + (contentWidth - 35), (priorityLines * entryHeight), 35, entryHeight),
-                        ActiveWeaponManager.targetWeightRange.ToString(), leftLabel);
+                        ActiveWeaponManager.targetWeightAirPreference.ToString(), leftLabel);
                     priorityLines++;
 
                     GUI.Label(new Rect(leftIndent, (priorityLines * entryHeight), 85, entryHeight), Localizer.Format("#LOC_BDArmory_WMWindow_targetAngletoTarget"), leftLabel); //target proximity"
@@ -2751,6 +2751,9 @@ namespace BDArmory.UI
                     GUI.Label(SLeftSliderRect(++line), $"{Localizer.Format("#LOC_BDArmory_Settings_DeathCameraInhibitPeriod")}:  ({(BDArmorySettings.DEATH_CAMERA_SWITCH_INHIBIT_PERIOD == 0 ? BDArmorySettings.CAMERA_SWITCH_FREQUENCY / 2f : BDArmorySettings.DEATH_CAMERA_SWITCH_INHIBIT_PERIOD)}s)", leftLabel); // Camera switch inhibit period after the active vessel dies.
                     BDArmorySettings.DEATH_CAMERA_SWITCH_INHIBIT_PERIOD = Mathf.RoundToInt(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.DEATH_CAMERA_SWITCH_INHIBIT_PERIOD, 0f, 10f));
                 }
+                GUI.Label(SLeftSliderRect(++line), $"{Localizer.Format("#LOC_BDArmory_Settings_Max_PWing_HP")}:  ({BDArmorySettings.MAX_PWING_HP})", leftLabel); // Max PWing HP
+                BDArmorySettings.MAX_PWING_HP = GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.MAX_PWING_HP, 100, 10000);
+                BDArmorySettings.MAX_PWING_HP = Mathf.Round(BDArmorySettings.MAX_PWING_HP / 100) * 100;
 
                 line += 0.5f;
             }


### PR DESCRIPTION
Improvements
-AI will now head to target's last known position if contact lost (out of sight range/angle/radar detection), with accuracy of predicted position decaying over time.
-Adds Proc Wing/ProcPart HP cap setting to clamp proc HP to a configurable maximum.
-AI will now enable radars when guard mode enabled.
Misc Fixes
-Fix target A2A/A2G preference GUI labels
-Fix some EMP weapon Selection logic
-Fix AI withdrawal after firing nukes/EMPs at close range