### PR TITLE
Radar detection code refactor

### DIFF
--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -1191,7 +1191,6 @@ namespace BDArmory.Radar
         {
             bool detected = false;
             // float distance already in km
-            jammingDistance /= 1000f; // Convert to km
 
             //evaluate if we can detect such a signature at that range
             if ((distance > radar.radarMinDistanceDetect) && (distance < radar.radarMaxDistanceDetect))
@@ -1201,7 +1200,7 @@ namespace BDArmory.Radar
                 //do not consider lockbreak factor from active ecm here!
                 //do not consider chaff here
 
-                if ((signature > minDetectSig) && (distance > jammingDistance))
+                if (signature > minDetectSig)
                 {
                     detected = true;
                 }

--- a/BDArmory/Radar/VesselRadarData.cs
+++ b/BDArmory/Radar/VesselRadarData.cs
@@ -680,6 +680,7 @@ namespace BDArmory.Radar
             (
                 radar.canLock
                 && (!radar.locked || radar.currentLocks < radar.maxLocks)
+                && RadarUtils.RadarCanDetect(radar, radarTarget.targetData.signalStrength, (radarTarget.targetData.predictedPosition - radar.transform.position).magnitude / 1000f)
                 && radarTarget.targetData.signalStrength > radar.radarLockTrackCurve.Evaluate((radarTarget.targetData.predictedPosition - radar.transform.position).magnitude / 1000f)
                 &&
                 (radar.omnidirectional ||


### PR DESCRIPTION
- Check that radar can also detect targets before allowing them to be locked.
- Refactor detection code, will make it easier to add jamming effects to detection later.