### PR TITLE
Pwings and things

### DIFF
--- a/BDArmory/Competition/VesselSpawning/SpawnUtils.cs
+++ b/BDArmory/Competition/VesselSpawning/SpawnUtils.cs
@@ -177,12 +177,12 @@ namespace BDArmory.Competition.VesselSpawning
             if (AI != null || WM != null)
             {
                 int count = 0;
-                if (AI != null && (AI.part.parent == null || AI.part.vessel.rootPart != AI.part.parent))
+                if (AI != null && (AI.part.parent == null || (AI.part.vessel.rootPart != AI.part.parent || AI.part.vessel.rootPart == AI.part)))
                 {
                     message += (WM == null ? " and its AI" : "'s AI");
                     ++count;
                 }
-                if (WM != null && (WM.part.parent == null || WM.part.vessel.rootPart != WM.part.parent))
+                if (WM != null && (WM.part.parent == null || (WM.part.vessel.rootPart != WM.part.parent || WM.part.vessel.rootPart == WM.part)))
                 {
                     message += (AI == null ? " and its WM" : (count > 0 ? " and WM" : "'s WM"));
                     ++count;

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -1564,6 +1564,15 @@ namespace BDArmory.Control
                             // weaponAimDebugStrings.Add($" - Target pos: {weapon.targetPosition.ToString("G3")}, vel: {weapon.targetVelocity.ToString("G4")}, acc: {weapon.targetAcceleration.ToString("G6")}");
                             // weaponAimDebugStrings.Add($" - Target rel pos: {(weapon.targetPosition - weapon.fireTransforms[0].position).ToString("G3")} ({(weapon.targetPosition - weapon.fireTransforms[0].position).magnitude:F1}), rel vel: {(weapon.targetVelocity - weapon.part.rb.velocity).ToString("G4")}, rel acc: {((Vector3)(weapon.targetAcceleration - weapon.vessel.acceleration)).ToString("G6")}");
                         }
+                        int shots = 0;
+                        int hits = 0;
+                        if (BDACompetitionMode.Instance.Scores.ScoreData.ContainsKey(vessel.vesselName))
+                        {
+                            hits = BDACompetitionMode.Instance.Scores.ScoreData[vessel.vesselName].hits;
+                            shots = BDACompetitionMode.Instance.Scores.ScoreData[vessel.vesselName].shotsFired;
+                        }
+                        weaponHeatDebugStrings.Add(" - Shots Fired: " + shots + ", Shots Hit: " + hits + ", Accuracy: " + (hits / shots));
+
                         if (weaponHeatDebugStrings.Count > 0)
                         {
                             debugString.AppendLine("Weapon Heat:\n" + string.Join("\n", weaponHeatDebugStrings));

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -86,7 +86,15 @@ namespace BDArmory.Control
 
         public void incrementRippleIndex(string weaponname)
         {
-            if (!gunRippleIndex.ContainsKey(weaponname)) { Debug.LogError($"[BDArmory.MissileFire]: Weapon {weaponname} on {vessel.vesselName} does not exist in the gunRippleIndex!"); return; }
+            if (!gunRippleIndex.ContainsKey(weaponname)) 
+            {
+                UpdateList();
+                if (!gunRippleIndex.ContainsKey(weaponname))
+                {
+                    Debug.LogError($"[BDArmory.MissileFire]: Weapon {weaponname} on {vessel.vesselName} does not exist in the gunRippleIndex!");
+                    return;
+                }
+            }
             gunRippleIndex[weaponname]++;
             if (gunRippleIndex[weaponname] >= GetRippleGunCount(weaponname))
             {
@@ -1571,7 +1579,7 @@ namespace BDArmory.Control
                             hits = BDACompetitionMode.Instance.Scores.ScoreData[vessel.vesselName].hits;
                             shots = BDACompetitionMode.Instance.Scores.ScoreData[vessel.vesselName].shotsFired;
                         }
-                        weaponHeatDebugStrings.Add(" - Shots Fired: " + shots + ", Shots Hit: " + hits + ", Accuracy: " + (hits / shots));
+                        weaponHeatDebugStrings.Add(" - Shots Fired: " + shots + ", Shots Hit: " + hits + ", Accuracy: " + (shots > 0 ? hits / shots : 0f));
 
                         if (weaponHeatDebugStrings.Count > 0)
                         {

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -119,7 +119,7 @@ namespace BDArmory.Damage
         [KSPField(isPersistant = true)]
         public float vFactor;
 
-        
+
         [KSPField(isPersistant = true)]
         public float muParam1;
         [KSPField(isPersistant = true)]
@@ -656,18 +656,18 @@ namespace BDArmory.Damage
         #endregion
 
         #region Hitpoints Functions
-        
-        //[KSPField(isPersistant = true)]
-        //public bool HPMode = false;
+
+        [KSPField(isPersistant = true)]
+        public bool HPMode = false;
         float oldmaxHitpoints;
-        /*
+
         [KSPEvent(advancedTweakable = true, guiActive = false, guiActiveEditor = true, guiName = "Toggle HP Calc", active = true)]//Self-Sealing Tank
         public void ToggleHPOption()
         {
             HPMode = !HPMode;
             if (!HPMode)
             {
-                Events["ToggleHPOption"].guiName = Localizer.Format("Revert to Legacy HP calc");  
+                Events["ToggleHPOption"].guiName = Localizer.Format("Revert to Legacy HP calc");
                 maxHitPoints = oldmaxHitpoints;
             }
             else
@@ -677,12 +677,12 @@ namespace BDArmory.Damage
                 maxHitPoints = -1;
             }
             SetupPrefab();
-            GUIUtils.RefreshAssociatedWindows(part);           
+            GUIUtils.RefreshAssociatedWindows(part);
         }
-        */
+
         public float CalculateTotalHitpoints()
         {
-            float hitpoints;// = -1;
+            float hitpoints = -1;
 
             if (!part.IsMissile())
             {
@@ -694,8 +694,8 @@ namespace BDArmory.Damage
                         float structuralMass = 100;
                         float structuralVolume = 1;
                         float density = 1;
-                        //if (!HPMode)
-                        //{
+                        if (!HPMode)
+                        {
                             var averageSize = part.GetAverageBoundSize();
                             var sphereRadius = averageSize * 0.5f;
                             var sphereSurface = 4 * Mathf.PI * sphereRadius * sphereRadius;
@@ -733,7 +733,7 @@ namespace BDArmory.Damage
                             // if (BDArmorySettings.DEBUG_LABELS) Debug.Log("[BDArmory.HitpointTracker]: " + part.name + " structural Volume: " + structuralVolume + "; density: " + density);
                             //3. final calculations
                             hitpoints = structuralMass * hitpointMultiplier * 0.333f;
-                        /*
+
                         }
                         else //revised HP calc, commented out for now until we get feedback on new method and decide to switch over
                         {
@@ -745,7 +745,7 @@ namespace BDArmory.Damage
                                                                          //parts that aren't cylinders or close enough and need exceptions: Wings, control surfaces, radiators/solar panels
                                                                          //var dryPartmass = part.mass - part.resourceMass;
                             var dryPartmass = part.mass;
-                            density = (dryPartmass * 1000) / structuralVolume; 
+                            density = (dryPartmass * 1000) / structuralVolume;
                             //var structuralMass = density * structuralVolume; // this means HP is solely determined my part mass, after assuming all parts have min density of 1000kg/m3
                             //Debug.Log("[BDArmory]: Hitpoint Calc" + part.name + " | structuralVolume : " + structuralVolume);
 
@@ -806,10 +806,10 @@ namespace BDArmory.Damage
                             if (part.IsAero() && !isProcWing)
                             {
                                 //hitpoints = dryPartmass * 7000 * hitpointMultiplier * 0.333f; //stock wing parts are 700 HP per unit of Lift, 10 lift/1000kg
-                                hitpoints = (float)part.Modules.GetModule<ModuleLiftingSurface>().deflectionLiftCoeff * 700  * hitpointMultiplier * 0.333f; //stock wings are 700 HP per lifting surface area; using lift instead of mass (110 Lift/ton) due to control surfaces weighing more
+                                hitpoints = (float)part.Modules.GetModule<ModuleLiftingSurface>().deflectionLiftCoeff * 700 * hitpointMultiplier * 0.333f; //stock wings are 700 HP per lifting surface area; using lift instead of mass (110 Lift/ton) due to control surfaces weighing more
                             }
                         }
-                        */
+
                         if (isProcPart)
                         {
                             structuralVolume = armorVolume * Mathf.PI / 6f * 0.1f; // Box area * sphere/cube ratio * 10cm. We use sphere/cube ratio to get similar results as part.GetAverageBoundSize().
@@ -858,7 +858,7 @@ namespace BDArmory.Damage
                             {
                                 float aeroVolume = ProceduralWing.GetPWingVolume(part); //PWing  0.7 * length * (widthRoot + WidthTip) + (thicknessRoot + ThicknessTip) / 4; yields 1.008 for a stock dimension 2*4*.18 board, so need mult of 1400 for parity with stock wing boards
                                 if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: Found {part.name}; HP: {Hitpoints}->{hitpoints} at time {Time.time}, partMass: {partMass}, Pwing Aerovolume: {aeroVolume}");
-                                hitpoints = (float)Math.Round(part.Modules.GetModule<ModuleControlSurface>() ? part.Modules.GetModule<ModuleLiftingSurface>().deflectionLiftCoeff * 700 : (aeroVolume * 1400), 2)  * hitpointMultiplier * 0.333f; //use volume for wings (since they may have lift toggled off), use lift area for control surfaces
+                                hitpoints = (float)Math.Round(part.Modules.GetModule<ModuleControlSurface>() ? part.Modules.GetModule<ModuleLiftingSurface>().deflectionLiftCoeff * 700 : (aeroVolume * 1400), 2) * hitpointMultiplier * 0.333f; //use volume for wings (since they may have lift toggled off), use lift area for control surfaces
                                 //hitpoints should scale with stock wings correctly (and if used as thicker structural elements, should scale with tanks of similar size)
                                 if (FerramAerospace.CheckForFAR())
                                 {
@@ -884,8 +884,9 @@ namespace BDArmory.Damage
                         //if (hitpoints > 2000) //Hardcoded? slider setting? .cfg setting?
                         //{
                         //--HP log scaling goes here--
-                            //Mathf.Min(hitpoints, 2000 * Mathf.Log(hitpoints / 1164 + 1)); //?
+                        //Mathf.Min(hitpoints, 2000 * Mathf.Log(hitpoints / 1164 + 1)); //? uncomment once part index finished for before and after comparisons
                         //}
+
                         switch (HullTypeNum)
                         {
                             case 1:

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -1208,7 +1208,33 @@ namespace BDArmory.Damage
 
                 SafeUseTemp = 993;
                 Armor = 10;
-                if (ArmorPanel) Armor = 25;
+                if (ArmorPanel)
+                {
+                    ArmorTypeNum = 2;
+                    Armor = 25;
+                    Density = 7850;
+                    Diffusivity = 48.5f;
+                    Ductility = 0.15f;
+                    Hardness = 1176;
+                    Strength = 940;
+
+                    // Calculated using yield = 700 MPa and youngModulus = 200 GPA
+                    vFactor = 9.47761748e-07f;
+                    muParam1 = 0.656060636f;
+                    muParam2 = 1.20190930f;
+                    muParam3 = 1.77791929f;
+                    muParam1S = 0.947031140f;
+                    muParam2S = 1.55575776f;
+                    muParam3S = 2.75371552f;
+                }
+                else
+                {
+                    Fields["Armor"].guiActiveEditor = false;
+                    Fields["guiArmorTypeString"].guiActiveEditor = false;
+                    Fields["guiArmorTypeString"].guiActive = false;
+                    Fields["armorCost"].guiActiveEditor = false;
+                    Fields["armorMass"].guiActiveEditor = false;
+                }
                 if (BDArmorySettings.DEBUG_ARMOR)
                 {
                     Debug.Log("[ARMOR] Armor of " + part.name + " reset to defaults by RESET_ARMOUR");
@@ -1258,6 +1284,11 @@ namespace BDArmory.Damage
                     armorFieldFlight.maxValue = maxSupportedArmor;
                 }
                 */
+                Fields["Armor"].guiActiveEditor = true;
+                Fields["guiArmorTypeString"].guiActiveEditor = true;
+                Fields["guiArmorTypeString"].guiActive = true;
+                Fields["armorCost"].guiActiveEditor = true;
+                Fields["armorMass"].guiActiveEditor = true;
                 UI_FloatRange armorFieldEditor = (UI_FloatRange)Fields["Armor"].uiControlEditor;
                 if (armorFieldEditor.maxValue != maxSupportedArmor)
                 {
@@ -1275,12 +1306,15 @@ namespace BDArmory.Damage
             else
             {
                 Armor = 10;
-                UI_FloatRange armorFieldEditor = (UI_FloatRange)Fields["Armor"].uiControlEditor;
-                armorFieldEditor.maxValue = 10; //max none armor to 10 (simulate part skin of alimunium)
-                armorFieldEditor.minValue = 10;
-                //UI_FloatRange armorFieldFlight = (UI_FloatRange)Fields["Armor"].uiControlFlight;
-                //armorFieldFlight.minValue = 0f;
-                //armorFieldFlight.maxValue = 10;
+                Fields["Armor"].guiActiveEditor = false;
+                Fields["guiArmorTypeString"].guiActiveEditor = false;
+                Fields["guiArmorTypeString"].guiActive = false;
+                Fields["armorCost"].guiActiveEditor = false;
+                Fields["armorMass"].guiActiveEditor = false;
+                //UI_FloatRange armorFieldEditor = (UI_FloatRange)Fields["Armor"].uiControlEditor;
+                //armorFieldEditor.maxValue = 10; //max none armor to 10 (simulate part skin of alimunium)
+                //armorFieldEditor.minValue = 10;
+
                 part.RefreshAssociatedWindows();
                 //GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
             }

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -835,37 +835,42 @@ namespace BDArmory.Damage
                         //hitpoints = (structuralVolume * Mathf.Pow(density, .333f) * Mathf.Clamp(80 - (structuralVolume / 2), 80 / 4, 80)) * hitpointMultiplier * 0.333f; //volume * cuberoot of density * HP mult scaled by size
 
                         if (isProcWing)
-                        {/*
-                            if (FerramAerospace.CheckForFAR())
+                        {
+                            if (!BDArmorySettings.RUNWAY_PROJECT) //how granular do we want to get with this...? Keep this inside the RP toggle, or spin it off into a new one?
                             {
-                                //procwing hp already modified by mass, because it is mass
-                                //so using base part mass as it can be properly modified by material HP mod below
-                                if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: Found {part.name} (FAR); HP: {Hitpoints}->{hitpoints} at time {Time.time}, partMass: {partMass}, FAR massMult: {FerramAerospace.GetFARMassMult(part)}");
-                                //hitpoints = ((partMass / FerramAerospace.GetFARMassMult(part)) * 1000f) * 3.5f * hitpointMultiplier * 0.333f; //To account for FAR's Strength-mass Scalar.  
-                                hitpoints = (partMass * 1000f) * 3.5f * hitpointMultiplier * 0.333f;
-                                armorVolume = (float)Math.Round(hitpoints / hitpointMultiplier / 0.333 / 175, 1) / FerramAerospace.GetFARMassMult(part); //half of HP due to wing's 0.5x area modifier to prevent double armor
-                            }
-                            else
-                            {
-                                hitpoints = (float)Math.Round(part.Modules.GetModule<ModuleControlSurface>() ? part.Modules.GetModule<ModuleLiftingSurface>().deflectionLiftCoeff : partMass * 10, 2) * 700 * hitpointMultiplier * 0.333f; //use mass*10 for wings (since they may have lift toggled off), use lift area for control surfaces
-								armorVolume = (float)Math.Round(hitpoints / hitpointMultiplier / 0.333 / 350, 1); //stock is 0.25 lift/m2, so...
-                                //edges contribute to HP when they shouldn't; suggestion was to use tank volume instead (which would also allow thickness to play a role in HP), try ProceduralWing.aeroStatVolume * 700 
-                            } 
-                            */
-                            hitpoints = -1;
-                            armorVolume = -1;
-                            if (ProceduralWing.CheckForB9ProcWing() && ProceduralWing.CheckForPWModule())
-                            {
-                                float aeroVolume = ProceduralWing.GetPWingVolume(part); //PWing  0.7 * length * (widthRoot + WidthTip) + (thicknessRoot + ThicknessTip) / 4; yields 1.008 for a stock dimension 2*4*.18 board, so need mult of 1400 for parity with stock wing boards
-                                if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: Found {part.name}; HP: {Hitpoints}->{hitpoints} at time {Time.time}, partMass: {partMass}, Pwing Aerovolume: {aeroVolume}");
-                                hitpoints = (float)Math.Round(part.Modules.GetModule<ModuleControlSurface>() ? part.Modules.GetModule<ModuleLiftingSurface>().deflectionLiftCoeff * 700 : (aeroVolume * 1400), 2) * hitpointMultiplier * 0.333f; //use volume for wings (since they may have lift toggled off), use lift area for control surfaces
-                                //hitpoints should scale with stock wings correctly (and if used as thicker structural elements, should scale with tanks of similar size)
-                                if (FerramAerospace.CheckForFAR())
+                                if (FerramAerospace.CheckForFAR()) //half-baked legacy method that we're stuck with lest FJRT whine
                                 {
+                                    //procwing hp already modified by mass, because it is mass
+                                    //so using base part mass as it can be properly modified by material HP mod below
                                     if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: Found {part.name} (FAR); HP: {Hitpoints}->{hitpoints} at time {Time.time}, partMass: {partMass}, FAR massMult: {FerramAerospace.GetFARMassMult(part)}");
-                                    hitpoints *= FerramAerospace.GetFARMassMult(part); //PWing HP no longer mass dependant, so lets have FAR's structural strengthening/weakening have an effect on HP. you want light wings? they're goingto be fragile, and vice versa
+                                    //hitpoints = ((partMass / FerramAerospace.GetFARMassMult(part)) * 1000f) * 3.5f * hitpointMultiplier * 0.333f; //To account for FAR's Strength-mass Scalar.  
+                                    hitpoints = (partMass * 1000f) * 3.5f * hitpointMultiplier * 0.333f;
+                                    armorVolume = (float)Math.Round(hitpoints / hitpointMultiplier / 0.333 / 175, 1) / FerramAerospace.GetFARMassMult(part); //half of HP due to wing's 0.5x area modifier to prevent double armor
                                 }
-                                armorVolume = ProceduralWing.GetPWingArea(part);
+                                else
+                                {
+                                    hitpoints = (float)Math.Round(part.Modules.GetModule<ModuleControlSurface>() ? part.Modules.GetModule<ModuleLiftingSurface>().deflectionLiftCoeff : partMass * 10, 2) * 700 * hitpointMultiplier * 0.333f; //use mass*10 for wings (since they may have lift toggled off), use lift area for control surfaces
+                                    armorVolume = (float)Math.Round(hitpoints / hitpointMultiplier / 0.333 / 350, 1); //stock is 0.25 lift/m2, so...
+                                                                                                                      //edges contribute to HP when they shouldn't; suggestion was to use tank volume instead (which would also allow thickness to play a role in HP), try ProceduralWing.aeroStatVolume * 700 
+                                }
+                            }
+                            if (BDArmorySettings.RUNWAY_PROJECT || part.name.Contains("B9_Aero_Wing_Procedural_Panel")) //method to make pwings balanced with stock. 
+                            {
+                                hitpoints = -1;
+                                armorVolume = -1;
+                                if (ProceduralWing.CheckForB9ProcWing() && ProceduralWing.CheckForPWModule())
+                                {
+                                    float aeroVolume = ProceduralWing.GetPWingVolume(part); //PWing  0.7 * length * (widthRoot + WidthTip) + (thicknessRoot + ThicknessTip) / 4; yields 1.008 for a stock dimension 2*4*.18 board, so need mult of 1400 for parity with stock wing boards
+                                    if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: Found {part.name}; HP: {Hitpoints}->{hitpoints} at time {Time.time}, partMass: {partMass}, Pwing Aerovolume: {aeroVolume}");
+                                    hitpoints = (float)Math.Round(part.Modules.GetModule<ModuleControlSurface>() ? part.Modules.GetModule<ModuleLiftingSurface>().deflectionLiftCoeff * 700 : (aeroVolume * 1400), 2) * hitpointMultiplier * 0.333f; //use volume for wings (since they may have lift toggled off), use lift area for control surfaces
+                                                                                                                                                                                                                                                     //hitpoints should scale with stock wings correctly (and if used as thicker structural elements, should scale with tanks of similar size)
+                                    if (FerramAerospace.CheckForFAR())
+                                    {
+                                        if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: Found {part.name} (FAR); HP: {Hitpoints}->{hitpoints} at time {Time.time}, partMass: {partMass}, FAR massMult: {FerramAerospace.GetFARMassMult(part)}");
+                                        hitpoints *= FerramAerospace.GetFARMassMult(part); //PWing HP no longer mass dependant, so lets have FAR's structural strengthening/weakening have an effect on HP. you want light wings? they're goingto be fragile, and vice versa
+                                    }
+                                    armorVolume = ProceduralWing.GetPWingArea(part);
+                                }
                             }
                             if (hitpoints < 0) //sanity checks
                             {

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -859,7 +859,7 @@ namespace BDArmory.Damage
                                 float aeroVolume = ProceduralWing.GetPWingVolume(part); //PWing  0.7 * length * (widthRoot + WidthTip) + (thicknessRoot + ThicknessTip) / 4; yields 1.008 for a stock dimension 2*4*.18 board, so need mult of 1400 for parity with stock wing boards
                                 if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: Found {part.name}; HP: {Hitpoints}->{hitpoints} at time {Time.time}, partMass: {partMass}, Pwing Aerovolume: {aeroVolume}");
                                 hitpoints = (float)Math.Round(part.Modules.GetModule<ModuleControlSurface>() ? part.Modules.GetModule<ModuleLiftingSurface>().deflectionLiftCoeff * 700 : (aeroVolume * 1400), 2)  * hitpointMultiplier * 0.333f; //use volume for wings (since they may have lift toggled off), use lift area for control surfaces
-
+                                //hitpoints should scale with stock wings correctly (and if used as thicker structural elements, should scale with tanks of similar size)
                                 if (FerramAerospace.CheckForFAR())
                                 {
                                     if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: Found {part.name} (FAR); HP: {Hitpoints}->{hitpoints} at time {Time.time}, partMass: {partMass}, FAR massMult: {FerramAerospace.GetFARMassMult(part)}");
@@ -881,6 +881,11 @@ namespace BDArmory.Damage
                         }
                         if ((isProcPart || isProcWing) && BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.MAX_PWING_HP >= 100) hitpoints = Mathf.Clamp(hitpoints, 100, BDArmorySettings.MAX_PWING_HP);
 
+                        //if (hitpoints > 2000) //Hardcoded? slider setting? .cfg setting?
+                        //{
+                        //--HP log scaling goes here--
+                            //Mathf.Min(hitpoints, 2000 * Mathf.Log(hitpoints / 1164 + 1)); //?
+                        //}
                         switch (HullTypeNum)
                         {
                             case 1:

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -656,11 +656,11 @@ namespace BDArmory.Damage
         #endregion
 
         #region Hitpoints Functions
-
-        [KSPField(isPersistant = true)]
-        public bool HPMode = false;
+        
+        //[KSPField(isPersistant = true)]
+        //public bool HPMode = false;
         float oldmaxHitpoints;
-
+        /*
         [KSPEvent(advancedTweakable = true, guiActive = false, guiActiveEditor = true, guiName = "Toggle HP Calc", active = true)]//Self-Sealing Tank
         public void ToggleHPOption()
         {
@@ -679,10 +679,10 @@ namespace BDArmory.Damage
             SetupPrefab();
             GUIUtils.RefreshAssociatedWindows(part);
         }
-
+        */
         public float CalculateTotalHitpoints()
         {
-            float hitpoints = -1;
+            float hitpoints;// = -1;
 
             if (!part.IsMissile())
             {
@@ -694,7 +694,7 @@ namespace BDArmory.Damage
                         float structuralMass = 100;
                         float structuralVolume = 1;
                         float density = 1;
-                        if (!HPMode)
+                        //if (!HPMode)
                         {
                             var averageSize = part.GetAverageBoundSize();
                             var sphereRadius = averageSize * 0.5f;
@@ -735,6 +735,7 @@ namespace BDArmory.Damage
                             hitpoints = structuralMass * hitpointMultiplier * 0.333f;
 
                         }
+                        /*
                         else //revised HP calc, commented out for now until we get feedback on new method and decide to switch over
                         {
                             //var averageSize = part.GetVolume(); // this grabs x/y/z dimensions from PartExtensions.cs 
@@ -809,7 +810,7 @@ namespace BDArmory.Damage
                                 hitpoints = (float)part.Modules.GetModule<ModuleLiftingSurface>().deflectionLiftCoeff * 700 * hitpointMultiplier * 0.333f; //stock wings are 700 HP per lifting surface area; using lift instead of mass (110 Lift/ton) due to control surfaces weighing more
                             }
                         }
-
+                        */
                         if (isProcPart)
                         {
                             structuralVolume = armorVolume * Mathf.PI / 6f * 0.1f; // Box area * sphere/cube ratio * 10cm. We use sphere/cube ratio to get similar results as part.GetAverageBoundSize().

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -837,7 +837,7 @@ namespace BDArmory.Damage
 
                         if (isProcWing)
                         {
-                            if (!BDArmorySettings.RUNWAY_PROJECT) //how granular do we want to get with this...? Keep this inside the RP toggle, or spin it off into a new one?
+                            if (!BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.PWING_EDGE_LIFT) 
                             {
                                 if (FerramAerospace.CheckForFAR()) //half-baked legacy method that we're stuck with lest FJRT whine
                                 {
@@ -855,7 +855,7 @@ namespace BDArmory.Damage
                                                                                                                       //edges contribute to HP when they shouldn't; suggestion was to use tank volume instead (which would also allow thickness to play a role in HP), try ProceduralWing.aeroStatVolume * 700 
                                 }
                             }
-                            if (BDArmorySettings.RUNWAY_PROJECT || part.name.Contains("B9_Aero_Wing_Procedural_Panel")) //method to make pwings balanced with stock. 
+                            if ((!BDArmorySettings.PWING_EDGE_LIFT || BDArmorySettings.RUNWAY_PROJECT) || part.name.Contains("B9_Aero_Wing_Procedural_Panel")) //method to make pwings balanced with stock. 
                             {
                                 hitpoints = -1;
                                 armorVolume = -1;
@@ -868,7 +868,7 @@ namespace BDArmory.Damage
                                     if (FerramAerospace.CheckForFAR())
                                     {
                                         if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: Found {part.name} (FAR); HP: {Hitpoints}->{hitpoints} at time {Time.time}, partMass: {partMass}, FAR massMult: {FerramAerospace.GetFARMassMult(part)}");
-                                        hitpoints *= FerramAerospace.GetFARMassMult(part); //PWing HP no longer mass dependant, so lets have FAR's structural strengthening/weakening have an effect on HP. you want light wings? they're goingto be fragile, and vice versa
+                                        hitpoints *= FerramAerospace.GetFARMassMult(part); //PWing HP no longer mass dependant, so lets have FAR's structural strengthening/weakening have an effect on HP. you want light wings? they're going to be fragile, and vice versa
                                     }
                                     armorVolume = ProceduralWing.GetPWingArea(part);
                                 }
@@ -885,13 +885,10 @@ namespace BDArmory.Damage
                             }
                             ArmorModified(null, null);
                         }
-                        if ((isProcPart || isProcWing) && BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.MAX_PWING_HP >= 100) hitpoints = Mathf.Clamp(hitpoints, 100, BDArmorySettings.MAX_PWING_HP);
-
-                        //if (hitpoints > 2000) //Hardcoded? slider setting? .cfg setting?
-                        //{
-                        //--HP log scaling goes here--
-                        //Mathf.Min(hitpoints, 2000 * Mathf.Log(hitpoints / 1164 + 1)); //? uncomment once part index finished for before and after comparisons
-                        //}
+                        if (BDArmorySettings.HP_THRESHOLD >= 100 && hitpoints > BDArmorySettings.HP_THRESHOLD)
+                        {
+                            Mathf.Min(hitpoints, 2000 * Mathf.Log(hitpoints / 1164 + 1));
+                        }
 
                         switch (HullTypeNum)
                         {

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -7,20 +7,24 @@ IMPROVEMENTS / FIXES
 	- Make wheels susceptible to bullets and explosions too.
 	- Fix off-centered arrow on inline radome texture  Git Issue #409
 	- Re-fix lead issue on Apple Silicon.
-	- Adjust Pwing HP calculations to be a bit more inline with stock.
-		- IF (and only if) 'RunwayProject' is enabled, colliderless Pwing edges will no longer be included for Pwing mass/lift calcs, to bring them in line with stock wings for balance reasons.
+	- Adds optional adjustable Logarithmic HP clamp, replacing the Proc PArt Max HP slider.
+	- Adds optional toggle to disable lift from colliderless PWing edges for better balance with stock wings/prevent pwing abuse
 	- Apply the gapless particle emitter option to 'DecalGaplessParticleEmitter's too.
 	- Reduce frequency of null FX object pool entries by catching unloading events too.
-  - Add Attachnode to the Ordinance bay to fix issues with Breaking Ground Robotics.
-
+    - Add Attachnode to the Ordinance bay to fix issues with Breaking Ground Robotics.
+	- Adds debugging messages to assist with making custom weapons.
+	- Adds MM patch to add liftless Proc Structural Panel if B9 Pwings installed.
 - UI:
 	- Fix exception when resetting colours in Team Icons.
 	- Prevent the kill timer from showing in the Loaded Vessel Switcher window for surface vessels.
 	- Updated German localization by EzBro.
+	- Adds Accuracy readout to the Weapon Debuggling telemetry.
+	- Setting the Armor Type to 'None' now disables the armor thickness slider; fixes PAW issue in KSP 1.9.1 installs.
 - Competition:
 	- Fix exception in auto-resuming tournaments when SpawnProbe.craft isn't found.
 	- Fix incorrect Kill Steal attribution from 1v1 fights.
 	- Abort competition if a team leader still isn't ready to engage (airborne for pilot AI) by the time the start-competition-now timer runs out.
+	- Fixes AI/WM not attached to Root Part error messages on competition start when using combat seats as the root part.
 - Spawning:
 	- Wait until after vessels are unpacked before reverting the spawn camera - fixes an exception with EVA kerbals and KSPCF.
 	- Fix freezing when vessel removal throws an exception.

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -172,7 +172,7 @@ Localization
         #LOC_BDArmory_Settings_TerrainAlertFrequency = Terrain Check Frequency
         #LOC_BDArmory_Settings_CameraSwitchFrequency = Camera Switch Frequency
         #LOC_BDArmory_Settings_DeathCameraInhibitPeriod = Death Camera Inhibit Period
-        #LOC_BDArmory_Settings_Max_PWing_HP = Max ProcPart HP
+        #LOC_BDArmory_Settings_Max_PWing_HP = HP Scaling Threshold
         #LOC_BDArmory_Settings_DisableRamming = Disable Ramming
         #LOC_BDArmory_Settings_DefaultFFATargeting = Default FFA Targeting
         #LOC_BDArmory_Settings_TagMode = Tag Mode
@@ -191,6 +191,7 @@ Localization
         #LOC_BDArmory_Settings_ResetArmor = Reset Armor of parts
         #LOC_BDArmory_Settings_ResetHull = Reset Material of parts
         #LOC_BDArmory_Settings_IntakeHack = Hack Intakes
+        #LOC_BDArmory_Settings_PWingsHack = Pwing Edge Lift
         #LOC_BDArmory_Settings_KerbalSafety = Kerbal Safety
         #LOC_BDArmory_Settings_KerbalSafetyInventory = Kerbal Inventory
         #LOC_BDArmory_Settings_KerbalSafetyInventory_NoChange = No Change

--- a/BDArmory/Distribution/GameData/BDArmory/MMPatches/StructPWing.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/MMPatches/StructPWing.cfg
@@ -1,0 +1,54 @@
++PART[B9_Aero_Wing_Procedural_TypeA]
+{
+    	@name = B9_Aero_Wing_Procedural_Panel
+	@title = B9-PW Procedural Structural Panel
+	@description = Procedural Structural Panel you can shape in any way you want using the context menu. Press J while pointing at this part to open the editor window allowing you to edit the shape and materials of this part. You can exit the editing mode by switching to editing of another part in the very same way, or by pressing J again, or by closing the window. The window can also be opened and closed using the B9 button in the bottom-right corner of the screen. THIS PART WILL NOT GENERATE LIFT.
+
+	@MODULE[ModuleLiftingSurface]
+	{
+		@deflectionLiftCoeff = 0
+	}
+}
+
+@PART[B9_Aero_Wing_Procedural_Panel]:NEEDS[ferramGraph]:FINAL
+{
+	!MODULE[ModuleLiftingSurface] {}
+	!MODULE[FARWingAerodynamicModel] {}
+}
+
+@PART[B9_Aero_Wing_Procedural_Panel]:HAS[@MODULE[WingProcedural]]:FOR[B9_Aerospace_WingStuff]:NEEDS[TexturesUnlimited&!TURD/TU_B9_ProcWings]
+{
+    MODULE
+    {
+        name = SSTURecolorGUI
+    }
+
+    MODULE
+    {
+        name = KSPTextureSwitch
+        transformName = surface
+        sectionName = Surface
+
+        currentTextureSet = Smooth-Metal-Solid
+        textureSet = Smooth-Metal-Solid
+    }
+
+	MODULE
+    {
+        name = KSPTextureSwitch
+        transformName = frame
+        sectionName = Frame
+
+        currentTextureSet = Smooth-Metal-Solid
+        textureSet = Smooth-Metal-Solid
+    }
+
+	MODULE
+    {
+        name = KSPTextureSwitch
+        sectionName = Edge
+
+		currentTextureSet = B9PWings-edge-metal
+        textureSet = B9PWings-edge-metal
+    }
+}

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -128,7 +128,8 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_SPREAD = 5f;
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_BIAS = 0.16f;
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_HIT_MULTIPLIER = 2f;
-        [BDAPersistentSettingsField] public static float MAX_PWING_HP = 2500f;
+        [BDAPersistentSettingsField] public static float HP_THRESHOLD = 2000f;                  //HP above this value will be scaled to a logarithmic value
+        [BDAPersistentSettingsField] public static bool PWING_EDGE_LIFT = true;                  //Toggle lift on PWing edges for balance with stock wings/remove edge abuse
         // Physics constants
         [BDAPersistentSettingsField] public static float GLOBAL_LIFT_MULTIPLIER = 0.25f;
         [BDAPersistentSettingsField] public static float GLOBAL_DRAG_MULTIPLIER = 6f;

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -2678,6 +2678,7 @@ namespace BDArmory.UI
 
                 if (BDArmorySettings.ADVANDED_USER_SETTINGS)
                 {
+                    BDArmorySettings.PWING_EDGE_LIFT = GUI.Toggle(SRightRect(line), BDArmorySettings.PWING_EDGE_LIFT, Localizer.Format("#LOC_BDArmory_Settings_PWingsHack"));//Toggle Pwing Edge Lift
                     BDArmorySettings.DEFAULT_FFA_TARGETING = GUI.Toggle(SLeftRect(++line), BDArmorySettings.DEFAULT_FFA_TARGETING, Localizer.Format("#LOC_BDArmory_Settings_DefaultFFATargeting"));// Free-for-all combat style
                     BDArmorySettings.DISABLE_RAMMING = GUI.Toggle(SRightRect(line), BDArmorySettings.DISABLE_RAMMING, Localizer.Format("#LOC_BDArmory_Settings_DisableRamming"));// Disable Ramming
                     BDArmorySettings.AUTONOMOUS_COMBAT_SEATS = GUI.Toggle(SLeftRect(++line), BDArmorySettings.AUTONOMOUS_COMBAT_SEATS, Localizer.Format("#LOC_BDArmory_Settings_AutonomousCombatSeats"));
@@ -2784,9 +2785,9 @@ namespace BDArmory.UI
                     GUI.Label(SLeftSliderRect(++line), $"{Localizer.Format("#LOC_BDArmory_Settings_DeathCameraInhibitPeriod")}:  ({(BDArmorySettings.DEATH_CAMERA_SWITCH_INHIBIT_PERIOD == 0 ? BDArmorySettings.CAMERA_SWITCH_FREQUENCY / 2f : BDArmorySettings.DEATH_CAMERA_SWITCH_INHIBIT_PERIOD)}s)", leftLabel); // Camera switch inhibit period after the active vessel dies.
                     BDArmorySettings.DEATH_CAMERA_SWITCH_INHIBIT_PERIOD = Mathf.RoundToInt(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.DEATH_CAMERA_SWITCH_INHIBIT_PERIOD, 0f, 10f));
                 }
-                GUI.Label(SLeftSliderRect(++line), $"{Localizer.Format("#LOC_BDArmory_Settings_Max_PWing_HP")}:  {(BDArmorySettings.MAX_PWING_HP >= 100 ? (BDArmorySettings.MAX_PWING_HP.ToString()) : "Unclamped")}", leftLabel); // Max PWing HP
-                BDArmorySettings.MAX_PWING_HP = GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.MAX_PWING_HP, 0, 10000);
-                BDArmorySettings.MAX_PWING_HP = Mathf.Round(BDArmorySettings.MAX_PWING_HP / 100) * 100;
+                GUI.Label(SLeftSliderRect(++line), $"{Localizer.Format("#LOC_BDArmory_Settings_Max_PWing_HP")}:  {(BDArmorySettings.HP_THRESHOLD >= 100 ? (BDArmorySettings.HP_THRESHOLD.ToString()) : "Unclamped")}", leftLabel); // Max PWing HP
+                BDArmorySettings.HP_THRESHOLD = GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.HP_THRESHOLD, 0, 10000);
+                BDArmorySettings.HP_THRESHOLD = Mathf.Round(BDArmorySettings.HP_THRESHOLD / 100) * 100;
 
                 line += 0.5f;
             }

--- a/BDArmory/Utils/FARUtils.cs
+++ b/BDArmory/Utils/FARUtils.cs
@@ -189,13 +189,18 @@ namespace BDArmory.Utils
                         float length = (float)PWType.GetField("sharedBaseLength", BindingFlags.Public | BindingFlags.Instance).GetValue(module);
                         float width = ((float)PWType.GetField("sharedBaseWidthRoot", BindingFlags.Public | BindingFlags.Instance).GetValue(module) + (float)PWType.GetField("sharedBaseWidthTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module));
                         float thickness = ((float)PWType.GetField("sharedBaseThicknessRoot", BindingFlags.Public | BindingFlags.Instance).GetValue(module) + (float)PWType.GetField("sharedBaseThicknessTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module));
-                        if (thickness > 0.36f) //0.18 * 2
-                            thickness = (Mathf.Max(0.36f, ((Mathf.Log(thickness * 0.5f) + 1) * 0.75f))); 
+                        //if (BDArmorySettings.RUNWAY_PROJECT)
+                        //{
+                            if (thickness > 0.36f) //0.18 * 2
+                                thickness = (Mathf.Max(0.36f, (Mathf.Log(1 + (thickness * 0.5f)) * 0.75f)));
                             //thickness = 0.36f; //thickness doesn't add to pwing mass, so why should it add to HP? 
-                            //- because edge lift don't contribute to HP anymore
+                            //- because edge lift doesn't contribute to HP anymore
+                            //will also incentivise using a single thick wing instead of wing sandwiching 
                             //look into making thickness add mass?
                             //-that seems like a change that really should be part of pwings proper, not bolted on here, even if it really would help balance out pwings...
-                        float aeroVolume = (0.7f * length * width * thickness) / 4;
+                        //}
+                        //else thickness = 0.36f;
+                        float aeroVolume = (0.786f * length * width * thickness) / 4; //original .7 was based on errorneous 2x4 wingboard dimensions; stock reference wing area is 1.875x3.75m
                         if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.FARUtils]: Found volume of {aeroVolume} for {part.name}.");
 						if (BDArmorySettings.RUNWAY_PROJECT && !ctrlSrf) //if RunwayProject and part !controlsurface, remove lift/mass from edges to bring inline with stock boards
 						{

--- a/BDArmory/Utils/FARUtils.cs
+++ b/BDArmory/Utils/FARUtils.cs
@@ -188,18 +188,20 @@ namespace BDArmory.Utils
                         bool ctrlSrf = (bool)PWType.GetField("isCtrlSrf", BindingFlags.Public | BindingFlags.Instance).GetValue(module);
                         float length = (float)PWType.GetField("sharedBaseLength", BindingFlags.Public | BindingFlags.Instance).GetValue(module);
                         float width = ((float)PWType.GetField("sharedBaseWidthRoot", BindingFlags.Public | BindingFlags.Instance).GetValue(module) + (float)PWType.GetField("sharedBaseWidthTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module));
-                        float thickness = ((float)PWType.GetField("sharedBaseThicknessRoot", BindingFlags.Public | BindingFlags.Instance).GetValue(module) + (float)PWType.GetField("sharedBaseThicknessTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module));
-                        //if (BDArmorySettings.RUNWAY_PROJECT)
-                        //{
+                        /*float thickness = ((float)PWType.GetField("sharedBaseThicknessRoot", BindingFlags.Public | BindingFlags.Instance).GetValue(module) + (float)PWType.GetField("sharedBaseThicknessTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module));
+                        if (BDArmorySettings.RUNWAY_PROJECT)
+                        {
                             if (thickness > 0.36f) //0.18 * 2
                                 thickness = (Mathf.Max(0.36f, (Mathf.Log(1 + (thickness * 0.5f)) * 0.75f)));
                             //thickness = 0.36f; //thickness doesn't add to pwing mass, so why should it add to HP? 
-                            //- because edge lift doesn't contribute to HP anymore
+                            //- because edge lift doesn't contribute to HP anymore, and past a certain thickness, the increased height of the collider is an issue
                             //will also incentivise using a single thick wing instead of wing sandwiching 
                             //look into making thickness add mass?
                             //-that seems like a change that really should be part of pwings proper, not bolted on here, even if it really would help balance out pwings...
-                        //}
-                        //else thickness = 0.36f;
+                        }
+                        else thickness = 0.36f;
+                        */
+                        float thickness = 0.36f;
                         float aeroVolume = (0.786f * length * width * thickness) / 4; //original .7 was based on errorneous 2x4 wingboard dimensions; stock reference wing area is 1.875x3.75m
                         if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.FARUtils]: Found volume of {aeroVolume} for {part.name}.");
 						if (BDArmorySettings.RUNWAY_PROJECT && !ctrlSrf) //if RunwayProject and part !controlsurface, remove lift/mass from edges to bring inline with stock boards
@@ -210,7 +212,13 @@ namespace BDArmory.Utils
                             if (!WingctrlSrf)
                                 PWType.GetField("aeroUIMass", BindingFlags.Public | BindingFlags.Instance).SetValue(module, liftCoeff / 10); //Adjust PWing GUI mass readout
                             else
-                                PWType.GetField("aeroUIMass", BindingFlags.Public | BindingFlags.Instance).SetValue(module, liftCoeff / 5); //this modifies the IPartMassModifier, so the mass will also change along with the GUI
+                                PWType.GetField("aeroUIMass", BindingFlags.Public | BindingFlags.Instance).SetValue(module, liftCoeff / 5); //this modifies the IPartMassModifier, so the mass will also change along with the GUI                          
+                        }
+                        if (part.name.Contains("B9_Aero_Wing_Procedural_Panel")) //if Josue's noLift PWings PR never gets folded in, here's an alternative using an MM'ed PWing structural panel part
+                        {
+                            PWType.GetField("stockLiftCoefficient", BindingFlags.Public | BindingFlags.Instance).SetValue(module, 0); //adjust PWing GUI lift readout
+                            PWType.GetField("aeroUIMass", BindingFlags.Public | BindingFlags.Instance).SetValue(module, ((length * (width / 2)) / 3.52f) / 12.5); //Struct panels lighter than wings      
+                            //PWType.GetField("aeroUIMass", BindingFlags.Public | BindingFlags.Instance).SetValue(module, (((length * (width / 2)) / 3.52f) / 12.5) * (thickness / 0.18f)); //version that has mass based on panel thickness
                         }
                         //Pcontrol surfaces are more difficult; can easily be just an edge with span thickness = 0, so removing lift from these would render them essentially decorative and nothing else
                         //...add a child boxCollider...? Again, a change that really should be done in Pwings, not here

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -1149,7 +1149,7 @@ namespace BDArmory.Weapons
                         KSPParticleEmitter kpe = mtf.Current.GetComponent<KSPParticleEmitter>();
                         if (kpe == null)
                         {
-                            Debug.Log("[BDArmory.ModuleWeapon] MuzzleFX transform missing KSPParticleEmitter component. Please fix your model");
+                            Debug.LogError("[BDArmory.ModuleWeapon] MuzzleFX transform missing KSPParticleEmitter component. Please fix your model");
                             continue;
                         }
                         EffectBehaviour.AddParticleEmitter(kpe);
@@ -1215,7 +1215,7 @@ namespace BDArmory.Weapons
 
                 //setup transforms
                 fireTransforms = part.FindModelTransforms(fireTransformName);
-                if (fireTransforms.Length == 0) Debug.Log("[BDArmory.ModuleWeapon] Weapon missing fireTransform [" + fireTransformName + "]! Please fix your model");
+                if (fireTransforms.Length == 0) Debug.LogError("[BDArmory.ModuleWeapon] Weapon missing fireTransform [" + fireTransformName + "]! Please fix your model");
                 shellEjectTransforms = part.FindModelTransforms(shellEjectTransformName);
 
                 //setup emitters
@@ -1297,7 +1297,7 @@ namespace BDArmory.Weapons
             else if (HighLogic.LoadedSceneIsEditor)
             {
                 fireTransforms = part.FindModelTransforms(fireTransformName);
-                if (fireTransforms.Length == 0) Debug.Log("[BDArmory.ModuleWeapon] Weapon missing fireTransform [" + fireTransformName + "]! Please fix your model");
+                if (fireTransforms.Length == 0) Debug.LogError("[BDArmory.ModuleWeapon] Weapon missing fireTransform [" + fireTransformName + "]! Please fix your model");
                 WeaponNameWindow.OnActionGroupEditorOpened.Add(OnActionGroupEditorOpened);
                 WeaponNameWindow.OnActionGroupEditorClosed.Add(OnActionGroupEditorClosed);
             }
@@ -1409,7 +1409,7 @@ namespace BDArmory.Weapons
                     if (rocketInfo == null)
                     {
                         //if (BDArmorySettings.DEBUG_WEAPONS)
-                        Debug.Log("[BDArmory.ModuleWeapon]: Failed To load rocket : " + currentType);
+                        Debug.LogWarning("[BDArmory.ModuleWeapon]: Failed To load rocket : " + currentType);
                     }
                     else
                     {
@@ -1420,7 +1420,7 @@ namespace BDArmory.Weapons
                             if (!BulletInfo.bulletNames.Contains(rocketInfo.subMunitionType) || !RocketInfo.rocketNames.Contains(rocketInfo.subMunitionType))
                             {
                                 beehive = false;
-                                Debug.Log("[BDArmory.ModuleWeapon]: Invalid submunition on : " + currentType);
+                                Debug.LogWarning("[BDArmory.ModuleWeapon]: Invalid submunition on : " + currentType);
                             }
                             else
                             {
@@ -1438,7 +1438,7 @@ namespace BDArmory.Weapons
                     if (bulletInfo == null)
                     {
                         //if (BDArmorySettings.DEBUG_WEAPONS)
-                        Debug.Log("[BDArmory.ModuleWeapon]: Failed To load bullet : " + currentType);
+                        Debug.LogWarning("[BDArmory.ModuleWeapon]: Failed To load bullet : " + currentType);
                     }
                     else
                     {
@@ -1449,7 +1449,7 @@ namespace BDArmory.Weapons
                             if (!BulletInfo.bulletNames.Contains(bulletInfo.subMunitionType))
                             {
                                 beehive = false;
-                                Debug.Log("[BDArmory.ModuleWeapon]: Invalid submunition on : " + currentType);
+                                Debug.LogWarning("[BDArmory.ModuleWeapon]: Invalid submunition on : " + currentType);
                             }
                         }
                     }

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -1072,7 +1072,6 @@ namespace BDArmory.Weapons
             Fields["FiringTolerance"].guiActiveEditor = FireAngleOverride;
             Fields["fireBurstLength"].guiActive = BurstOverride;
             Fields["fireBurstLength"].guiActiveEditor = BurstOverride;
-            vessel.Velocity();
             if (BurstFire)
             {
                 BeltFed = false;
@@ -1148,6 +1147,11 @@ namespace BDArmory.Weapons
                     {
                         if (mtf.Current == null) continue;
                         KSPParticleEmitter kpe = mtf.Current.GetComponent<KSPParticleEmitter>();
+                        if (kpe == null)
+                        {
+                            Debug.Log("[BDArmory.ModuleWeapon] MuzzleFX transform missing KSPParticleEmitter component. Please fix your model");
+                            continue;
+                        }
                         EffectBehaviour.AddParticleEmitter(kpe);
                         muzzleFlashEmitters.Add(kpe);
                         kpe.emit = false;
@@ -1211,6 +1215,7 @@ namespace BDArmory.Weapons
 
                 //setup transforms
                 fireTransforms = part.FindModelTransforms(fireTransformName);
+                if (fireTransforms.Length == 0) Debug.Log("[BDArmory.ModuleWeapon] Weapon missing fireTransform [" + fireTransformName + "]! Please fix your model");
                 shellEjectTransforms = part.FindModelTransforms(shellEjectTransformName);
 
                 //setup emitters
@@ -1292,6 +1297,7 @@ namespace BDArmory.Weapons
             else if (HighLogic.LoadedSceneIsEditor)
             {
                 fireTransforms = part.FindModelTransforms(fireTransformName);
+                if (fireTransforms.Length == 0) Debug.Log("[BDArmory.ModuleWeapon] Weapon missing fireTransform [" + fireTransformName + "]! Please fix your model");
                 WeaponNameWindow.OnActionGroupEditorOpened.Add(OnActionGroupEditorOpened);
                 WeaponNameWindow.OnActionGroupEditorClosed.Add(OnActionGroupEditorClosed);
             }
@@ -1323,24 +1329,48 @@ namespace BDArmory.Weapons
             if (hasDeployAnim)
             {
                 deployState = GUIUtils.SetUpSingleAnimation(deployAnimName, part);
-                deployState.normalizedTime = 0;
-                deployState.speed = 0;
-                deployState.enabled = true;
-                ReloadAnimTime = (ReloadTime - deployState.length);
+                if (deployState != null)
+                {
+                    deployState.normalizedTime = 0;
+                    deployState.speed = 0;
+                    deployState.enabled = true;
+                    ReloadAnimTime = (ReloadTime - deployState.length);
+                }
+                else
+                {
+                    Debug.LogWarning($"[BDArmory.ModuleWeapon]: {OriginalShortName} is missing deploy anim");
+                    hasDeployAnim = false;
+                }
             }
             if (hasReloadAnim)
             {
                 reloadState = GUIUtils.SetUpSingleAnimation(reloadAnimName, part);
-                reloadState.normalizedTime = 0;
-                reloadState.speed = 0;
-                reloadState.enabled = true;
+                if (reloadState != null)
+                {
+                    reloadState.normalizedTime = 0;
+                    reloadState.speed = 0;
+                    reloadState.enabled = true;
+                }
+                else
+                {
+                    Debug.LogWarning($"[BDArmory.ModuleWeapon]: {OriginalShortName} is missing reload anim");
+                    hasReloadAnim = false;
+                }
             }
             if (hasChargeAnimation)
             {
                 chargeState = GUIUtils.SetUpSingleAnimation(chargeAnimName, part);
-                chargeState.normalizedTime = 0;
-                chargeState.speed = 0;
-                chargeState.enabled = true;
+                if (chargeState != null)
+                {
+                    chargeState.normalizedTime = 0;
+                    chargeState.speed = 0;
+                    chargeState.enabled = true;
+                }
+                else
+                {
+                    Debug.LogWarning($"[BDArmory.ModuleWeapon]: {OriginalShortName} is missing charge anim");
+                    hasChargeAnimation = false;
+                }
             }
             if (hasFireAnimation)
             {


### PR DESCRIPTION
- Armor Type 'none' disables armor thickness slider, should fix KSP 1.9.1 slider min can't equal slider max issue
- Adds weapon debugging messages if weapon is missing various things it shouldn't be, or has config errors
- Fixes AI/WM not attached to root part errors when using combat seat/podracer cockpit
- Procwing HP/mass/lift changes now fully segregated behind RUNWAYPROJECT toggle, review if we need a separate toggle
- Adds new Proc Structural Panel part (if pwings installed) as stopgap if Josue's no-lift Pwing's PR doesn't get added, also adds new part, which may be more intuitive/easier to police
- Adds hits/accuracy readout to weapon debugging (FJRT request)