### PR TITLE
Space tweaks

### DIFF
--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -1185,7 +1185,7 @@ namespace BDArmory.Bullets
                 {
                     Debug.Log("[BDArmory.PooledBullet]: Bullet Velocity too low, stopping");
                 }
-                KillBullet();
+                if (!fuzeTriggered) KillBullet();
                 distanceTraveled += hit.distance;
                 return true;
             }

--- a/BDArmory/Competition/VesselSpawning/SpawnUtils.cs
+++ b/BDArmory/Competition/VesselSpawning/SpawnUtils.cs
@@ -211,6 +211,35 @@ namespace BDArmory.Competition.VesselSpawning
             }
         }
         #endregion
+        public static void SpaceFrictionOnNewVessels(bool enable)
+        {
+            if (enable)
+            {
+                GameEvents.onVesselLoaded.Add(SpaceHacksEventHandler);
+                GameEvents.OnVesselRollout.Add(SpaceHacks);
+            }
+            else
+            {
+                GameEvents.onVesselLoaded.Remove(SpaceHacksEventHandler);
+                GameEvents.OnVesselRollout.Remove(SpaceHacks);
+            }
+        }
+        static void SpaceHacksEventHandler(Vessel vessel) => SpaceHacks(vessel);
+
+        public static void SpaceHacks(Vessel vessel)
+        {
+            if (vessel == null || !vessel.loaded) return;
+
+            if (VesselModuleRegistry.GetMissileFire(vessel, true) != null && vessel.rootPart.FindModuleImplementing<ModuleSpaceFriction>() == null)
+            {
+                vessel.rootPart.AddModule("ModuleSpaceFriction");
+            }
+        }
+        public static void SpaceHacks(ShipConstruct ship) // This version only needs to enable the hack.
+        {
+            if (ship == null) return;
+            ship.Parts[0].AddModule("ModuleSpaceFriction");
+        }
 
         #region Vessel Removal
         public static bool removingVessels => SpawnUtilsInstance.Instance.removeVesselsPending > 0;
@@ -286,6 +315,7 @@ namespace BDArmory.Competition.VesselSpawning
             spawnLocationCamera = (GameObject)Instantiate(spawnLocationCamera, Vector3.zero, Quaternion.identity);
             spawnLocationCamera.SetActive(false);
             if (BDArmorySettings.HACK_INTAKES) SpawnUtils.HackIntakesOnNewVessels(true);
+            if (BDArmorySettings.SPACE_HACKS) SpawnUtils.SpaceFrictionOnNewVessels(true);
         }
 
         void OnDestroy()

--- a/BDArmory/Distribution/GameData/BDArmory/MMPatches/BDA_battledamage.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/MMPatches/BDA_battledamage.cfg
@@ -57,6 +57,13 @@
 	{
 	}
 }
+@PART[*]:HAS[@MODULE[ModuleB9PartSwitch]]
+{
+	%MODULE[ModuleSelfSealingTank]
+	{
+	}
+}
+
 //Mod configs
 //AviatorArsenal
 @PART[7mmBox|50calBox|13mmBox|15mmBox|20mmBox|23mmBox|30mmBox|40mmBox|75mmBox]

