### PR TITLE
AI and Armor fixes

### DIFF
--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -923,6 +923,7 @@ namespace BDArmory.Bullets
                         if (fuzeType == BulletFuzeTypes.Impact || fuzeType == BulletFuzeTypes.Timed)
                         {
                             ExplosiveDetonation(hitPart, hit, bulletRay);
+                            ProjectileUtils.CalculateShrapnelDamage(hitPart, hit, caliber, tntMass, 0, sourceVesselName, ExplosionSourceType.Bullet, bulletMass, penetrationFactor); //calc daamge from bullet exploding 
                         }
                         if (fuzeType == BulletFuzeTypes.Delay)
                         {
@@ -957,6 +958,7 @@ namespace BDArmory.Bullets
                         StopCoroutine(DelayedDetonationRoutine());
                     }
                     ExplosiveDetonation(hitPart, hit, bulletRay);
+                    ProjectileUtils.CalculateShrapnelDamage(hitPart, hit, caliber, tntMass, 0, sourceVesselName, ExplosionSourceType.Bullet, bulletMass, penetrationFactor); //calc daamge from bullet exploding 
                     ProjectileUtils.ApplyScore(hitPart, sourceVesselName, distanceTraveled, 0, bullet.name, ExplosionSourceType.Bullet, penTicker > 0 ? false : true);
                     hasDetonated = true;
                     KillBullet();

--- a/BDArmory/Competition/BDACompetitionMode.cs
+++ b/BDArmory/Competition/BDACompetitionMode.cs
@@ -718,8 +718,8 @@ namespace BDArmory.Competition
                     if (!pilot.weaponManager.guardMode)
                         pilot.weaponManager.ToggleGuardMode();
 
-                    foreach (var leader in leaders)
-                        BDATargetManager.ReportVessel(pilot.vessel, leader.weaponManager);
+                    //foreach (var leader in leaders)
+                        //BDATargetManager.ReportVessel(pilot.vessel, leader.weaponManager);
 
                     pilot.ReleaseCommand();
                     pilot.CommandAttack(centerGPS);

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -1325,11 +1325,12 @@ namespace BDArmory.Control
         void FixedUpdate()
         {
             //floating origin and velocity offloading corrections
+            if (!HighLogic.LoadedSceneIsFlight) return;
             if (!FloatingOrigin.Offset.IsZero() || !Krakensbane.GetFrameVelocity().IsZero())
             {
                 if (lastTargetPosition != null) lastTargetPosition -= FloatingOrigin.OffsetNonKrakensbane;
             }
-            if (weaponManager.detectedTargetTimeout > weaponManager.targetScanInterval)
+            if (weaponManager && weaponManager.guardMode && weaponManager.detectedTargetTimeout > weaponManager.targetScanInterval)
             {
                 staleTargetTimer += Time.fixedDeltaTime;
                 if (staleTargetTimer >= 50) //add some error to the predicted position every second
@@ -3447,7 +3448,7 @@ namespace BDArmory.Control
                 else
                 {
                     SetStatus("Attack");
-                    FlyOrbit(s, assignedPositionGeo, 4500, maxSpeed, ClockwiseOrbit);
+                    FlyOrbit(s, assignedPositionGeo, 2500, maxSpeed, ClockwiseOrbit);
                 }
             }
         }

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -5256,7 +5256,7 @@ namespace BDArmory.Control
             // but to prevent AI from stopping an engagement just because a target dropped behind a small hill 5 seconds ago, clamp the timeout to 30 seconds
             // i.e. let's have at least some object permanence :)
             // If we can't directly see the target via sight or radar, AI will head to last known position of target, based on target's vector at time contact was lost,
-            //with precision of estimated position degrading over time.
+            // with precision of estimated position degrading over time.
 
             // can we get a visual sight of the target?
             if ((target.Vessel.transform.position - transform.position).sqrMagnitude < guardRange * guardRange &&

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -731,7 +731,7 @@ namespace BDArmory.Damage
                             } //breaks when pWings are made stupidly large. Clamp HP to a maximum?
                             ArmorModified(null, null);
                         }
