### PR TITLE
Vessel radius, closure time, lift calc changes

### DIFF
--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -1837,7 +1837,7 @@ namespace BDArmory.Control
             }
 
             // Adjust some values for asteroids.
-            var targetRadius = v.GetRadius(true);
+            var targetRadius = v.GetRadius();
             var threshold = collisionAvoidanceThreshold + targetRadius; // Add the target's average radius to the threshold.
             if (v.vesselType == VesselType.SpaceObject) // Give asteroids some extra room.
             {

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -4371,7 +4371,7 @@ namespace BDArmory.Control
                             float Cannistershot = Gun.ProjectileCount;
                             float candidateMinrange = Gun.engageRangeMin;
                             int candidatePriority = Mathf.RoundToInt(Gun.priority);
-                            float candidateRadius = currentTarget.Vessel.GetRadius();
+                            float candidateRadius = currentTarget.Vessel.GetRadius(Gun.fireTransforms[0].forward, target.bounds);
                             float candidateCaliber = Gun.caliber;
                             if (BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.RUNWAY_PROJECT_ROUND == 41)
                             {
@@ -4669,7 +4669,7 @@ namespace BDArmory.Control
                             bool candidateGimbal = Gun.turret;
                             float candidateMinrange = Gun.engageRangeMin;
                             float candidateTraverse = Gun.yawRange * Gun.maxPitch;
-                            float candidateRadius = currentTarget.Vessel.GetRadius();
+                            float candidateRadius = currentTarget.Vessel.GetRadius(Gun.fireTransforms[0].forward, target.bounds);
                             float candidateCaliber = Gun.caliber;
                             Transform fireTransform = Gun.fireTransforms[0];
 
@@ -6141,6 +6141,8 @@ namespace BDArmory.Control
             float closureTime = 3600f; // Default closure time of one hour
             if (threat) // If we weren't passed a null
             {
+                closureTime = vessel.ClosestTimeToCPA(threat, closureTime);
+                
                 float targetDistance = Vector3.Distance(threat.transform.position, vessel.transform.position);
                 Vector3 currVel = (float)vessel.srfSpeed * vessel.Velocity().normalized;
                 closureTime = Mathf.Clamp((float)(1 / ((threat.Velocity() - currVel).magnitude / targetDistance)), 0f, closureTime);

--- a/BDArmory/Extensions/VesselExtensions.cs
+++ b/BDArmory/Extensions/VesselExtensions.cs
@@ -66,16 +66,32 @@ namespace BDArmory.Extensions
         }
 
         // Get a vessel's "radius".
-        public static float GetRadius(this Vessel vessel, bool average = false)
+        public static float GetRadius(this Vessel vessel, Vector3 fireTransform = default(Vector3), Vector3 bounds = default(Vector3))
         {
-            // Get vessel size.
-            Vector3 size = vessel.vesselSize;
+            
 
-            if (average) // Get the average of the dimensions.
-                return (size.x + size.y + size.z) / 6f;
+            if (fireTransform == Vector3.zero || bounds == Vector3.zero)
+            {
+                // Get vessel size.
+                Vector3 size = vessel.vesselSize;
 
-            // Get largest dimension.
-            return Mathf.Max(Mathf.Max(size.x, size.y), size.z) / 2f;
+                // Get largest dimension.
+                return Mathf.Max(Mathf.Max(size.x, size.y), size.z) / 2f;
+            }
+            else
+            {
+                return Vector3.ProjectOnPlane(vessel.vesselTransform.up * bounds.y + vessel.vesselTransform.right * bounds.x + vessel.vesselTransform.forward * bounds.z, fireTransform).magnitude / 2f;
+            }
+        }
+
+        // Get a vessel's bounds.
+        public static Vector3 GetBounds(this Vessel vessel)
+        {
+            var vesselRot = vessel.transform.rotation;
+            vessel.SetRotation(Quaternion.identity);
+            Vector3 size = ShipConstruction.CalculateCraftSize(vessel.Parts, vessel.rootPart); //x: Width, y: Length, z: Height
+            vessel.SetRotation(vesselRot);
+            return size;
         }
     }
 }

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -33,6 +33,7 @@ namespace BDArmory.Targeting
         public float radarJammingDistance;
         public bool alreadyScheduledRCSUpdate = false;
         public float radarMassAtUpdate = 0f;
+        public Vector3 bounds = Vector3.zero;
 
         public List<Part> targetWeaponList = new List<Part>();
         public List<Part> targetEngineList = new List<Part>();
@@ -281,6 +282,9 @@ namespace BDArmory.Targeting
             //power generation? - radiators/generators - if doing CoaDE style fights/need reactors to power weapons
 
             if (vessel == null) return;
+
+            bounds = vessel.GetBounds(); // Update vessel bounds on part changes
+
             using (List<Part>.Enumerator part = vessel.Parts.GetEnumerator())
                 while (part.MoveNext())
                 {

--- a/BDArmory/Utils/FARUtils.cs
+++ b/BDArmory/Utils/FARUtils.cs
@@ -199,8 +199,9 @@ namespace BDArmory.Utils
                         if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.FARUtils]: Found volume of {aeroVolume} for {part.name}.");
 						if (BDArmorySettings.RUNWAY_PROJECT && !ctrlSrf) //if RunwayProject and part !controlsurface, remove lift/mass from edges to bring inline with stock boards
 						{
+                            bool isLiftingSurface = (float)PWType.GetField("stockLiftCoefficient", BindingFlags.Public | BindingFlags.Instance).GetValue(module) > 0f;
                             float liftCoeff = (length * (width / 2)) / 3.52f;
-                            PWType.GetField("stockLiftCoefficient", BindingFlags.Public | BindingFlags.Instance).SetValue(module, liftCoeff); //adjust PWing GUI lift readout
+                            PWType.GetField("stockLiftCoefficient", BindingFlags.Public | BindingFlags.Instance).SetValue(module, isLiftingSurface ? liftCoeff : 0f); //adjust PWing GUI lift readout
                             part.Modules.GetModule<ModuleLiftingSurface>().deflectionLiftCoeff = (length * (width / 2) / 3.52f); //adjust lift to be inline with stock wings
                             if (!WingctrlSrf)
                                 PWType.GetField("aeroUIMass", BindingFlags.Public | BindingFlags.Instance).SetValue(module, liftCoeff / 10); //Adjust PWing GUI mass readout

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -4265,6 +4265,7 @@ namespace BDArmory.Weapons
                     if (visualTargetPart == null || visualTargetPart.vessel != visualTargetVessel)
                     {
                         TargetInfo currentTarget = visualTargetVessel.gameObject.GetComponent<TargetInfo>();
+                        targetRadius = visualTargetVessel.GetRadius(fireTransforms[0].forward, currentTarget.bounds);
                         if (currentTarget == null)
                         {
                             if (BDArmorySettings.DEBUG_WEAPONS) Debug.Log("[BDArmory.ModuleWeapon]: Targeted vessel " + (visualTargetVessel != null ? visualTargetVessel.vesselName : "'unknown'") + " has no TargetInfo.");


### PR DESCRIPTION
 - Use vessel bounds based on ShipConstruction.CalculateCraftSize to get a more accurate calculation of vessel size for aiming with guns.
  - Fix lift readout adjustment when using non-lifting surface branch of PWing with Runway Project enabled.
  - Use TimeToCPA for missile closing time calculation so that acceleration is factored into closing time.