--- a/BDArmory/FX/NukeFX.cs
+++ b/BDArmory/FX/NukeFX.cs
@@ -300,7 +300,7 @@ namespace BDArmory.FX
                         LightFx.range = thermalRadius;
                         if (lastValidAtmDensity < 0.05)
                         {
-                            FXEmitter.CreateFX(transform.position, scale, flashModelPath, "", 0.3f, 0.3f);
+                            FXEmitter.CreateFX(transform.position, scale, flashModelPath, "", 0.3f);
                         }
                         else
                         {
@@ -313,16 +313,17 @@ namespace BDArmory.FX
                                 FXEmitter.CreateFX(transform.position, scale * lastValidAtmDensity, shockModelPath, "", 0.3f, -1, default, true);
                             if (!string.IsNullOrWhiteSpace(blastModelPath))
                                 FXEmitter.CreateFX(transform.position, scale, blastModelPath, blastSoundPath, 1.5f, Mathf.Clamp(30 * scale, 30f, 90f), default, true);
-                        }
-                        if (BodyUtils.GetRadarAltitudeAtPos(transform.position) < 200 * scale)
-                        {
-                            double latitudeAtPos = FlightGlobals.currentMainBody.GetLatitude(transform.position);
-                            double longitudeAtPos = FlightGlobals.currentMainBody.GetLongitude(transform.position);
-                            double altitude = FlightGlobals.currentMainBody.TerrainAltitude(latitudeAtPos, longitudeAtPos);
-                            if (!string.IsNullOrWhiteSpace(plumeModelPath))
-                                FXEmitter.CreateFX(FlightGlobals.currentMainBody.GetWorldSurfacePosition(latitudeAtPos, longitudeAtPos, altitude), Mathf.Clamp(scale, 0.01f, 3f), plumeModelPath, "", Mathf.Clamp(30 * scale, 30f, 90f), Mathf.Clamp(30 * scale, 30f, 90f), default, true, true);
-                            if (!string.IsNullOrWhiteSpace(debrisModelPath))
-                                FXEmitter.CreateFX(FlightGlobals.currentMainBody.GetWorldSurfacePosition(latitudeAtPos, longitudeAtPos, altitude), scale, debrisModelPath, "", 1.5f, Mathf.Clamp(30 * scale, 30f, 90f), default, true);
+
+                            if (BodyUtils.GetRadarAltitudeAtPos(transform.position) < 200 * scale)
+                            {
+                                double latitudeAtPos = FlightGlobals.currentMainBody.GetLatitude(transform.position);
+                                double longitudeAtPos = FlightGlobals.currentMainBody.GetLongitude(transform.position);
+                                double altitude = FlightGlobals.currentMainBody.TerrainAltitude(latitudeAtPos, longitudeAtPos);
+                                if (!string.IsNullOrWhiteSpace(plumeModelPath))
+                                    FXEmitter.CreateFX(FlightGlobals.currentMainBody.GetWorldSurfacePosition(latitudeAtPos, longitudeAtPos, altitude), Mathf.Clamp(scale, 0.01f, 3f), plumeModelPath, "", Mathf.Clamp(30 * scale, 30f, 90f), Mathf.Clamp(30 * scale, 30f, 90f), default, true, true);
+                                if (!string.IsNullOrWhiteSpace(debrisModelPath))
+                                    FXEmitter.CreateFX(FlightGlobals.currentMainBody.GetWorldSurfacePosition(latitudeAtPos, longitudeAtPos, altitude), scale, debrisModelPath, "", 1.5f, Mathf.Clamp(30 * scale, 30f, 90f), default, true);
+                            }
                         }
                     }
                     if (LightFx != null) LightFx.intensity -= 12 * scale * Time.deltaTime;

--- a/BDArmory/Modules/ModuleSelfSealingTank.cs
+++ b/BDArmory/Modules/ModuleSelfSealingTank.cs
@@ -211,10 +211,10 @@ namespace BDArmory.Modules
         Coroutine firebottleRoutine;
 
         PartResource fuel;
+        PartResource monoprop;
         PartResource solid;
         public bool isOnFire = false;
         bool procPart = false;
-
         public bool externallyCalled = false;
         ModuleEngines engine;
         ModuleCommand cockpit;
@@ -224,6 +224,14 @@ namespace BDArmory.Modules
             if (part.name.Contains("B9.Aero.Wing.Procedural") || part.name.Contains("procedural")) //could add other proc parts here for similar support
             {
                 procPart = true;
+            }
+            else
+            {
+                if (part.Modules.Contains("ModuleB9PartSwitch"))
+                {
+                    var B9FuelSwitch = ConfigNodeUtils.FindPartModuleConfigNodeValue(part.partInfo.partConfig, "ModuleB9PartSwitch", "baseVolume");
+                    if (B9FuelSwitch != null) procPart = true;
+                }
             }
             if (HighLogic.LoadedSceneIsEditor)
             {
@@ -247,6 +255,7 @@ namespace BDArmory.Modules
             else
             {
                 fuel = part.Resources.Where(pr => pr.resourceName == "LiquidFuel").FirstOrDefault();
+                monoprop = part.Resources.Where(pr => pr.resourceName == "MonoPropellant").FirstOrDefault();
                 solid = part.Resources.Where(pr => pr.resourceName == "SolidFuel").FirstOrDefault();
 
                 engine = part.FindModuleImplementing<ModuleEngines>();
@@ -256,7 +265,7 @@ namespace BDArmory.Modules
                     Events["ToggleInertOption"].guiActiveEditor = false;
                     if (solid != null && engine.throttleLocked && !engine.allowShutdown) //SRB?
                     {
-                        if (fuel == null || (fuel != null && solid.maxAmount > fuel.maxAmount))
+                        if (fuel == null && monoprop == null || ((fuel != null && solid.maxAmount > fuel.maxAmount) || (monoprop != null && solid.maxAmount > monoprop.maxAmount)))
                         {
                             part.RemoveModule(this); //don't add firebottles to SRBs, but allow for the S1.5.5 MH soyuz tank with integrated seperatrons
                         }
@@ -268,7 +277,11 @@ namespace BDArmory.Modules
                         }
                     }
                 }
