### PR TITLE
Depreciate allAspect

### DIFF
--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -5476,7 +5476,7 @@ namespace BDArmory.Control
                     heatTarget.predictedPosition - CurrentMissile.MissileReferenceTransform.position
                     : CurrentMissile.GetForwardTransform();
 
-                heatTarget = BDATargetManager.GetHeatTarget(vessel, vessel, new Ray(CurrentMissile.MissileReferenceTransform.position + (50 * CurrentMissile.GetForwardTransform()), direction), TargetSignatureData.noTarget, scanRadius, CurrentMissile.heatThreshold, CurrentMissile.allAspect, CurrentMissile.lockedSensorFOVBias, CurrentMissile.lockedSensorVelocityBias, this);
+                heatTarget = BDATargetManager.GetHeatTarget(vessel, vessel, new Ray(CurrentMissile.MissileReferenceTransform.position + (50 * CurrentMissile.GetForwardTransform()), direction), TargetSignatureData.noTarget, scanRadius, CurrentMissile.heatThreshold, CurrentMissile.uncagedLock, CurrentMissile.lockedSensorFOVBias, CurrentMissile.lockedSensorVelocityBias, this);
             }
         }
 
@@ -6078,7 +6078,7 @@ namespace BDArmory.Control
                     target = MissileGuidance.GetAirToAirFireSolution(missile, targetV);
                 }
 
-                float boresightFactor = (mf.vessel.LandedOrSplashed || targetV.LandedOrSplashed || missile.allAspect) ? 0.75f : 0.35f; // Allow launch at close to maxOffBoresight for ground targets or missiles with allAspect = true
+                float boresightFactor = (mf.vessel.LandedOrSplashed || targetV.LandedOrSplashed || missile.uncagedLock) ? 0.75f : 0.35f; // Allow launch at close to maxOffBoresight for ground targets or missiles with allAspect = true
 
                 //if(missile.TargetingMode == MissileBase.TargetingModes.Gps) maxOffBoresight = 45;
 

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/aim-120/amraam.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/aim-120/amraam.cfg
@@ -78,8 +78,9 @@ PART
 		homingType = aam //air to air missile different types are AAM, AGM, Cruise and Ballistic
 		targetingType = radar
 		activeRadarRange = 6000
-		maxOffBoresight = 120 //maximum angle, from the boresight, that the missile can track the target. This also controls how the missile can launch off boresight. When launched from the air at another air target with allAspect = false, launch off boresight is at 0.35*maxOffBoresight, otherwise it is at 0.75*,maxOffBoresight (allAspect = true OR either launching craft or target is landed/splashed).
-		allAspect = false // Only affects when missile can launch for radar-guided missiles, see comment on maxOffBoresight for how. For heat-seeking missiles this also allows lock-on after launch.
+		maxOffBoresight = 120 //maximum angle, from the boresight, that the missile can track the target. This also controls how the missile can launch off boresight. When launched from the air at another air target with uncagedLock = false, launch off boresight is at 0.35*maxOffBoresight, otherwise it is at 0.75*,maxOffBoresight (uncagedLock = true OR either launching craft or target is landed/splashed).
+		// allAspect = false // DEPRECIATED - use uncagedLock instead
+		uncagedLock = false // Only affects when missile can launch for radar-guided missiles, see comment on maxOffBoresight for how. For heat-seeking missiles this also allows lock-on after launch.
 		lockedSensorFOV = 7 //the field of view the missile can see to maintain a lock after launch, will affect accuracy
 		chaffEffectivity = 1 //modifies how the missile targeting is affected by chaff, 1 is fully affected (normal behavior), lower values mean less affected (i.e. 0 ignores chaff), higher values means more affected
 

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/sidewinder/sidewinder.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/sidewinder/sidewinder.cfg
@@ -75,8 +75,9 @@ PART
         missileType = missile
         targetingType = heat
         heatThreshold = 50   // Distance-adjusted heat of target in order to be detected by missile, lower value results in better detection range