-                        if (isProcPart || isProcWing) hitpoints = Mathf.Clamp(hitpoints, 100, BDArmorySettings.MAX_PWING_HP);
+                        if ((isProcPart || isProcWing) && BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.MAX_PWING_HP >= 100) hitpoints = Mathf.Clamp(hitpoints, 100, BDArmorySettings.MAX_PWING_HP);
 
                         switch (HullTypeNum)
                         {

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -11,6 +11,9 @@ FIXES
 - Fixes Proc Armor bugs.
 - Fixes broken hydraulics on Chaingun, Hydra Turret and Patriot Launcher models.
 - Fixes custom armor volumes in .cfgs being ignored.
+- EMP AMRAAM and EMP Hellfire missiles now have different names to differentiate them from vanilla variants.
+- Fixes Armor explosion resistance.
+- Armor panels no longer indestructible.
 
 IMPROVEMENTS
 - General:
@@ -26,6 +29,7 @@ IMPROVEMENTS
 	- Refactor the debug settings to be more specific and to have an on-screen only debug labels.
 	- Adds SelfSealingTanks/Firebottle options to Proc Part Tanks.
 	- Adds Oblique Triangle Proc Armor panel.
+	- Proc Armor nodes on triangular panels now orient themselves to current angle of panel edge.
 	- Bullets now ignore flags.
 	- Adds new CameraTools switching modes, right click the cameraTools button [A] on the VesselSwitcherGUI.
 		- [S] - Camera will autoswitch to vessel with highest score.
@@ -34,6 +38,8 @@ IMPROVEMENTS
 	- Update the continuous spawning log parsing script.
 	- Add some extra layer masks (internal kerbals are 1<<16, wheels are 1<<26).
 	- Add a BodyUtils.GetTerrainAltitudeAtPos function.
+	- Adds setting to clamp proc part/proc wing max HP to a configurable maximum.
+	- Adds UI Icon team color reset button.
 - AI:
 	- Add a 5° deadzone around being on target for dynamic damping to avoid feed-back loop in PID.
 	- Add a check for requested extending already being satisfied.
@@ -47,6 +53,8 @@ IMPROVEMENTS
 	- Add Air/Ground target preference weighting to Target Priorities.
 	- Make the extend toggle apply to air-to-air missiles as well as air-to-air guns.
 	- Update the AI GUI help text for the current extending settings.
+	- AI will now activate radars when enabling Guard Mode even if not carrying radar missiles.
+	- Adds Target Permanence; AIs that lose sight of target craft will head towards target's estimated position based on last known position and velocity vector.
 - GameModes:
 	- Waypoints:
 		- Add support for multiple waypoint gate models.
@@ -74,6 +82,8 @@ IMPROVEMENTS
 	- Add charge-up mechanic for weapons.
 		- Adds new .cfg fields: ChargeTime = n; hasChargeAnimation = T/F; chargeAnimName = animName
 	- Weapon debug lines now account for frame velocity and flight integrator delay.
+	- Rockets now support beehive/nuclear warhead options.
+	- EMP weapons fired at targets with AI/ WM off will not cause them to activate when target reboots.
 	- Missiles:
 		- Adds Missile multi-targeting.
 		- Adds new Max Missile Tgts setting in WM to set max targets to engage with missiles.

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -169,7 +169,7 @@ Localization
         #LOC_BDArmory_Settings_TerrainAlertFrequency = Terrain Check Frequency
         #LOC_BDArmory_Settings_CameraSwitchFrequency = Camera Switch Frequency
         #LOC_BDArmory_Settings_DeathCameraInhibitPeriod = Death Camera Inhibit Period
-        #LOC_BDArmory_Settings_Max_PWing_HP = Max PWing HP
+        #LOC_BDArmory_Settings_Max_PWing_HP = Max ProcPart HP
         #LOC_BDArmory_Settings_DisableRamming = Disable Ramming
         #LOC_BDArmory_Settings_DefaultFFATargeting = Default FFA Targeting
         #LOC_BDArmory_Settings_TagMode = Tag Mode

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/localization-en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/localization-en-us.cfg
@@ -39,7 +39,7 @@ Localization
 		#loc_BDArmory_part_bahaAim120_description = Medium range radar guided homing missile.
 
 		//AIM-120 AMRAAM EMP Missile
-		#loc_BDArmory_part_bahaEMP120_title = AIM-120 AMRAAM Missile
+		#loc_BDArmory_part_bahaEMP120_title = AIM-120 AMRAAM EMP Missile
 		//Medium range radar guided homing missile.
 		#loc_BDArmory_part_bahaEMP120_description = Medium range radar guided homing missile equipped with the latest miniaturized EMP warhead.  While the pulse radius is not huge (100 meters), it is quite effective. The missile does minimal structural damage, but renders all electronic devices within it's blast radius inoperable.
 

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/aim-120/amraam_emp.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/aim-120/amraam_emp.cfg
@@ -50,7 +50,7 @@ PART
 	{
 		name = MissileLauncher
 
-		shortName = AIM-120
+		shortName = EMP AIM-120
 
 		thrust = 55 //KN thrust during boost phase
 		cruiseThrust = 25 //thrust during cruise phase

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/hellfireMissile/hellfire_emp.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/hellfireMissile/hellfire_emp.cfg
@@ -49,7 +49,7 @@ PART
 	{
 		name = MissileLauncher
 
-		shortName = AGM-114R
+		shortName = EMP Hellfire
 
 		thrust = 10 //KN thrust during boost phase
 		cruiseThrust = 0 //thrust during cruise phase

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -649,7 +649,7 @@ namespace BDArmory.FX
                 }
                 else //majority of force concentrated in blast cone for shaped warheads, not going to apply much force to stuff outside 
                 {
-                    if (realDistance < Range / 2)
+                    if (realDistance > Range / 2) //further away than half the blast range, falloff blast effect outside primary AoE
                     {
                         blastInfo = BlastPhysicsUtils.CalculatePartBlastEffects(part, realDistance, vesselMass * 1000f, Power / 4, Range / 2);
                     }
@@ -776,7 +776,7 @@ namespace BDArmory.FX
                         }
                         else
                         {
-                            if ((part == hitpart && ProjectileUtils.IsArmorPart(part)) || !ProjectileUtils.CalculateExplosiveArmorDamage(part, blastInfo.TotalPressure, SourceVesselName, eventToExecute.Hit, ExplosionSource)) //false = armor blowthrough or bullet detonating inside part
+                            if ((part == hitpart && ProjectileUtils.IsArmorPart(part)) || !ProjectileUtils.CalculateExplosiveArmorDamage(part, blastInfo.TotalPressure, SourceVesselName, eventToExecute.Hit, ExplosionSource, Range-realDistance)) //false = armor blowthrough or bullet detonating inside part
                             {
                                 if (RA != null && !RA.NXRA) //blast wave triggers RA; detonate all remaining RA sections
                                 {
@@ -790,7 +790,7 @@ namespace BDArmory.FX
                                     damage = part.AddExplosiveDamage(blastInfo.Damage, Caliber, ExplosionSource, dmgMult);
                                     if (part == hitpart && ProjectileUtils.IsArmorPart(part)) //deal armor damage to armor panel, since we didn't do that earlier
                                     {
-                                        ProjectileUtils.CalculateExplosiveArmorDamage(part, blastInfo.TotalPressure, SourceVesselName, eventToExecute.Hit, ExplosionSource); 
+                                        ProjectileUtils.CalculateExplosiveArmorDamage(part, blastInfo.TotalPressure, SourceVesselName, eventToExecute.Hit, ExplosionSource, Range - realDistance); 
                                     }
                                     penetrationFactor = damage / 10; //closer to the explosion/greater magnitude of the explosion at point blank, the greater the blowthrough
                                     if (float.IsNaN(damage)) Debug.LogError("DEBUG NaN damage!");

--- a/BDArmory/FX/NukeFX.cs
+++ b/BDArmory/FX/NukeFX.cs
@@ -450,7 +450,7 @@ namespace BDArmory.FX
                         }
                         else
                         {
-                            if (!ProjectileUtils.CalculateExplosiveArmorDamage(part, blastImpulse, SourceVesselName, eventToExecute.Hit, ExplosionSource)) //false = armor blowthrough
+                            if (!ProjectileUtils.CalculateExplosiveArmorDamage(part, blastImpulse, SourceVesselName, eventToExecute.Hit, ExplosionSource, thermalRadius - realDistance)) //false = armor blowthrough
                             {
                                 damage = part.AddExplosiveDamage(blastDamage, 1, ExplosionSource, 1);
                             }

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -780,6 +780,7 @@ namespace BDArmory.UI
 
                 { "targetBias", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.targetBias, -10, 10) },
                 { "targetWeightRange", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.targetWeightRange, -10, 10) },
+                { "targetWeightAirPreference", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.targetWeightAirPreference, -10, 10) },
                 { "targetWeightATA", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.targetWeightATA, -10, 10) },
                 { "targetWeightAoD", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.targetWeightAoD, -10, 10) },
                 { "targetWeightAccel", gameObject.AddComponent<NumericInputField>().Initialise(0, ActiveWeaponManager.targetWeightAccel,-10, 10) },

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -2752,8 +2752,8 @@ namespace BDArmory.UI
                     GUI.Label(SLeftSliderRect(++line), $"{Localizer.Format("#LOC_BDArmory_Settings_DeathCameraInhibitPeriod")}:  ({(BDArmorySettings.DEATH_CAMERA_SWITCH_INHIBIT_PERIOD == 0 ? BDArmorySettings.CAMERA_SWITCH_FREQUENCY / 2f : BDArmorySettings.DEATH_CAMERA_SWITCH_INHIBIT_PERIOD)}s)", leftLabel); // Camera switch inhibit period after the active vessel dies.
                     BDArmorySettings.DEATH_CAMERA_SWITCH_INHIBIT_PERIOD = Mathf.RoundToInt(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.DEATH_CAMERA_SWITCH_INHIBIT_PERIOD, 0f, 10f));
                 }
