### PR TITLE
Fix for M1 Mac Mathf.Sqrt Issue

### DIFF
--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -872,7 +872,7 @@ namespace BDArmory.Bullets
                             {
                                 if (hitAngle < 80) //ERA isn't going to do much against near-perpendicular hits
                                 {
-                                    caliber = Mathf.Sqrt((caliber * (((bulletMass * 1000) / ((caliber * caliber * Mathf.PI / 400) * 19)) + 1) * 4) / Mathf.PI); //increase caliber to sim sabot hitting perpendicualr instead of point-first
+                                    caliber = BDAMath.Sqrt((caliber * (((bulletMass * 1000) / ((caliber * caliber * Mathf.PI / 400) * 19)) + 1) * 4) / Mathf.PI); //increase caliber to sim sabot hitting perpendicualr instead of point-first
                                     bulletMass /= 2; //sunder sabot
                                                      //RA isn't going to stop sabot, but underlying part's armor will (probably)
                                     if (BDArmorySettings.DEBUG_ARMOR) Debug.Log("[BDArmory.PooledBullet]: Sabot caliber and mass now: " + caliber + ", " + bulletMass);
@@ -991,7 +991,7 @@ namespace BDArmory.Bullets
                 }
                 else
                 {
-                    float cockpitPen = (float)(16f * impactVelocity.magnitude * Mathf.Sqrt(bulletMass / 1000) / Mathf.Sqrt(caliber) * apBulletMod); //assuming a 20mm steel armor plate for cockpit armor
+                    float cockpitPen = (float)(16f * impactVelocity.magnitude * BDAMath.Sqrt(bulletMass / 1000) / BDAMath.Sqrt(caliber) * apBulletMod); //assuming a 20mm steel armor plate for cockpit armor
                     ProjectileUtils.ApplyDamage(hitPart, hit, dmgMult, penetrationFactor, caliber, bulletMass, currentVelocity.magnitude, viableBullet ? bulletDmgMult : bulletDmgMult / 2, distanceTraveled, explosive, incendiary, hasRicocheted, sourceVessel, bullet.name, team, ExplosionSourceType.Bullet, penTicker > 0 ? false : true, partsHit.Contains(hitPart) ? false : true, (cockpitPen > Mathf.Max(20 / anglemultiplier, 1)) ? true : false);
                     //need to add a check for if the bullet has already struck the part, since it doesn't make sense for some battledamage to apply on the second hit from the bullet exiting the part - wings/ctrl srfs, pilot kills, subsystem damage
                 }
@@ -1143,7 +1143,7 @@ namespace BDArmory.Bullets
                 pBullet.ballisticCoefficient = subMunitionType.bulletMass / (((Mathf.PI * 0.25f * subMunitionType.caliber * subMunitionType.caliber) / 1000000f) * 0.295f);
                 pBullet.timeElapsedSinceCurrentSpeedWasAdjusted = 0;
                 pBullet.timeToLiveUntil = 4000 / bulletVelocity * 1.1f + Time.time;
-                Vector3 firedVelocity = VectorUtils.GaussianDirectionDeviation(currentVelocity.normalized, (subMunitionType.subProjectileCount / Mathf.Sqrt((currentVelocity * dragVelocityFactor).magnitude / 10))) * (subMunitionType.bulletVelocity / 10); //more subprojectiles = wider spread, higher base velocity = tighter spread
+                Vector3 firedVelocity = VectorUtils.GaussianDirectionDeviation(currentVelocity.normalized, (subMunitionType.subProjectileCount / BDAMath.Sqrt((currentVelocity * dragVelocityFactor).magnitude / 10))) * (subMunitionType.bulletVelocity / 10); //more subprojectiles = wider spread, higher base velocity = tighter spread
                 pBullet.currentVelocity = (GetDragAdjustedVelocity() + Krakensbane.GetFrameVelocityV3f()) + firedVelocity; // use the real velocity, w/o offloading
                 pBullet.sourceWeapon = sourceWeapon;
                 pBullet.sourceVessel = sourceVessel;

--- a/BDArmory/Ammo/PooledRocket.cs
+++ b/BDArmory/Ammo/PooledRocket.cs
@@ -503,7 +503,7 @@ namespace BDArmory.Bullets
                             }
                             else
                             {
-                                float cockpitPen = (float)(16f * impactVelocity * Mathf.Sqrt(rocketMass) / Mathf.Sqrt(caliber));
+                                float cockpitPen = (float)(16f * impactVelocity * BDAMath.Sqrt(rocketMass) / BDAMath.Sqrt(caliber));
                                 if (cockpitPen > Mathf.Max(20 / anglemultiplier, 1))
                                     ProjectileUtils.ApplyDamage(hitPart, hit, dmgMult, penetrationFactor, caliber, rocketMass * 1000, impactVelocity, bulletDmgMult, distanceFromStart, explosive, incendiary, false, sourceVessel, rocketName, team, ExplosionSourceType.Rocket, penTicker > 0 ? false : true, penTicker > 0 ? false : true, (cockpitPen > Mathf.Max(20 / anglemultiplier, 1)) ? true : false);
                                 if (!explosive)
@@ -858,7 +858,7 @@ namespace BDArmory.Bullets
                     pBullet.ballisticCoefficient = sBullet.bulletMass / (((Mathf.PI * 0.25f * sBullet.caliber * sBullet.caliber) / 1000000f) * 0.295f);
                     pBullet.timeElapsedSinceCurrentSpeedWasAdjusted = 0;
                     pBullet.timeToLiveUntil = 4000 / sBullet.bulletVelocity * 1.1f + Time.time;
-                    Vector3 firedVelocity = VectorUtils.GaussianDirectionDeviation(currentVelocity.normalized, (sBullet.subProjectileCount / Mathf.Sqrt(currentVelocity.magnitude / 10))) * (sBullet.bulletVelocity / 10); //more subprojectiles = wider spread, higher base velocity = tighter spread
+                    Vector3 firedVelocity = VectorUtils.GaussianDirectionDeviation(currentVelocity.normalized, (sBullet.subProjectileCount / BDAMath.Sqrt(currentVelocity.magnitude / 10))) * (sBullet.bulletVelocity / 10); //more subprojectiles = wider spread, higher base velocity = tighter spread
                     pBullet.currentVelocity = (currentVelocity + Krakensbane.GetFrameVelocityV3f()) + firedVelocity; // use the real velocity, w/o offloading
                     pBullet.sourceWeapon = sourceWeapon;
                     pBullet.sourceVessel = sourceVessel;

--- a/BDArmory/Competition/BDACompetitionMode.cs
+++ b/BDArmory/Competition/BDACompetitionMode.cs
@@ -1870,7 +1870,7 @@ namespace BDArmory.Competition
             // Example usage of UpcomingCollisions(). Note that the timeToCPA values are only updated after an interval of half the current timeToCPA.
             // if (competitionIsActive)
             //     foreach (var upcomingCollision in UpcomingCollisions(100f).Take(3))
-            //         Debug.Log("[BDArmory.BDACompetitionMode]: Upcoming potential collision between " + upcomingCollision.Key.Item1 + " and " + upcomingCollision.Key.Item2 + " at distance " + Mathf.Sqrt(upcomingCollision.Value.Item1) + "m in " + upcomingCollision.Value.Item2 + "s.");
+            //         Debug.Log("[BDArmory.BDACompetitionMode]: Upcoming potential collision between " + upcomingCollision.Key.Item1 + " and " + upcomingCollision.Key.Item2 + " at distance " + BDAMath.Sqrt(upcomingCollision.Value.Item1) + "m in " + upcomingCollision.Value.Item2 + "s.");
             var now = Planetarium.GetUniversalTime();
             if (now < nextUpdateTick)
                 return;
@@ -2257,7 +2257,7 @@ namespace BDArmory.Competition
                 int maxVesselsActive = (ContinuousSpawning.Instance.vesselsSpawningContinuously && BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS > 0) ? BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS : Scores.Players.Count;
                 double time = now - competitionStartTime;
                 gravityMultiplier = 1f + 7f * (float)(Scores.deathCount % maxVesselsActive) / (float)(maxVesselsActive - 1); // From 1G to 8G.
-                gravityMultiplier += ContinuousSpawning.Instance.vesselsSpawningContinuously ? Mathf.Sqrt(5f - 5f * Mathf.Cos((float)time / 600f * Mathf.PI)) : Mathf.Sqrt((float)time / 60f); // Plus up to 3.16G.
+                gravityMultiplier += ContinuousSpawning.Instance.vesselsSpawningContinuously ? BDAMath.Sqrt(5f - 5f * Mathf.Cos((float)time / 600f * Mathf.PI)) : BDAMath.Sqrt((float)time / 60f); // Plus up to 3.16G.
                 PhysicsGlobals.GraviticForceMultiplier = (double)gravityMultiplier;
                 VehiclePhysics.Gravity.Refresh();
                 if (Mathf.RoundToInt(10 * gravityMultiplier) != Mathf.RoundToInt(10 * lastGravityMultiplier)) // Only write a message when it shows something different.

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -2082,7 +2082,7 @@ namespace BDArmory.Control
                 var m = Vector3.Cross(n, upDirection).normalized; // cos(theta) = dot(m,v).
                 if (m.magnitude < 0.1f) m = upDirection; // In case n and upDirection are colinear.
                 var a = Vector3.Dot(n, upDirection); // sin(phi) = dot(n,up)
-                var b = Mathf.Sqrt(1f - a * a); // cos(phi) = sqrt(1-sin(phi)^2)
+                var b = BDAMath.Sqrt(1f - a * a); // cos(phi) = sqrt(1-sin(phi)^2)
                 var r = turnRadius * turnRadiusTwiddleFactorMin; // Radius of turning circle.
                 var h = r * (1 + Vector3.Dot(m, vessel.srf_vel_direction)) * b; // Required altitude: h = r * (1+cos(theta)) * cos(phi).
                 if (vessel.radarAltitude < h) // Too low for this manoeuvre.
@@ -2804,7 +2804,7 @@ namespace BDArmory.Control
                         else
                         { terrainAlertDirection = Vector3.ProjectOnPlane(vessel.srf_vel_direction, terrainAlertNormal).normalized; }
                         float sinTheta = Math.Min(0.0f, Vector3.Dot(vessel.srf_vel_direction, terrainAlertNormal)); // sin(theta) (measured relative to the plane of the surface).
-                        float oneMinusCosTheta = 1.0f - Mathf.Sqrt(Math.Max(0.0f, 1.0f - sinTheta * sinTheta));
+                        float oneMinusCosTheta = 1.0f - BDAMath.Sqrt(Math.Max(0.0f, 1.0f - sinTheta * sinTheta));
                         turnRadiusTwiddleFactor = (turnRadiusTwiddleFactorMin + turnRadiusTwiddleFactorMax) / 2.0f - (turnRadiusTwiddleFactorMax - turnRadiusTwiddleFactorMin) / 2.0f * Vector3.Dot(terrainAlertNormal, -vessel.transform.forward); // This would depend on roll rate (i.e., how quickly the vessel can reorient itself to perform the terrain avoidance maneuver) and probably other things.
                         float controlLagCompensation = Mathf.Max(0f, -Vector3.Dot(AIUtils.PredictPosition(vessel, controlLagTime * turnRadiusTwiddleFactor) - vessel.transform.position, terrainAlertNormal)); // Include twiddle factor as more re-orienting requires more control surface movement.
                         terrainAlertThreshold = turnRadiusTwiddleFactor * turnRadius * oneMinusCosTheta + controlLagCompensation;
@@ -2841,7 +2841,7 @@ namespace BDArmory.Control
                     float sinTheta = Vector3.Dot(vessel.srf_vel_direction, upDirection); // sin(theta) (measured relative to the ocean surface).
                     if (sinTheta < 0f) // Heading downwards
                     {
-                        float oneMinusCosTheta = 1.0f - Mathf.Sqrt(Math.Max(0.0f, 1.0f - sinTheta * sinTheta));
+                        float oneMinusCosTheta = 1.0f - BDAMath.Sqrt(Math.Max(0.0f, 1.0f - sinTheta * sinTheta));
                         turnRadiusTwiddleFactor = (turnRadiusTwiddleFactorMin + turnRadiusTwiddleFactorMax) / 2.0f - (turnRadiusTwiddleFactorMax - turnRadiusTwiddleFactorMin) / 2.0f * Vector3.Dot(upDirection, -vessel.transform.forward); // This would depend on roll rate (i.e., how quickly the vessel can reorient itself to perform the terrain avoidance maneuver) and probably other things.
                         float controlLagCompensation = Mathf.Max(0f, -Vector3.Dot(AIUtils.PredictPosition(vessel, controlLagTime * turnRadiusTwiddleFactor) - vessel.transform.position, upDirection)); // Include twiddle factor as more re-orienting requires more control surface movement.
                         terrainAlertThreshold = turnRadiusTwiddleFactor * turnRadius * oneMinusCosTheta + controlLagCompensation;

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -84,7 +84,7 @@ namespace BDArmory.FX
         {
             StartTime = Time.time;
             disabled = false;
-            MaxTime = Mathf.Sqrt((Range / ExplosionVelocity) * 3f) * 2f; // Scale MaxTime to get a reasonable visualisation of the explosion.
+            MaxTime = BDAMath.Sqrt((Range / ExplosionVelocity) * 3f) * 2f; // Scale MaxTime to get a reasonable visualisation of the explosion.
             blastRange = warheadType == WarheadTypes.Standard ? Range * 2 : Range; //to properly account for shrapnel hits when compiling list of hit parts from the spherecast
             if (!isFX)
             {

--- a/BDArmory/FX/NukeFX.cs
+++ b/BDArmory/FX/NukeFX.cs
@@ -82,8 +82,8 @@ namespace BDArmory.FX
         private void OnEnable()
         {
             StartTime = Time.time;
-            MaxTime = Mathf.Sqrt((thermalRadius / ExplosionVelocity) * 3f) * 2f; // Scale MaxTime to get a reasonable visualisation of the explosion.
-            scale = Mathf.Sqrt(400 * (6 * yield)) / 219;
+            MaxTime = BDAMath.Sqrt((thermalRadius / ExplosionVelocity) * 3f) * 2f; // Scale MaxTime to get a reasonable visualisation of the explosion.
+            scale = BDAMath.Sqrt(400 * (6 * yield)) / 219;
             if (BDArmorySettings.DEBUG_DAMAGE)
             {
                 Debug.Log("[BDArmory.NukeFX]: Explosion started tntMass: {" + yield + "}  BlastRadius: {" + thermalRadius + "} StartTime: {" + StartTime + "}, Duration: {" + MaxTime + "}");
@@ -103,11 +103,11 @@ namespace BDArmory.FX
                 //above 10km, emp radius can easily reach 100s of km. But that's no fun, so...
                 if (FlightGlobals.getAltitudeAtPos(transform.position) < 10000)
                 {
-                    EMPRadius = Mathf.Sqrt(yield) * 500;
+                    EMPRadius = BDAMath.Sqrt(yield) * 500;
                 }
                 else
                 {
-                    EMPRadius = Mathf.Sqrt(yield) * 1000;
+                    EMPRadius = BDAMath.Sqrt(yield) * 1000;
                 }
 
                 pEmitters = gameObject.GetComponentsInChildren<KSPParticleEmitter>();

--- a/BDArmory/FX/SeismicChargeFX.cs
+++ b/BDArmory/FX/SeismicChargeFX.cs
@@ -1,5 +1,6 @@
 using System;
 using BDArmory.Extensions;
+using BDArmory.Utils;
 using UnityEngine;
 
 namespace BDArmory.FX
@@ -30,7 +31,7 @@ namespace BDArmory.FX
             audioSource.maxDistance = 5000;
             audioSource.dopplerLevel = 0f;
             audioSource.pitch = UnityEngine.Random.Range(0.93f, 1f);
-            audioSource.volume = Mathf.Sqrt(originalShipVolume);
+            audioSource.volume = BDAMath.Sqrt(originalShipVolume);
 
             audioSource.PlayOneShot(GameDatabase.Instance.GetAudioClip("BDArmory/Sounds/seismicCharge"));
 

--- a/BDArmory/GameModes/Asteroids.cs
+++ b/BDArmory/GameModes/Asteroids.cs
@@ -311,7 +311,7 @@ namespace BDArmory.GameModes
                         asteroid.Splashed = false;
                         var direction = Vector3.ProjectOnPlane(Quaternion.AngleAxis((float)RNG.NextDouble() * 360f, upDirection) * refDirection, upDirection).normalized;
                         var x = (float)RNG.NextDouble();
-                        var distance = Mathf.Sqrt(1f - x) * radius;
+                        var distance = BDAMath.Sqrt(1f - x) * radius;
                         StartCoroutine(RepositionWhenReady(asteroid, direction * distance));
                     }
                     --spawnRateTracker;
@@ -344,7 +344,7 @@ namespace BDArmory.GameModes
                 {
                     foreach (var vessel in LoadedVesselSwitcher.Instance.WeaponManagers.SelectMany(tm => tm.Value).Where(wm => wm != null && wm.vessel != null).Select(wm => wm.vessel))
                     { maxSqrDistance = Mathf.Max(maxSqrDistance, (vessel.transform.position - averagePosition).sqrMagnitude); }
-                    radius = maxSqrDistance > 5e5f ? Mathf.Sqrt(maxSqrDistance) * 1.5f : 1000f;
+                    radius = maxSqrDistance > 5e5f ? BDAMath.Sqrt(maxSqrDistance) * 1.5f : 1000f;
                 }
             }
             else
@@ -715,7 +715,7 @@ namespace BDArmory.GameModes
             {
                 var direction = Vector3.ProjectOnPlane(Quaternion.AngleAxis((float)RNG.NextDouble() * 360f, upDirection) * refDirection, upDirection).normalized;
                 var x = (float)RNG.NextDouble();
-                var distance = Mathf.Sqrt(1f - x) * radius;
+                var distance = BDAMath.Sqrt(1f - x) * radius;
                 var height = RNG.NextDouble() * (altitude - 50f) + 50f;
                 var position = spawnPoint + direction * distance;
                 position += (height - BodyUtils.GetRadarAltitudeAtPos(position)) * upDirection;

--- a/BDArmory/Guidances/MissileGuidance.cs
+++ b/BDArmory/Guidances/MissileGuidance.cs
@@ -59,11 +59,11 @@ namespace BDArmory.Guidances
             float height = FlightGlobals.getAltitudeAtPos(targetPosition) -
                            FlightGlobals.getAltitudeAtPos(missileVessel.transform.position);
             float sqrRange = forward.sqrMagnitude;
-            float range = Mathf.Sqrt(sqrRange);
+            float range = BDAMath.Sqrt(sqrRange);
 
             float plusOrMinus = direct ? -1 : 1;
 
-            float top = sqrSpeed + (plusOrMinus * Mathf.Sqrt(sqrSpeedSqr - (g * ((g * sqrRange + (2 * height * sqrSpeed))))));
+            float top = sqrSpeed + (plusOrMinus * BDAMath.Sqrt(sqrSpeedSqr - (g * ((g * sqrRange + (2 * height * sqrSpeed))))));
             float bottom = g * range;
             float theta = Mathf.Atan(top / bottom);
 
@@ -92,11 +92,11 @@ namespace BDArmory.Guidances
             float height = FlightGlobals.getAltitudeAtPos(targetPosition) -
                            FlightGlobals.getAltitudeAtPos(missilePosition);
             float sqrRange = forward.sqrMagnitude;
-            float range = Mathf.Sqrt(sqrRange);
+            float range = BDAMath.Sqrt(sqrRange);
 
             float plusOrMinus = direct ? -1 : 1;
 
-            float top = sqrSpeed + (plusOrMinus * Mathf.Sqrt(sqrSpeedSqr - (g * ((g * sqrRange + (2 * height * sqrSpeed))))));
+            float top = sqrSpeed + (plusOrMinus * BDAMath.Sqrt(sqrSpeedSqr - (g * ((g * sqrRange + (2 * height * sqrSpeed))))));
             float bottom = g * range;
             float theta = Mathf.Atan(top / bottom);
 

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -1401,7 +1401,7 @@ namespace BDArmory.Radar
             float targetCosAngle = threatWeapon.FiringSolutionVector != null ? Vector3.Dot(aimDirection, (Vector3)threatWeapon.FiringSolutionVector) : Vector3.Dot(aimDirection, (self.vesselTransform.position - fireTransform.position).normalized);
 
             // Find vertical component of aiming angle
-            float angleThreat = targetCosAngle < 0 ? float.MaxValue : Mathf.Sqrt(Mathf.Max(0f, 1f - targetCosAngle * targetCosAngle)); // Treat angles beyond 90 degrees as not a threat
+            float angleThreat = targetCosAngle < 0 ? float.MaxValue : BDAMath.Sqrt(Mathf.Max(0f, 1f - targetCosAngle * targetCosAngle)); // Treat angles beyond 90 degrees as not a threat
 
             // Calculate distance between incoming threat position and its aimpoint (or self position)
             float distanceThreat = !threatWeapon.finalAimTarget.IsZero() ? Vector3.Magnitude(threatWeapon.finalAimTarget - fireTransform.position) : Vector3.Magnitude(self.vesselTransform.position - fireTransform.position);

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -1209,7 +1209,7 @@ namespace BDArmory.UI
                                         {
                                             if (!BDArmorySettings.DISABLE_RAMMING && AI != null && AI.allowRamming) //ramming's fun to watch
                                             {
-                                                vesselScore *= (0.031623f * Mathf.Sqrt(targetDistance) / 2);
+                                                vesselScore *= (0.031623f * BDAMath.Sqrt(targetDistance) / 2);
                                             }
                                             else
                                             {
@@ -1218,7 +1218,7 @@ namespace BDArmory.UI
                                         }
                                         //else got weapons and engaging
                                     }
-                                    vesselScore *= 0.031623f * Mathf.Sqrt(targetDistance); // Equal to 1 at 1000m
+                                    vesselScore *= 0.031623f * BDAMath.Sqrt(targetDistance); // Equal to 1 at 1000m
                                     if (wm.Current.currentGun != null)
                                     {
                                         if (wm.Current.currentGun.recentlyFiring)
@@ -1237,7 +1237,7 @@ namespace BDArmory.UI
                                     {
                                         vesselScore *= 0.5f;
                                         var distance = Vector3.Distance(wm.Current.vessel.GetWorldPos3D(), wm.Current.incomingThreatPosition);
-                                        vesselScore *= 0.031623f * Mathf.Sqrt(distance); // Equal to 1 at 1000m, we don't want to overly disadvantage craft that are super far away, but could be firing missiles or doing other interesting things
+                                        vesselScore *= 0.031623f * BDAMath.Sqrt(distance); // Equal to 1 at 1000m, we don't want to overly disadvantage craft that are super far away, but could be firing missiles or doing other interesting things
                                                                                          //we're very interested when threat and target are the same
                                         if (wm.Current.incomingThreatVessel != null && wm.Current.currentTarget != null)
                                         {

--- a/BDArmory/Utils/AIUtils.cs
+++ b/BDArmory/Utils/AIUtils.cs
@@ -78,7 +78,7 @@ namespace BDArmory.Utils
             // float discriminant = 18f * A * B * C * D - 4f * Mathf.Pow(B, 3f) * D + Mathf.Pow(B, 2f) * Mathf.Pow(C, 2f) - 4f * A * Mathf.Pow(C, 3f) - 27f * Mathf.Pow(A, 2f) * Mathf.Pow(D, 2f);
             if (E > 0)
             { // Single solution (E is positive)
-                float F = (D1 + Mathf.Sign(D1) * Mathf.Sqrt(E)) / 2f;
+                float F = (D1 + Mathf.Sign(D1) * BDAMath.Sqrt(E)) / 2f;
                 float G = Mathf.Sign(F) * Mathf.Pow(Mathf.Abs(F), 1f / 3f);
                 float time = -1f / 3f / A * (B + G + D0 / G);
                 return Mathf.Clamp(time, 0f, maxTime);
@@ -86,8 +86,8 @@ namespace BDArmory.Utils
             else if (E < 0)
             { // Triple solution (E is negative)
                 float F_real = D1 / 2f;
-                float F_imag = Mathf.Sign(D1) * Mathf.Sqrt(-E) / 2f;
-                float F_abs = Mathf.Sqrt(F_real * F_real + F_imag * F_imag);
+                float F_imag = Mathf.Sign(D1) * BDAMath.Sqrt(-E) / 2f;
+                float F_abs = BDAMath.Sqrt(F_real * F_real + F_imag * F_imag);
                 float F_ang = Mathf.Atan2(F_imag, F_real);
                 float G_abs = Mathf.Pow(F_abs, 1f / 3f);
                 float G_ang = F_ang / 3f;
@@ -361,7 +361,7 @@ namespace BDArmory.Utils
                     this.body != body || movementType != vehicleType || this.maxSlopeAngle != maxSlopeAngle * Mathf.Deg2Rad)
                 {
                     GridSize = gridSize;
-                    GridDiagonal = gridSize * Mathf.Sqrt(2);
+                    GridDiagonal = gridSize * BDAMath.Sqrt(2);
                     this.body = body;
                     this.maxSlopeAngle = maxSlopeAngle * Mathf.Deg2Rad;
                     rebuildDistance = Mathf.Clamp(Mathf.Asin(MaxDistortion) * (float)body.Radius, GridSize * 4, GridSize * 256);
@@ -475,7 +475,7 @@ namespace BDArmory.Utils
             Vector3 gridToGeo(float x, float y)
             {
                 if (x == 0 && y == 0) return origin;
-                return VectorUtils.GeoCoordinateOffset(origin, body, Mathf.Atan2(y, x) * Mathf.Rad2Deg, Mathf.Sqrt(x * x + y * y) * GridSize);
+                return VectorUtils.GeoCoordinateOffset(origin, body, Mathf.Atan2(y, x) * Mathf.Rad2Deg, BDAMath.Sqrt(x * x + y * y) * GridSize);
             }
 
             Vector3 gridToGeo(Coords coords) => gridToGeo(coords.X, coords.Y);

--- a/BDArmory/Utils/BDAMath.cs
+++ b/BDArmory/Utils/BDAMath.cs
@@ -58,5 +58,14 @@ namespace BDArmory.Utils
             var rounded = Mathf.Round(value / unit) * unit;
             return (unit % 1 != 0) ? rounded : Mathf.Round(rounded); // Fix near-integer loss of precision.
         }
+
+        // This is a fun workaround for M1-chip Macs (Apple Silicon). Specific issue the workaround is for is here: 
+        // https://issuetracker.unity3d.com/issues/m1-incorrect-calculation-of-values-using-multiplication-with-mathf-dot-sqrt-when-an-unused-variable-is-declared
+        public static float Sqrt(float value)
+        {
+            float sqrt = Mathf.Sqrt(value);
+            float sqrt1 = 1f * sqrt;
+            return sqrt1;
+        }
     }
 }

--- a/BDArmory/Utils/ProjectileUtils.cs
+++ b/BDArmory/Utils/ProjectileUtils.cs
@@ -263,7 +263,7 @@ namespace BDArmory.Utils
                 HERatio = Mathf.Clamp(HEmass / projmass, 0.01f, 0.95f);
                 float frangibility = 5000 * HERatio;
                 float shrapnelThickness = ((.0075f * Mathf.Pow((HERatio * 100), 1.05f)) + .06f) * caliber; //min thickness of material for HE to blow caliber size hole in steel
-                shrapnelThickness *= (950 / Strength) * (8000 / Density) * (Mathf.Sqrt(1100 / hardness)); //adjusted min thickness after material hardness/strength/density
+                shrapnelThickness *= (950 / Strength) * (8000 / Density) * (BDAMath.Sqrt(1100 / hardness)); //adjusted min thickness after material hardness/strength/density
                 float shrapnelCount;
                 float radiativeArea = !double.IsNaN(hitPart.radiativeArea) ? (float)hitPart.radiativeArea : hitPart.GetArea();
                 if (detonationDist > 0)
@@ -294,7 +294,7 @@ namespace BDArmory.Utils
                                 Debug.Log("[BDArmory.ProjectileUtils{CalcShrapnel}]: " + hitPart.name + " on " + hitPart.vessel.GetName() + ", detonationDist: " + detonationDist + "; " + shrapnelCount + " shrapnel hits; Armor damage: " + volumeToReduce + "cm3; part damage: " + damage);
                             }
                             ApplyScore(hitPart, sourceVesselName, 0, damage, "Shrapnel", explosionSource);
-                            CalculateArmorDamage(hitPart, (shrapnelThickness / thickness), Mathf.Sqrt((float)volumeToReduce / 3.14159f), hardness, Ductility, Density, 430, sourceVesselName, explosionSource, armorType);
+                            CalculateArmorDamage(hitPart, (shrapnelThickness / thickness), BDAMath.Sqrt((float)volumeToReduce / 3.14159f), hardness, Ductility, Density, 430, sourceVesselName, explosionSource, armorType);
                             BattleDamageHandler.CheckDamageFX(hitPart, caliber, (shrapnelThickness / thickness), false, false, sourceVesselName, hit); //bypass score mechanic so HE rounds don't have inflated scores
                         }
                     }
@@ -666,7 +666,7 @@ namespace BDArmory.Utils
                     Debug.Log("[BDArmory.ProjectileUtils{Calc Deformation}]: yield:" + yieldStrength + "; Energy: " + bulletEnergy + "; caliber: " + caliber + "; impactVel: " + impactVel);
                     Debug.Log("[BDArmory.ProjectileUtils{Calc Deformation}]: hardness:" + hardness + "; BulletDurabilityMod: " + BulletDurabilityMod + "; density: " + Density);
                 }
-                float newCaliber = ((((yieldStrength / bulletEnergy) * (hardness * Mathf.Sqrt(Density / 1000))) / impactVel) / (BulletDurabilityMod * apBulletMod)); //faster penetrating rounds less deformed, thin armor will impart less deformation before failing
+                float newCaliber = ((((yieldStrength / bulletEnergy) * (hardness * BDAMath.Sqrt(Density / 1000))) / impactVel) / (BulletDurabilityMod * apBulletMod)); //faster penetrating rounds less deformed, thin armor will impart less deformation before failing
                 if (!sabot && impactVel > 1250) //too fast and steel/lead begin to melt on impact - hence DU/Tungsten hypervelocity penetrators
                 {
                     newCaliber *= (impactVel / 1250);
@@ -720,7 +720,7 @@ namespace BDArmory.Utils
             //caliber in mm, converted to length in cm, converted to mm
             float length = ((projMass * 1000) / ((newCaliber * newCaliber * Mathf.PI / 400) * (sabot ? 19.1f : 11.34f)) + 1) * 10;
             //if (impactVel > 1500)
-            //penetration = length * Mathf.Sqrt((sabot ? 19100 : 11340) / Density); //at hypervelocity, impacts are akin to fluid displacement
+            //penetration = length * BDAMath.Sqrt((sabot ? 19100 : 11340) / Density); //at hypervelocity, impacts are akin to fluid displacement
             //penetration in mm
             //sabots should have a caliber check, or a mass check? - else a lighter, smaller caliber sabot of equal length will have similar penetration charateristics as a larger, heavier round..?
             //or just have sabots that are too narrow simply snap due to structural stress...
@@ -730,7 +730,7 @@ namespace BDArmory.Utils
             {
                 yieldStrength *= 0.7f; //necking and point embrittlement reduce total tensile strength of material
             }
-            penetration = Mathf.Min(((Energy / yieldStrength) * thickness * APmod), (length * Mathf.Sqrt((sabot ? 19100 : 11340) / Density) * (sabot ? 0.385f : 1) * APmod));
+            penetration = Mathf.Min(((Energy / yieldStrength) * thickness * APmod), (length * BDAMath.Sqrt((sabot ? 19100 : 11340) / Density) * (sabot ? 0.385f : 1) * APmod));
             //cap penetration to max possible pen depth from hypervelocity impact
             //need to re-add APBulletMod to sabots, also need to reduce sabot pen depth by about 0.6x; Abrams sabot ammos can apparently pen about their length through steel
             //penetration in mm

--- a/BDArmory/Utils/VectorUtils.cs
+++ b/BDArmory/Utils/VectorUtils.cs
@@ -52,7 +52,7 @@ namespace BDArmory.Utils
             // If the determinant is negative, then there is no solution
             if (det > 0f)
             {
-                return 2f * c / (Mathf.Sqrt(det) - b);
+                return 2f * c / (BDAMath.Sqrt(det) - b);
             }
             else
             {
@@ -117,7 +117,7 @@ namespace BDArmory.Utils
             // Technically this will raise an exception if the first random produces a zero (which should never happen now that it's log(1-rnd))
             try
             {
-                return Mathf.Sqrt(-2 * Mathf.Log(1f - UnityEngine.Random.value)) * Mathf.Cos(Mathf.PI * UnityEngine.Random.value);
+                return BDAMath.Sqrt(-2 * Mathf.Log(1f - UnityEngine.Random.value)) * Mathf.Cos(Mathf.PI * UnityEngine.Random.value);
             }
             catch (Exception e)
             { // I have no idea what exception Mathf.Log raises when it gets a zero
@@ -147,7 +147,7 @@ namespace BDArmory.Utils
             // Technically this will raise an exception if the random produces a zero, which should almost never happen
             try
             {
-                return Mathf.Sqrt(-2 * Mathf.Log(UnityEngine.Random.value));
+                return BDAMath.Sqrt(-2 * Mathf.Log(UnityEngine.Random.value));
             }
             catch (Exception e)
             { // I have no idea what exception Mathf.Log raises when it gets a zero
@@ -228,8 +228,8 @@ namespace BDArmory.Utils
             float dlat = lat2 - lat1;
             float dlon = (destination.y - start.y) * Mathf.Deg2Rad;
             float a = Mathf.Sin(dlat / 2) * Mathf.Sin(dlat / 2) + Mathf.Cos(lat1) * Mathf.Cos(lat2) * Mathf.Sin(dlon / 2) * Mathf.Sin(dlon / 2);
-            float distance = 2 * Mathf.Atan2(Mathf.Sqrt(a), Mathf.Sqrt(1 - a)) * (float)body.Radius;
-            return Mathf.Sqrt(distance * distance + (destination.z - start.z) * (destination.z - start.z));
+            float distance = 2 * Mathf.Atan2(BDAMath.Sqrt(a), BDAMath.Sqrt(1 - a)) * (float)body.Radius;
+            return BDAMath.Sqrt(distance * distance + (destination.z - start.z) * (destination.z - start.z));
         }
 
         public static Vector3 RotatePointAround(Vector3 pointToRotate, Vector3 pivotPoint, Vector3 axis, float angle)

--- a/BDArmory/Weapons/Missiles/MissileLaunchParams.cs
+++ b/BDArmory/Weapons/Missiles/MissileLaunchParams.cs
@@ -3,6 +3,7 @@
 using BDArmory.Control;
 using BDArmory.Extensions;
 using BDArmory.Settings;
+using BDArmory.Utils;
 
 namespace BDArmory.Weapons.Missiles
 {
@@ -64,7 +65,7 @@ namespace BDArmory.Weapons.Missiles
                 MissileLauncher ml = missile.GetComponent<MissileLauncher>();
                 float maxMissileAccel = ml.thrust / missile.part.mass;
                 float blastRadius = Mathf.Min(missile.GetBlastRadius(), 150f); // Allow missiles with absurd blast ranges to still be launched if desired
-                missileActiveTime = Mathf.Min((missile.vessel.LandedOrSplashed ? 0f : missile.dropTime) + Mathf.Sqrt(2 * blastRadius / maxMissileAccel), 2f); // Clamp at 2s for now
+                missileActiveTime = Mathf.Min((missile.vessel.LandedOrSplashed ? 0f : missile.dropTime) + BDAMath.Sqrt(2 * blastRadius / maxMissileAccel), 2f); // Clamp at 2s for now
 
                 if ((Vector3.Dot(vectorToTarget, missile.GetForwardTransform()) < 0.965f) || ((!missile.vessel.LandedOrSplashed) && (missile.GetWeaponClass() != WeaponClasses.SLW) && (ml.guidanceActive))) // Only evaluate missile turning ability if the target is outside ~15 deg cone, or isn't a torpedo and has guidance
                 {

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -677,7 +677,7 @@ namespace BDArmory.Weapons.Missiles
                 else if (partModules.Current.moduleName == "BDModuleNuke")
                 {
                     warheadType = WarheadTypes.Nuke;
-                    StandOffDistance = Mathf.Sqrt(((BDModuleNuke)partModules.Current).yield) * 500;
+                    StandOffDistance = BDAMath.Sqrt(((BDModuleNuke)partModules.Current).yield) * 500;
                 }
                 else continue;
                 break;
@@ -810,7 +810,7 @@ namespace BDArmory.Weapons.Missiles
                 {
                     if (part.FindModuleImplementing<BDModuleNuke>() != null)
                     {
-                        return Mathf.Sqrt(part.FindModuleImplementing<BDModuleNuke>().yield) * 500;
+                        return BDAMath.Sqrt(part.FindModuleImplementing<BDModuleNuke>().yield) * 500;
                     }
                     else
                     {

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -2218,7 +2218,7 @@ namespace BDArmory.Weapons
 
                                     if (armor != null)// technically, lasers shouldn't do damage until armor gone, but that would require localized armor tracking instead of the monolithic model currently used                                              
                                     {
-                                        damage = (initialDamage * (pulseLaser ? 1 : TimeWarp.fixedDeltaTime)) * Mathf.Clamp((1 - (Mathf.Sqrt(armor.Diffusivity * (armor.Density / 1000)) * armor.ArmorThickness) / initialDamage), 0.005f, 1); //old calc lacked a clamp, could potentially become negative damage
+                                        damage = (initialDamage * (pulseLaser ? 1 : TimeWarp.fixedDeltaTime)) * Mathf.Clamp((1 - (BDAMath.Sqrt(armor.Diffusivity * (armor.Density / 1000)) * armor.ArmorThickness) / initialDamage), 0.005f, 1); //old calc lacked a clamp, could potentially become negative damage
                                     }  //clamps laser damage to not go negative, allow some small amount of bleedthrough - ~30 Be/Steel will negate ABL, ~62 Ti, 42 DU
                                     else
                                     {
@@ -4601,7 +4601,7 @@ namespace BDArmory.Weapons
                 acceleration = Vector3.ProjectOnPlane(acceleration, VectorUtils.GetUpDirection(position));
 
             var distance = Vector3.Distance(position, part.transform.position);
-            var alpha = Mathf.Max(1f - Mathf.Sqrt(distance) / 512f, 0.1f);
+            var alpha = Mathf.Max(1f - BDAMath.Sqrt(distance) / 512f, 0.1f);
             var beta = alpha * alpha;
             if (!reset)
             {


### PR DESCRIPTION
Fix for an issue on M1 Macs (Apple Silicon) where Mathf.Sqrt(x) * y =0 for non-zero x and y.

Issue described here, thanks to Timmy for help in debugging the issue in BDA.
https://issuetracker.unity3d.com/issues/m1-incorrect-calculation-of-values-using-multiplication-with-mathf-dot-sqrt-when-an-unused-variable-is-declared