### PR TITLE
Penetration calc tweaks

### DIFF
--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -848,32 +848,41 @@ namespace BDArmory.Bullets
                 
                 //calculate bullet deformation
                 float newCaliber = caliber;
-                if (!sabot)
+                if (Ductility > 0.05)
                 {
-                    // Moved the bulletEnergy and armorStrength calculations here because
-                    // they are no longer needed for CalculatePenetration. This should
-                    // improve performance somewhat for sabot rounds, which is a good
-                    // thing since that new model requires the use of Mathf.Log and
-                    // Mathf.Exp.
+                    if (!sabot)
+                    {
+                        // Moved the bulletEnergy and armorStrength calculations here because
+                        // they are no longer needed for CalculatePenetration. This should
+                        // improve performance somewhat for sabot rounds, which is a good
+                        // thing since that new model requires the use of Mathf.Log and
+                        // Mathf.Exp.
+                        float bulletEnergy = ProjectileUtils.CalculateProjectileEnergy(bulletMass, impactSpeed);
+                        float armorStrength = ProjectileUtils.CalculateArmorStrength(caliber, thickness, Ductility, Strength, Density, safeTemp, hitPart);
+                        newCaliber = ProjectileUtils.CalculateDeformation(armorStrength, bulletEnergy, caliber, impactSpeed, hardness, Density, HERatio, apBulletMod, sabot);
+
+                        // Also set the params to the non-sabot ones
+                        muParam1 = Armor.muParam1;
+                        muParam2 = Armor.muParam2;
+                        muParam3 = Armor.muParam3;
+                    }
+                    else
+                    {
+                        // If it's a sabot just set the params to the sabot ones
+                        muParam1 = Armor.muParam1S;
+                        muParam2 = Armor.muParam2S;
+                        muParam3 = Armor.muParam3S;
+                    }
+                    //penetration = ProjectileUtils.CalculatePenetration(caliber, newCaliber, bulletMass, impactSpeed, Ductility, Density, Strength, thickness, apBulletMod, sabot);
+                    penetration = ProjectileUtils.CalculatePenetration(caliber, impactSpeed, bulletMass, apBulletMod, Strength, vFactor, muParam1, muParam2, muParam3, sabot);
+                }
+                else
+                {
                     float bulletEnergy = ProjectileUtils.CalculateProjectileEnergy(bulletMass, impactSpeed);
                     float armorStrength = ProjectileUtils.CalculateArmorStrength(caliber, thickness, Ductility, Strength, Density, safeTemp, hitPart);
                     newCaliber = ProjectileUtils.CalculateDeformation(armorStrength, bulletEnergy, caliber, impactSpeed, hardness, Density, HERatio, apBulletMod, sabot);
-
-                    // Also set the params to the non-sabot ones
-                    muParam1 = Armor.muParam1;
-                    muParam2 = Armor.muParam2;
-                    muParam3 = Armor.muParam3;
-                } 
-                else
-                {
-                    // If it's a sabot just set the params to the sabot ones
-                    muParam1 = Armor.muParam1S;
-                    muParam2 = Armor.muParam2S;
-                    muParam3 = Armor.muParam3S;
+                    penetration = ProjectileUtils.CalculateCeramicPenetration(caliber, newCaliber, bulletMass, impactSpeed, Ductility, Density, Strength, thickness, apBulletMod, sabot);
                 }
-                //penetration = ProjectileUtils.CalculatePenetration(caliber, newCaliber, bulletMass, impactSpeed, Ductility, Density, Strength, thickness, apBulletMod, sabot);
-                penetration = ProjectileUtils.CalculatePenetration(caliber, impactSpeed, bulletMass, apBulletMod, Strength, vFactor, muParam1, muParam2, muParam3, sabot);
-
                 caliber = newCaliber; //update bullet with new caliber post-deformation(if any)
                 penetrationFactor = ProjectileUtils.CalculateArmorPenetration(hitPart, penetration, thickness);
                 //Reactive Armor calcs

--- a/BDArmory/Ammo/PooledRocket.cs
+++ b/BDArmory/Ammo/PooledRocket.cs
@@ -450,8 +450,15 @@ namespace BDArmory.Bullets
                             //calculate bullet deformation
                             float newCaliber = ProjectileUtils.CalculateDeformation(armorStrength, bulletEnergy, caliber, impactVelocity, hardness, Density, HERatio, 1, false);
                             //calculate penetration
-                            //penetration = ProjectileUtils.CalculatePenetration(caliber, newCaliber, rocketMass * 1000, impactVelocity, Ductility, Density, Strength, thickness, 1);
-                            penetration = ProjectileUtils.CalculatePenetration(caliber, impactVelocity, rocketMass * 1000f, 1f , Strength, vFactor, muParam1, muParam2, muParam3);
+                            if (Ductility > 0.05)
+                            {
+                                penetration = ProjectileUtils.CalculatePenetration(caliber, impactVelocity, rocketMass * 1000f, 1f, Strength, vFactor, muParam1, muParam2, muParam3);
+                            }
+                            else
+                            {
+                                penetration = ProjectileUtils.CalculateCeramicPenetration(caliber, newCaliber, rocketMass * 1000, impactVelocity, Ductility, Density, Strength, thickness, 1);
+                            }
+
                             caliber = newCaliber; //update bullet with new caliber post-deformation(if any)
                             penetrationFactor = ProjectileUtils.CalculateArmorPenetration(hitPart, penetration, thickness);
 

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -25,6 +25,7 @@ IMPROVEMENTS / FIXES
 - Armor:
 	- Fix ProcArmor max scalar clamp not appearing.
 	- Add Yield and YoungModulus fields to armour for reflection - fixes armour definitions without these properties not loading properly.
+	- Tweak penetration calcs for ultra-low ductility armor materials
 - UI:
 	- Missile names now linked to launching craft teamcolor.
 	- Set the AI GUI window rect in Start, not Awake, to guarantee that BDArmorySettings values have been read - fixes the 0-height AI GUI window.

--- a/BDArmory/Utils/ProjectileUtils.cs
+++ b/BDArmory/Utils/ProjectileUtils.cs
@@ -772,8 +772,8 @@ namespace BDArmory.Utils
 
 
         // Deprecated formula
-        /*
-        public static float CalculatePenetration(float caliber, float newCaliber, float projMass, float impactVel, float Ductility, float Density, float Strength, float thickness, float APmod, bool sabot = false)
+        // Using this for the moment as the Tate formula doesn't work well with ceramic/ceramic-adjacent ultra-low ductility armor materials. Numbers aren't as accurate, but are close enough for BDA
+        public static float CalculateCeramicPenetration(float caliber, float newCaliber, float projMass, float impactVel, float Ductility, float Density, float Strength, float thickness, float APmod, bool sabot = false)
         {
             float Energy = CalculateProjectileEnergy(projMass, impactVel);
             if (thickness < 1)
@@ -810,9 +810,7 @@ namespace BDArmory.Utils
                 Debug.Log("[BDArmory.ProjectileUtils{Calc Penetration}]: Length: " + length + "; sabot: " + sabot + " ;Penetration: " + Mathf.Round(penetration / 10) + " cm");
             }
             return penetration;
-        }
-        */
-        
+        }             
 
         public static float CalculateThickness(Part hitPart, float anglemultiplier)
         {


### PR DESCRIPTION
Tate calc returns odd numbers when dealing with ceramics (Fiberlgass is now a better armor material than _Depleted Uranium_), reverting to older calc for impacts against ceramics/ceramic-adjacent armor materials for now 