-                GUI.Label(SLeftSliderRect(++line), $"{Localizer.Format("#LOC_BDArmory_Settings_Max_PWing_HP")}:  ({BDArmorySettings.MAX_PWING_HP})", leftLabel); // Max PWing HP
-                BDArmorySettings.MAX_PWING_HP = GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.MAX_PWING_HP, 100, 10000);
+                GUI.Label(SLeftSliderRect(++line), $"{Localizer.Format("#LOC_BDArmory_Settings_Max_PWing_HP")}:  {(BDArmorySettings.MAX_PWING_HP >= 100 ? (BDArmorySettings.MAX_PWING_HP.ToString()) : "Unclamped")}", leftLabel); // Max PWing HP
+                BDArmorySettings.MAX_PWING_HP = GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.MAX_PWING_HP, 0, 10000);
                 BDArmorySettings.MAX_PWING_HP = Mathf.Round(BDArmorySettings.MAX_PWING_HP / 100) * 100;
 
                 line += 0.5f;

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -1323,8 +1323,9 @@ namespace BDArmory.Weapons
             if (hasFireAnimation)
             {
                 List<string> animList = BDAcTools.ParseNames(fireAnimName);
-                fireState = new AnimationState[animList.Count]; //this should become animList.Count, for cases where there's a bultibarrel weapon with a single fireanim
-                for (int i = 0; i < fireTransforms.Length; i++)
+                fireState = new AnimationState[animList.Count]; //this should become animList.Count, for cases where there's a multibarrel weapon with a single fireanim
+                //for (int i = 0; i < fireTransforms.Length; i++)
+                for (int i = 0; i < animList.Count; i++)
                 {
                     try
                     {


### PR DESCRIPTION
FIXES & IMPROVEMENTS:
-Add check for vessels that were off at time of getting EMP'd to prevent them from turning on when rebooting
-Change EMP AMRAAM/Hellfire titles & shortnames to differentiate them from vanilla variants
-Fix Armor explosion resistance; explosions will no longer be completely blocked by just a few mm of armor
-Fix Armor reduction calcs, armor panels now properly degrade and get destroyed after taking too much punishment

Internal:
-Fix Square Panel node NREs, orientations.
-Fix Iso/Scalene tri toggle button appearing in Flight/on square panels
-Fix AnimState Error message on multibarrel weapons with single fireAnim
-Fix AI targeting issue at competition start when craft spawn outside detection range of each other
-ProcWing HP cap now linked to the RUNWAY_PROJECT setting, and can be disabled if RWP enabled