-        maxOffBoresight = 90 //maximum angle, from the boresight, that the missile can track the target. This also controls how the missile can launch off boresight. When launched from the air at another air target with allAspect = false, launch off boresight is at 0.35*maxOffBoresight, otherwise it is at 0.75*,maxOffBoresight (allAspect = true OR either launching craft or target is landed/splashed).
-		allAspect = false	 // true: Allows missile to be cued to a radar target, also controls launch conditions, see above
+        maxOffBoresight = 90 //maximum angle, from the boresight, that the missile can track the target. This also controls how the missile can launch off boresight. When launched from the air at another air target with uncagedLock = false, launch off boresight is at 0.35*maxOffBoresight, otherwise it is at 0.75*,maxOffBoresight (uncagedLock = true OR either launching craft or target is landed/splashed).
+		uncagedLock = false // true: Allows missile to be cued to a radar target, also controls launch conditions, see above
+        // allAspect = false // DEPRECIATED - use uncagedLock instead
         lockedSensorFOV = 6 // How much the seeker can see in the direction it is looking (in terms of angle cone).
         lockedSensorFOVBias
         {

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -355,7 +355,7 @@ namespace BDArmory.UI
         /// <summary>
         /// Find a flare closest in heat signature to passed heat signature
         /// </summary>
-        public static TargetSignatureData GetFlareTarget(Ray ray, float scanRadius, float highpassThreshold, bool allAspect, FloatCurve lockedSensorFOVBias, FloatCurve lockedSensorVelocityBias, TargetSignatureData heatTarget)
+        public static TargetSignatureData GetFlareTarget(Ray ray, float scanRadius, float highpassThreshold, FloatCurve lockedSensorFOVBias, FloatCurve lockedSensorVelocityBias, TargetSignatureData heatTarget)
         {
             TargetSignatureData flareTarget = TargetSignatureData.noTarget;
             float heatSignature = heatTarget.signalStrength;
@@ -399,7 +399,7 @@ namespace BDArmory.UI
             return flareTarget;
         }
 
-        public static TargetSignatureData GetHeatTarget(Vessel sourceVessel, Vessel missileVessel, Ray ray, TargetSignatureData priorHeatTarget, float scanRadius, float highpassThreshold, bool allAspect, FloatCurve lockedSensorFOVBias, FloatCurve lockedSensorVelocityBias, MissileFire mf = null)
+        public static TargetSignatureData GetHeatTarget(Vessel sourceVessel, Vessel missileVessel, Ray ray, TargetSignatureData priorHeatTarget, float scanRadius, float highpassThreshold, bool uncagedLock, FloatCurve lockedSensorFOVBias, FloatCurve lockedSensorVelocityBias, MissileFire mf = null)
         {
             float minMass = 0.05f;  //otherwise the RAMs have trouble shooting down incoming missiles
             TargetSignatureData finalData = TargetSignatureData.noTarget;
@@ -449,12 +449,12 @@ namespace BDArmory.UI
 
                 float angle = Vector3.Angle(vessel.CoM - ray.origin, ray.direction);
 
-                if ((angle < scanRadius) || (allAspect && !priorHeatTarget.exists)) // Allow allAspect=true missiles to find target outside of seeker FOV before launch
+                if ((angle < scanRadius) || (uncagedLock && !priorHeatTarget.exists)) // Allow allAspect=true missiles to find target outside of seeker FOV before launch
                 {
                     if (RadarUtils.TerrainCheck(ray.origin, vessel.transform.position))
                         continue;
 
-                    if (!allAspect)
+                    if (!uncagedLock)
                     {
                         if (!OtherUtils.CheckSightLineExactDistance(ray.origin, vessel.CoM + vessel.Velocity(), Vector3.Distance(vessel.CoM, ray.origin), 5, 5))
                             continue;
@@ -494,7 +494,7 @@ namespace BDArmory.UI
             TargetSignatureData flareData = TargetSignatureData.noTarget;
             if (priorHeatScore > 0) // Flares can only decoy if we already had a target
             {
-                flareData = GetFlareTarget(ray, scanRadius, highpassThreshold, allAspect, lockedSensorFOVBias, lockedSensorVelocityBias, priorHeatTarget);
+                flareData = GetFlareTarget(ray, scanRadius, highpassThreshold, lockedSensorFOVBias, lockedSensorVelocityBias, priorHeatTarget);
                 flareSuccess = ((!flareData.Equals(TargetSignatureData.noTarget)) && (flareData.signalStrength > highpassThreshold));
             }
 

--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -99,8 +99,10 @@ namespace BDArmory.Weapons.Missiles
         [KSPField]
         public float chaffEffectivity = 1f;                            // Modifies  how the missile targeting is affected by chaff, 1 is fully affected (normal behavior), lower values mean less affected (0 is ignores chaff), higher values means more affected
 
+        public bool allAspect = false;                                 // DEPRECIATED, replaced by uncagedIRLock. uncagedIRLock is automatically set to this value upon loading (to maintain compatability with old BDA mods)
+
         [KSPField]
-        public bool allAspect = false;
+        public bool uncagedLock = false;                             //if true it simulates a modern IR missile with "uncaged lock" ability. Even if the target is not within boresight fov, it can be radar locked and the target information transfered to the missile. It will then try to lock on with the heat seeker. If false, it is an older missile which requires a direct "in boresight" lock.
 
         [KSPField]
         public bool isTimed = false;
@@ -493,7 +495,7 @@ namespace BDArmory.Weapons.Missiles
                 DrawDebugLine(lookRay.origin, lookRay.origin + lookRay.direction * 10000, Color.magenta);
 
                 // Update heat target
-                heatTarget = BDATargetManager.GetHeatTarget(SourceVessel, vessel, lookRay, predictedHeatTarget, lockedSensorFOV / 2, heatThreshold, allAspect, lockedSensorFOVBias, lockedSensorVelocityBias, (SourceVessel == null ? null : SourceVessel.gameObject == null ? null : SourceVessel.gameObject.GetComponent<MissileFire>()));
+                heatTarget = BDATargetManager.GetHeatTarget(SourceVessel, vessel, lookRay, predictedHeatTarget, lockedSensorFOV / 2, heatThreshold, uncagedLock, lockedSensorFOVBias, lockedSensorVelocityBias, (SourceVessel == null ? null : SourceVessel.gameObject == null ? null : SourceVessel.gameObject.GetComponent<MissileFire>()));
 
                 if (heatTarget.exists)
                 {

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -600,6 +600,9 @@ namespace BDArmory.Weapons.Missiles
 
             SetInitialDetonationDistance();
 
+            // set uncagedLock = true if depreciated allAspect = true
+            uncagedLock = (allAspect) ? allAspect : uncagedLock;
+
             // fill lockedSensorFOVBias with default values if not set by part config:
             if ((TargetingMode == TargetingModes.Heat || TargetingModeTerminal == TargetingModes.Heat) && heatThreshold > 0 && lockedSensorFOVBias.minTime == float.MaxValue)
             {
@@ -2340,7 +2343,7 @@ namespace BDArmory.Weapons.Missiles
 
             if (TargetingMode == TargetingModes.Heat)
             {
-                output.AppendLine($"All Aspect: {allAspect}");
+                output.AppendLine($"Uncaged Lock: {uncagedLock}");
                 output.AppendLine($"Min Heat threshold: {heatThreshold}");
                 output.AppendLine($"Max Offborsight: {maxOffBoresight}");
                 output.AppendLine($"Locked FOV: {lockedSensorFOV}");
@@ -2367,7 +2370,7 @@ namespace BDArmory.Weapons.Missiles
 
                     if (TargetingModeTerminal == TargetingModes.Heat)
                     {
-                        output.AppendLine($"All Aspect: {allAspect}");
+                        output.AppendLine($"Uncaged Lock: {uncagedLock}");
                         output.AppendLine($"Min Heat threshold: {heatThreshold}");
                         output.AppendLine($"Max Offborsight: {maxOffBoresight}");
                         output.AppendLine($"Locked FOV: {lockedSensorFOV}");


### PR DESCRIPTION
- Depreciate allAspect, replace with better named uncagedLock. Set uncagedLock to true if allAspect is true to maintain compatibility with BDA mods that aren't updated.