-                else if (fuel == null && solid == null)
+                else if (monoprop != null)
+                {
+                    Events["ToggleInertOption"].guiActiveEditor = false; //inerting isn't going to do anything against a substance that contains its own oxidizer
+                }
+                else if (fuel == null && monoprop == null && solid == null)
                 {
                     Events["ToggleTankOption"].guiActiveEditor = false;
                     Events["ToggleInertOption"].guiActiveEditor = false;
@@ -304,7 +317,7 @@ namespace BDArmory.Modules
                 GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
             if (HighLogic.LoadedSceneIsFlight)
             {
-                if (cockpit == null && engine == null && fuel == null) part.RemoveModule(this); //PWing with no tank
+                if (cockpit == null && engine == null && (fuel == null && monoprop == null)) part.RemoveModule(this); //PWing with no tank
             }
             FBSetup(null, null);
             //Debug.Log("[BDArmory.SelfSealingTank]: SST: " + SSTank + "; Inerting: " + InertTank + "; armored cockpit: " + armoredCockpit);
@@ -513,10 +526,11 @@ namespace BDArmory.Modules
                     if (updateTimer < 0)
                     {
                         fuel = part.Resources.Where(pr => pr.resourceName == "LiquidFuel").FirstOrDefault();
-                        if (fuel != null)
+                        monoprop = part.Resources.Where(pr => pr.resourceName == "MonoPropellant").FirstOrDefault();
+                        if (fuel != null || monoprop != null)
                         {
                             Events["ToggleTankOption"].guiActiveEditor = true;
-                            Events["ToggleInertOption"].guiActiveEditor = true;
+                            if (fuel != null) Events["ToggleInertOption"].guiActiveEditor = true; //I don't think inerting would work on something containing its own oxidizer...
                             if (!InertTank)
                             {
                                 Fields["FireBottles"].guiActiveEditor = true;
@@ -552,7 +566,7 @@ namespace BDArmory.Modules
                 if (InertTank) return;
                 if (!isOnFire)
                 {
-                    if ((fuel != null && fuel.amount > 0) && part.temperature > 493) //autoignition temp of kerosene is 220 c
+                    if (((fuel != null && fuel.amount > 0) || (monoprop != null && monoprop.amount > 0) )&& part.temperature > 493) //autoignition temp of kerosene is 220 c. hydrazine is 24-270, so this works for monoprop as well
                     {
                         string fireStarter;
                         var vesselFire = part.vessel.GetComponentInChildren<FireFX>();

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -931,7 +931,6 @@ namespace BDArmory.UI
 
             // Version.
             GUI.Label(new Rect(columnWidth - _windowMargin - (numberOfButtons - 1) * _buttonSize - 100, 23, 57, 10), Version, waterMarkStyle);
-
             //SETTINGS BUTTON
             if (!BDKeyBinder.current &&
                 GUI.Button(new Rect(columnWidth - _windowMargin - ++buttonNumber * _buttonSize, _windowMargin, _buttonSize, _buttonSize), settingsIconTexture, BDGuiSkin.button))
@@ -2958,25 +2957,40 @@ namespace BDArmory.UI
                     GUI.Label(SLeftSliderRect(++line, 1), $"{Localizer.Format("#LOC_BDArmory_Settings_CMStealRation")}:  ({BDArmorySettings.RESOURCE_STEAL_CM_RATION})", leftLabel);//CM Steal Ration
                     BDArmorySettings.RESOURCE_STEAL_CM_RATION = Mathf.RoundToInt(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.RESOURCE_STEAL_CM_RATION, 0f, 1f) * 100f) / 100f;
                 }
-                var oldSpaceHacks = BDArmorySettings.SPACE_HACKS;
-                BDArmorySettings.SPACE_HACKS = GUI.Toggle(SLeftRect(++line), BDArmorySettings.SPACE_HACKS, Localizer.Format("#LOC_BDArmory_Settings_SpaceHacks"));
+                bool oldSpaceHacks = BDArmorySettings.SPACE_HACKS;
+                BDArmorySettings.SPACE_HACKS = GUI.Toggle(SLeftRect(++line), BDArmorySettings.SPACE_HACKS, Localizer.Format("#LOC_BDArmory_Settings_SpaceHacks"));//Space Tools
+                if (BDArmorySettings.SPACE_HACKS)
                 {
-                    if (BDArmorySettings.SPACE_HACKS)
+                    if (HighLogic.LoadedSceneIsFlight)
                     {
-                        if (!oldSpaceHacks) ModuleSpaceFriction.AddSpaceFrictionToAllValidVessels(); // Add missing modules when Space Hacks is toggled.
-                        BDArmorySettings.SF_FRICTION = GUI.Toggle(SLeftRect(++line, 1f), BDArmorySettings.SF_FRICTION, Localizer.Format("#LOC_BDArmory_Settings_SpaceFriction"));
-                        BDArmorySettings.SF_GRAVITY = GUI.Toggle(SLeftRect(++line, 1f), BDArmorySettings.SF_GRAVITY, Localizer.Format("#LOC_BDArmory_Settings_IgnoreGravity"));
-                        GUI.Label(SLeftSliderRect(++line, 1f), $"{Localizer.Format("#LOC_BDArmory_Settings_SpaceFrictionMult")}:  ({BDArmorySettings.SF_DRAGMULT})", leftLabel);//Space Friction Mult
-                        BDArmorySettings.SF_DRAGMULT = Mathf.Round(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.SF_DRAGMULT, 1f, 10));
-                        BDArmorySettings.SF_REPULSOR = GUI.Toggle(SLeftRect(++line, 1f), BDArmorySettings.SF_REPULSOR, Localizer.Format("#LOC_BDArmory_Settings_Repulsor"));
+                        if (oldSpaceHacks != BDArmorySettings.SPACE_HACKS)
+                        {
+                            SpawnUtils.SpaceFrictionOnNewVessels(BDArmorySettings.SPACE_HACKS);
+                            if (BDArmorySettings.SPACE_HACKS) // Add the hack to all in-game intakes.
+                            {
+                                foreach (var vessel in FlightGlobals.Vessels)
+                                {
+                                    if (vessel == null || !vessel.loaded) continue;
+                                    SpawnUtils.SpaceHacks(vessel);
+                                }
+                            }
+                        }
                     }
-                    else
-                    {
-                        BDArmorySettings.SF_FRICTION = false;
-                        BDArmorySettings.SF_GRAVITY = false;
-                        BDArmorySettings.SF_REPULSOR = false;
-                    }
+                    //ModuleSpaceFriction.AddSpaceFrictionToAllValidVessels(); // Add missing modules when Space Hacks is toggled.
+
+                    BDArmorySettings.SF_FRICTION = GUI.Toggle(SLeftRect(++line, 1f), BDArmorySettings.SF_FRICTION, Localizer.Format("#LOC_BDArmory_Settings_SpaceFriction"));
+                    BDArmorySettings.SF_GRAVITY = GUI.Toggle(SLeftRect(++line, 1f), BDArmorySettings.SF_GRAVITY, Localizer.Format("#LOC_BDArmory_Settings_IgnoreGravity"));
+                    GUI.Label(SLeftSliderRect(++line, 1f), $"{Localizer.Format("#LOC_BDArmory_Settings_SpaceFrictionMult")}:  ({BDArmorySettings.SF_DRAGMULT})", leftLabel);//Space Friction Mult
+                    BDArmorySettings.SF_DRAGMULT = Mathf.Round(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.SF_DRAGMULT, 1f, 10));
+                    BDArmorySettings.SF_REPULSOR = GUI.Toggle(SLeftRect(++line, 1f), BDArmorySettings.SF_REPULSOR, Localizer.Format("#LOC_BDArmory_Settings_Repulsor"));
                 }
+                else
+                {
+                    BDArmorySettings.SF_FRICTION = false;
+                    BDArmorySettings.SF_GRAVITY = false;
+                    BDArmorySettings.SF_REPULSOR = false;
+                }            
+                
                 // Asteroids
                 if (BDArmorySettings.ASTEROID_FIELD != (BDArmorySettings.ASTEROID_FIELD = GUI.Toggle(SLeftRect(++line), BDArmorySettings.ASTEROID_FIELD, Localizer.Format("#LOC_BDArmory_Settings_AsteroidField")))) // Asteroid Field
                 {

--- a/BDArmory/Utils/ProjectileUtils.cs
+++ b/BDArmory/Utils/ProjectileUtils.cs
@@ -61,10 +61,10 @@ namespace BDArmory.Utils
             }
 
             // Update scoring structures
-            if (firstHit)
-            {
-                ApplyScore(hitPart, sourceVessel.GetName(), distanceTraveled, damage, name, explosionSource, true);
-            }
+            //if (firstHit)
+            //{
+                ApplyScore(hitPart, sourceVessel.GetName(), distanceTraveled, damage, name, explosionSource, firstHit);
+            //}
             ResourceUtils.StealResources(hitPart, sourceVessel);
         }
         public static void ApplyScore(Part hitPart, string sourceVessel, double distanceTraveled, float damage, string name, ExplosionSourceType ExplosionSource, bool newhit = false)

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -126,7 +126,7 @@ namespace BDArmory.Weapons
 
         private BDStagingAreaGauge gauge;
         private int AmmoID;
-
+        private int ECID;
         //AI
         public bool aiControlled = false;
         public bool autoFire;
@@ -1258,7 +1258,7 @@ namespace BDArmory.Weapons
                 gauge.ReloadCompleteAudioClip = reloadCompleteAudioClip;
 
                 AmmoID = PartResourceLibrary.Instance.GetDefinition(ammoName).id;
-
+                ECID = PartResourceLibrary.Instance.GetDefinition("ElectricCharge").id;
                 //laser setup
                 if (eWeaponType == WeaponTypes.Laser)
                 {
@@ -2731,10 +2731,14 @@ namespace BDArmory.Weapons
             if (BDArmorySettings.INFINITE_AMMO) return true;
             if (ECPerShot != 0)
             {
-                double chargeAvailable = part.RequestResource("ElectricCharge", ECPerShot, ResourceFlowMode.ALL_VESSEL);
-                if (chargeAvailable < ECPerShot * 0.95f && !CheatOptions.InfiniteElectricity)
+                vessel.GetConnectedResourceTotals(ECID, out double EcCurrent, out double ecMax);
+                if (EcCurrent > ECPerShot * 0.95f && !CheatOptions.InfiniteElectricity)
                 {
-                    ScreenMessages.PostScreenMessage("Weapon Requires EC", 5.0f, ScreenMessageStyle.UPPER_CENTER);
+                    part.RequestResource(ECID, ECPerShot, ResourceFlowMode.ALL_VESSEL);
+                }
+                else
+                {
+                    if (this.part.vessel.isActiveVessel) ScreenMessages.PostScreenMessage("Weapon Requires EC", 5.0f, ScreenMessageStyle.UPPER_CENTER);
                     return false;
                 }
                 //else return true; //this is causing weapons thath have ECPerShot + standard ammo (railguns, etc) to not consume ammo, only EC


### PR DESCRIPTION
-fix delay/penetrating fuze rounds sometimes not detonating
-better implement SpaceFriction initialization at round start
-Fix AI limiting to idle speed in space
-Add dynpressure limits in AdjustPitchForGAndAOALimits() when in space to prevent infinity values - may require further tweaking
-Add selfsealing options to Monoprop tanks
-Tanks using B9PartSwitcher now get selfsealing options
-penetrating rounds now register damage to all parts they hit, not just first
-Fix 'no EC' message spam if active vessel is not vessel with EC weapon
-EcPerShot now only drains EC if current EC >= ECPerShot