### PR TITLE
rippleindex NRE fix

### DIFF
--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2872,8 +2872,8 @@ namespace BDArmory.Control
             }
 
             //gun ripple stuff
-            if (selectedWeapon != null && (selectedWeapon.GetWeaponClass() == WeaponClasses.Gun || selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket || selectedWeapon.GetWeaponClass() == WeaponClasses.DefenseLaser) &&
-                currentGun.useRippleFire) //currentGun.roundsPerMinute < 1500)
+            if (selectedWeapon != null && (selectedWeapon.GetWeaponClass() == WeaponClasses.Gun || selectedWeapon.GetWeaponClass() == WeaponClasses.Rocket || selectedWeapon.GetWeaponClass() == WeaponClasses.DefenseLaser))
+                //&& currentGun.useRippleFire) //currentGun.roundsPerMinute < 1500)
             {
                 float counter = 0; // Used to get a count of the ripple weapons.  a float version of rippleGunCount.
                 gunRippleIndex.Clear();

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -974,7 +974,7 @@ namespace BDArmory.Weapons
             }
             OriginalShortName = shortName;
             WeaponDisplayName = shortName;
-            WeaponName = ConfigNodeUtils.FindPartModuleConfigNodeValue(part.partInfo.partConfig, "ModuleWeapon", "shortName"); //have weaponname be the .cfg shortname, not whatever it happens to be set to when the scene laods
+            WeaponName = part.partInfo.name; //have weaponname be the .cfg part name, since not all weapons have a shortName in the .cfg
             using (var emitter = part.FindModelComponents<KSPParticleEmitter>().AsEnumerable().GetEnumerator())
                 while (emitter.MoveNext())
                 {


### PR DESCRIPTION
-fixes some weapons not getting added to rippleDictionary
-Fixes NRE from trying to find non-existent shortnames in some weapon cfgs (Vulcan/ABL/GAU-22)