### PR TITLE
Fix ProcStructpanel

### DIFF
--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -885,9 +885,9 @@ namespace BDArmory.Damage
                             }
                             ArmorModified(null, null);
                         }
-                        if (BDArmorySettings.HP_THRESHOLD >= 100 && hitpoints > BDArmorySettings.HP_THRESHOLD)
+                        if (BDArmorySettings.RUNWAY_PROJECT || BDArmorySettings.HP_THRESHOLD >= 100 && hitpoints > BDArmorySettings.HP_THRESHOLD) //If RunwayProject or Clamped HP setting, clamp HP
                         {
-                            Mathf.Min(hitpoints, 2000 * Mathf.Log(hitpoints / 1164 + 1));
+                            Mathf.Min(hitpoints, BDArmorySettings.HP_THRESHOLD >= 100 ? BDArmorySettings.HP_THRESHOLD : 2000 * Mathf.Log(hitpoints / 1164 + 1)); //use default of 2K for RP if slider set to unclamped
                         }
 
                         switch (HullTypeNum)

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -855,7 +855,7 @@ namespace BDArmory.Damage
                                                                                                                       //edges contribute to HP when they shouldn't; suggestion was to use tank volume instead (which would also allow thickness to play a role in HP), try ProceduralWing.aeroStatVolume * 700 
                                 }
                             }
-                            if ((!BDArmorySettings.PWING_EDGE_LIFT || BDArmorySettings.RUNWAY_PROJECT) || part.name.Contains("B9_Aero_Wing_Procedural_Panel")) //method to make pwings balanced with stock. 
+                            if (!BDArmorySettings.PWING_EDGE_LIFT || BDArmorySettings.RUNWAY_PROJECT || part.name.Contains("Panel")) //method to make pwings balanced with stock. 
                             {
                                 hitpoints = -1;
                                 armorVolume = -1;

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -129,7 +129,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_SPREAD = 5f;
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_BIAS = 0.16f;
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_HIT_MULTIPLIER = 2f;
-        [BDAPersistentSettingsField] public static float HP_THRESHOLD = 2000f;                  //HP above this value will be scaled to a logarithmic value
+        [BDAPersistentSettingsField] public static float HP_THRESHOLD = 0;                  //HP above this value will be scaled to a logarithmic value
         [BDAPersistentSettingsField] public static bool PWING_EDGE_LIFT = true;                  //Toggle lift on PWing edges for balance with stock wings/remove edge abuse
         // Physics constants
         [BDAPersistentSettingsField] public static float GLOBAL_LIFT_MULTIPLIER = 0.25f;

--- a/BDArmory/Utils/FARUtils.cs
+++ b/BDArmory/Utils/FARUtils.cs
@@ -204,7 +204,7 @@ namespace BDArmory.Utils
                         float thickness = 0.36f;
                         float aeroVolume = (0.786f * length * width * thickness) / 4; //original .7 was based on errorneous 2x4 wingboard dimensions; stock reference wing area is 1.875x3.75m
                         if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.FARUtils]: Found volume of {aeroVolume} for {part.name}.");
-						if (BDArmorySettings.RUNWAY_PROJECT && !ctrlSrf) //if RunwayProject and part !controlsurface, remove lift/mass from edges to bring inline with stock boards
+						if (BDArmorySettings.RUNWAY_PROJECT || BDArmorySettings.PWING_EDGE_LIFT && !ctrlSrf) //if RunwayProject and part !controlsurface, remove lift/mass from edges to bring inline with stock boards
 						{
                             bool isLiftingSurface = (float)PWType.GetField("stockLiftCoefficient", BindingFlags.Public | BindingFlags.Instance).GetValue(module) > 0f;
                             float liftCoeff = (length * (width / 2)) / 3.52f;

--- a/BDArmory/Utils/FARUtils.cs
+++ b/BDArmory/Utils/FARUtils.cs
@@ -215,7 +215,7 @@ namespace BDArmory.Utils
                             else
                                 PWType.GetField("aeroUIMass", BindingFlags.Public | BindingFlags.Instance).SetValue(module, liftCoeff / 5); //this modifies the IPartMassModifier, so the mass will also change along with the GUI                          
                         }
-                        if (part.name.Contains("B9_Aero_Wing_Procedural_Panel")) //if Josue's noLift PWings PR never gets folded in, here's an alternative using an MM'ed PWing structural panel part
+                        if (part.name.Contains("Panel")) //if Josue's noLift PWings PR never gets folded in, here's an alternative using an MM'ed PWing structural panel part
                         {
                             PWType.GetField("stockLiftCoefficient", BindingFlags.Public | BindingFlags.Instance).SetValue(module, 0); //adjust PWing GUI lift readout
                             PWType.GetField("aeroUIMass", BindingFlags.Public | BindingFlags.Instance).SetValue(module, ((length * (width / 2)) / 3.52f) / 12.5); //Struct panels lighter than wings      

--- a/BDArmory/Utils/FARUtils.cs
+++ b/BDArmory/Utils/FARUtils.cs
@@ -204,7 +204,7 @@ namespace BDArmory.Utils
                         float thickness = 0.36f;
                         float aeroVolume = (0.786f * length * width * thickness) / 4; //original .7 was based on errorneous 2x4 wingboard dimensions; stock reference wing area is 1.875x3.75m
                         if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.FARUtils]: Found volume of {aeroVolume} for {part.name}.");
-						if (BDArmorySettings.RUNWAY_PROJECT || BDArmorySettings.PWING_EDGE_LIFT && !ctrlSrf) //if RunwayProject and part !controlsurface, remove lift/mass from edges to bring inline with stock boards
+						if ((BDArmorySettings.RUNWAY_PROJECT || !BDArmorySettings.PWING_EDGE_LIFT) && !ctrlSrf) //if RunwayProject and part !controlsurface, remove lift/mass from edges to bring inline with stock boards
 						{
                             bool isLiftingSurface = (float)PWType.GetField("stockLiftCoefficient", BindingFlags.Public | BindingFlags.Instance).GetValue(module) > 0f;
                             float liftCoeff = (length * (width / 2)) / 3.52f;
@@ -215,7 +215,7 @@ namespace BDArmory.Utils
                             else
                                 PWType.GetField("aeroUIMass", BindingFlags.Public | BindingFlags.Instance).SetValue(module, liftCoeff / 5); //this modifies the IPartMassModifier, so the mass will also change along with the GUI                          
                         }
-                        if (part.name.Contains("Panel")) //if Josue's noLift PWings PR never gets folded in, here's an alternative using an MM'ed PWing structural panel part
+                        if (part.name.Contains("B9.Aero.Wing.Procedural.Panel")) //if Josue's noLift PWings PR never gets folded in, here's an alternative using an MM'ed PWing structural panel part
                         {
                             PWType.GetField("stockLiftCoefficient", BindingFlags.Public | BindingFlags.Instance).SetValue(module, 0); //adjust PWing GUI lift readout
                             PWType.GetField("aeroUIMass", BindingFlags.Public | BindingFlags.Instance).SetValue(module, ((length * (width / 2)) / 3.52f) / 12.5); //Struct panels lighter than wings      


### PR DESCRIPTION
-Fix incorrect name ID, struct panel now properly liftless
-New HP log scaling now off by default, on if RunwayProject enabled
