### PR TITLE
Building Damage and bugfixes

### DIFF
--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -747,7 +747,7 @@ namespace BDArmory.Bullets
 
             if (ProjectileUtils.CheckGroundHit(hitPart, hit, caliber))
             {
-                ProjectileUtils.CheckBuildingHit(hit, bulletMass, impactVelocity, bulletDmgMult);
+                if (!BDArmorySettings.PAINTBALL_MODE) ProjectileUtils.CheckBuildingHit(hit, bulletMass, impactVelocity, bulletDmgMult);
                 if (!RicochetScenery(hitAngle))
                 {
                     ExplosiveDetonation(hitPart, hit, bulletRay);

--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -747,7 +747,7 @@ namespace BDArmory.Bullets
 
             if (ProjectileUtils.CheckGroundHit(hitPart, hit, caliber))
             {
-                ProjectileUtils.CheckBuildingHit(hit, bulletMass, currentVelocity, bulletDmgMult);
+                ProjectileUtils.CheckBuildingHit(hit, bulletMass, impactVelocity, bulletDmgMult);
                 if (!RicochetScenery(hitAngle))
                 {
                     ExplosiveDetonation(hitPart, hit, bulletRay);

--- a/BDArmory/Ammo/PooledRocket.cs
+++ b/BDArmory/Ammo/PooledRocket.cs
@@ -395,7 +395,7 @@ namespace BDArmory.Bullets
 
                         if (ProjectileUtils.CheckGroundHit(hitPart, hit, caliber))
                         {
-                            ProjectileUtils.CheckBuildingHit(hit, rocketMass * 1000, rb.velocity, bulletDmgMult);
+                            if (!BDArmorySettings.PAINTBALL_MODE) ProjectileUtils.CheckBuildingHit(hit, rocketMass * 1000, rb.velocity, bulletDmgMult);
                             Detonate(hit.point, false);
                             return;
                         }

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2756,7 +2756,7 @@ namespace BDArmory.Control
             targetMissiles = false;
             weaponTypesGround.Clear();
             weaponTypesSLW.Clear();
-            gunRippleIndex.Clear();
+            //gunRippleIndex.Clear(); //since there keeps being issues with the more limited ripple dict, lets just make it perisitant for all weapons on the craft
             hasAntiRadiationOrdinance = false;
             if (vessel == null || !vessel.loaded) return;
 
@@ -2777,6 +2777,11 @@ namespace BDArmory.Control
                             }
                         }
 
+                    if (weapon.Current.GetWeaponClass() == WeaponClasses.Gun || weapon.Current.GetWeaponClass() == WeaponClasses.Rocket || weapon.Current.GetWeaponClass() == WeaponClasses.DefenseLaser)
+                    {
+                        if (!gunRippleIndex.ContainsKey(weapon.Current.GetPart().partInfo.name)) //I think the empty rocketpod? contine might have been tripping up the ripple dict and not adding the hydra
+                            gunRippleIndex.Add(weapon.Current.GetPart().partInfo.name, 0);
+                    }
                     //dont add empty rocket pods
                     if (weapon.Current.GetWeaponClass() == WeaponClasses.Rocket &&
                     (weapon.Current.GetPart().FindModuleImplementing<ModuleWeapon>().rocketPod && !weapon.Current.GetPart().FindModuleImplementing<ModuleWeapon>().externalAmmo) &&
@@ -2784,11 +2789,6 @@ namespace BDArmory.Control
                     && !BDArmorySettings.INFINITE_AMMO)
                     {
                         continue;
-                    }
-                    if (weapon.Current.GetWeaponClass() == WeaponClasses.Gun || weapon.Current.GetWeaponClass() == WeaponClasses.Rocket || weapon.Current.GetWeaponClass() == WeaponClasses.DefenseLaser)
-                    {
-                        if (!gunRippleIndex.ContainsKey(weapon.Current.GetPart().partInfo.name))
-                            gunRippleIndex.Add(weapon.Current.GetPart().partInfo.name, 0);
                     }
                     //dont add APS
                     if ((weapon.Current.GetWeaponClass() == WeaponClasses.Gun || weapon.Current.GetWeaponClass() == WeaponClasses.Rocket || weapon.Current.GetWeaponClass() == WeaponClasses.DefenseLaser) &&

--- a/BDArmory/Damage/BuildingDamage.cs
+++ b/BDArmory/Damage/BuildingDamage.cs
@@ -7,13 +7,13 @@ namespace BDArmory.Damage
     [KSPAddon(KSPAddon.Startup.Flight, false)]
     public class BuildingDamage : MonoBehaviour
     {
-        static List<DestructibleBuilding> buildingsDamaged = new List<DestructibleBuilding>();
+        static Dictionary<DestructibleBuilding, float> buildingsDamaged = new Dictionary<DestructibleBuilding, float>();
 
         public static void RegisterDamage(DestructibleBuilding building)
         {
-            if (!buildingsDamaged.Contains(building))
+            if (!buildingsDamaged.ContainsKey(building))
             {
-                buildingsDamaged.Add(building);
+                buildingsDamaged.Add(building, building.FacilityDamageFraction);
                 //Debug.Log("[BDArmory.BuildingDamage] registered " + building.name + " tracking " + buildingsDamaged.Count + " buildings");
             }
         }
@@ -32,22 +32,22 @@ namespace BDArmory.Damage
                 buildingRegenTimer -= Time.fixedDeltaTime;
                 if (buildingRegenTimer < 0)
                 {
-                    for (int b = 0; b < buildingsDamaged.Count; b++)
+                    foreach (KeyValuePair<DestructibleBuilding, float> building in buildingsDamaged)
                     {
-                        if (!buildingsDamaged[b].IsIntact || buildingsDamaged[b] == null)
+                        if (!building.Key.IsIntact)
                         {
-                            buildingsDamaged.Remove(buildingsDamaged[b]);
-                            //Debug.Log("[BDArmory.BuildingDamage] building destroyed or null! Removing");
+                            buildingsDamaged.Remove(building.Key);
+                            Debug.Log("[BDArmory.BuildingDamage] building destroyed or null! Removing");
                         }
-                        if (buildingsDamaged[b].FacilityDamageFraction > 100)
+                        if (building.Key.FacilityDamageFraction > building.Value)
                         {
-                            buildingsDamaged[b].FacilityDamageFraction -= RegenFactor;
-                            //Debug.Log("[BDArmory.BuildingDamage] " + buildingsDamaged[b].name + " current HP: " + buildingsDamaged[b].FacilityDamageFraction);
+                            building.Key.FacilityDamageFraction -= RegenFactor;
+                            Debug.Log("[BDArmory.BuildingDamage] " + building.Key.name + " current HP: " + building.Key.FacilityDamageFraction);
                         }
                         else
                         {
-                            //Debug.Log("[BDArmory.BuildingDamage] " + buildingsDamaged[b].name + " regenned to full HP, removing from list");
-                            buildingsDamaged.RemoveAt(b);
+                            Debug.Log("[BDArmory.BuildingDamage] " + building.Key.name + " regenned to full HP, removing from list");
+                            buildingsDamaged.Remove(building.Key);
                         }
                     }
                     buildingRegenTimer = 1;

--- a/BDArmory/Damage/BuildingDamage.cs
+++ b/BDArmory/Damage/BuildingDamage.cs
@@ -37,16 +37,16 @@ namespace BDArmory.Damage
                         if (!building.Key.IsIntact)
                         {
                             buildingsDamaged.Remove(building.Key);
-                            Debug.Log("[BDArmory.BuildingDamage] building destroyed or null! Removing");
+                            //Debug.Log("[BDArmory.BuildingDamage] building destroyed or null! Removing");
                         }
                         if (building.Key.FacilityDamageFraction > building.Value)
                         {
                             building.Key.FacilityDamageFraction -= RegenFactor;
-                            Debug.Log("[BDArmory.BuildingDamage] " + building.Key.name + " current HP: " + building.Key.FacilityDamageFraction);
+                            //Debug.Log("[BDArmory.BuildingDamage] " + building.Key.name + " current HP: " + building.Key.FacilityDamageFraction);
                         }
                         else
                         {
-                            Debug.Log("[BDArmory.BuildingDamage] " + building.Key.name + " regenned to full HP, removing from list");
+                            //Debug.Log("[BDArmory.BuildingDamage] " + building.Key.name + " regenned to full HP, removing from list");
                             buildingsDamaged.Remove(building.Key);
                         }
                     }

--- a/BDArmory/Damage/BuildingDamage.cs
+++ b/BDArmory/Damage/BuildingDamage.cs
@@ -1,27 +1,58 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
-/*
+
 namespace BDArmory.Damage
 {
-    [KSPAddon(KSPAddon.Startup.MainMenu, false)]
-    public class BuildingDamage : ScenarioDestructibles
+    [KSPAddon(KSPAddon.Startup.Flight, false)]
+    public class BuildingDamage : MonoBehaviour
     {
+        static List<DestructibleBuilding> buildingsDamaged = new List<DestructibleBuilding>();
 
-        public override void OnAwake()
+        public static void RegisterDamage(DestructibleBuilding building)
         {
-            Debug.Log("[BDArmory.BuildingDamage]: Modifying Buildings");
-
-            foreach (KeyValuePair<string, ProtoDestructible> bldg in protoDestructibles)
+            if (!buildingsDamaged.Contains(building))
             {
-                using (var building = bldg.Value.dBuildingRefs.GetEnumerator())
-                    while( building.MoveNext())
-                    {
-                        building.Current.damageDecay = 600f;
-                        building.Current.impactMomentumThreshold *= 150; //this triggeres every time the menu is visited, oops
-                    }
+                buildingsDamaged.Add(building);
+                //Debug.Log("[BDArmory.BuildingDamage] registered " + building.name + " tracking " + buildingsDamaged.Count + " buildings");
             }
         }
-         //disabling this for now, as it isn't needed. I suspect, but haven't tested, that multipying the impact tolerance also affects how hard you have to collide into a building with a part/craft to destroy it...
+        float buildingRegenTimer = 1; //regen 1 HP per second
+        float RegenFactor = 1; //could always turn these into customizable settings if you want faster/slower healing buildings.
+        void Update()
+        {
+            if (buildingsDamaged.Count > 0 && !HighLogic.LoadedSceneIsFlight)
+            {
+                buildingsDamaged.Clear();
+            }
+            if (UI.BDArmorySetup.GameIsPaused) return;
+
+            if (buildingsDamaged.Count > 0)
+            {
+                buildingRegenTimer -= Time.fixedDeltaTime;
+                if (buildingRegenTimer < 0)
+                {
+                    for (int b = 0; b < buildingsDamaged.Count; b++)
+                    {
+                        if (!buildingsDamaged[b].IsIntact || buildingsDamaged[b] == null)
+                        {
+                            buildingsDamaged.Remove(buildingsDamaged[b]);
+                            //Debug.Log("[BDArmory.BuildingDamage] building destroyed or null! Removing");
+                        }
+                        if (buildingsDamaged[b].FacilityDamageFraction > 100)
+                        {
+                            buildingsDamaged[b].FacilityDamageFraction -= RegenFactor;
+                            //Debug.Log("[BDArmory.BuildingDamage] " + buildingsDamaged[b].name + " current HP: " + buildingsDamaged[b].FacilityDamageFraction);
+                        }
+                        else
+                        {
+                            //Debug.Log("[BDArmory.BuildingDamage] " + buildingsDamaged[b].name + " regenned to full HP, removing from list");
+                            buildingsDamaged.RemoveAt(b);
+                        }
+                    }
+                    buildingRegenTimer = 1;
+                }
+            }
+        }
     }
 }
-*/

--- a/BDArmory/Damage/BuildingDamage.cs
+++ b/BDArmory/Damage/BuildingDamage.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
-
+/*
 namespace BDArmory.Damage
 {
     [KSPAddon(KSPAddon.Startup.MainMenu, false)]
     public class BuildingDamage : ScenarioDestructibles
     {
+
         public override void OnAwake()
         {
             Debug.Log("[BDArmory.BuildingDamage]: Modifying Buildings");
@@ -16,9 +17,11 @@ namespace BDArmory.Damage
                     while( building.MoveNext())
                     {
                         building.Current.damageDecay = 600f;
-                        building.Current.impactMomentumThreshold *= 150;
+                        building.Current.impactMomentumThreshold *= 150; //this triggeres every time the menu is visited, oops
                     }
             }
         }
+         //disabling this for now, as it isn't needed. I suspect, but haven't tested, that multipying the impact tolerance also affects how hard you have to collide into a building with a part/craft to destroy it...
     }
 }
+*/

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -893,11 +893,11 @@ namespace BDArmory.Damage
                         }
                         if ((BDArmorySettings.RUNWAY_PROJECT || BDArmorySettings.HP_THRESHOLD >= 100) && hitpoints > BDArmorySettings.HP_THRESHOLD) //If RunwayProject or Clamped HP setting, clamp HP
                         {
-                            var scale = BDArmorySettings.HP_THRESHOLD / (Mathf.Exp(1) - 1);
-                            hitpoints = Mathf.Min(hitpoints, BDArmorySettings.HP_THRESHOLD >= 100 ? BDArmorySettings.HP_THRESHOLD : 2000 * Mathf.Log(hitpoints / scale + 1)); //use default of 2K for RP if slider set to unclamped
+                            var scale = (BDArmorySettings.HP_THRESHOLD >= 100 ? BDArmorySettings.HP_THRESHOLD : 2000f) / (Mathf.Exp(1) - 1);
+                            hitpoints = Mathf.Min(hitpoints, (BDArmorySettings.HP_THRESHOLD >= 100 ? BDArmorySettings.HP_THRESHOLD : 2000f) * Mathf.Log(hitpoints / scale + 1)); //use default of 2K for RP if slider set to unclamped
                         }
 
-                        switch (HullTypeNum)
+                            switch (HullTypeNum)
                         {
                             case 1:
                                 hitpoints /= 4;

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -713,7 +713,8 @@ namespace BDArmory.Damage
                             if (density > 1e5f || density < 10)
                             {
                                 if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: {part.name} extreme density detected: {density}! Trying alternate approach based on partSize.");
-                                structuralVolume = (partSize.x * partSize.y + partSize.x * partSize.z + partSize.y * partSize.z) * 2f * sizeAdjust * Mathf.PI / 6f * 0.1f; // Box area * sphere/cube ratio * 10cm. We use sphere/cube ratio to get similar results as part.GetAverageBoundSize().
+                                //structuralVolume = (partSize.x * partSize.y + partSize.x * partSize.z + partSize.y * partSize.z) * 2f * sizeAdjust * Mathf.PI / 6f * 0.1f; // Box area * sphere/cube ratio * 10cm. We use sphere/cube ratio to get similar results as part.GetAverageBoundSize().
+                                structuralVolume = armorVolume * Mathf.PI / 6f * 0.1f; //part bounds change between editor and flight, so use existing persistant size value
                                 density = (partMass * 1000f) / structuralVolume;
                                 if (density > 1e5f || density < 10)
                                 {

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -69,6 +69,8 @@ namespace BDArmory.Damage
         [KSPField(advancedTweakable = true, guiActive = false, guiActiveEditor = true, guiName = "#LOC_BDArmory_ArmorMass")]//armor mass
         public float armorMass = 0f;
 
+        private float totalArmorQty = 0f;
+
         [KSPField(advancedTweakable = true, guiActive = false, guiActiveEditor = true, guiName = "#LOC_BDArmory_ArmorCost")]//armor cost
         public float armorCost = 0f;
 
@@ -1033,10 +1035,10 @@ namespace BDArmory.Damage
                 Debug.Log("[HPTracker] armor mass: " + armorMass + "; mass to reduce: " + (massToReduce * Math.Round((Density / 1000000), 3)) + "kg"); //g/m3
             }
             float reduceMass = (massToReduce * (Density / 1000000000)); //g/cm3 conversion to yield tons
-            if (armorMass > 0)
+            if (totalArmorQty > 0)
             {
                 //Armor -= ((reduceMass * 2) / armorMass) * Armor; //armor that's 50% air isn't going to stop anything and could be considered 'destroyed' so lets reflect that by doubling armor loss (this will also nerf armor panels from 'god-tier' to merely 'very very good'
-                Armor -= ((reduceMass * 1.5f) / armorMass) * Armor;
+                Armor -= ((reduceMass * 1.5f) / totalArmorQty) * Armor;
                 if (Armor < 0)
                 {
                     Armor = 0;
@@ -1062,7 +1064,8 @@ namespace BDArmory.Damage
                     DestroyPart();
                 }
             }
-            armorMass -= reduceMass; //tons
+            totalArmorQty -= reduceMass;
+            armorMass = totalArmorQty * BDArmorySettings.ARMOR_MASS_MOD; //tons
             if (armorMass <= 0)
             {
                 armorMass = 0;
@@ -1254,6 +1257,7 @@ namespace BDArmory.Damage
             var oldArmorMass = armorMass;
             armorMass = 0;
             armorCost = 0;
+            totalArmorQty = 0;
             if (ArmorTypeNum > 1 && (!BDArmorySettings.LEGACY_ARMOR || (!BDArmorySettings.RESET_ARMOUR || (BDArmorySettings.RESET_ARMOUR && ArmorThickness > 10)))) //don't apply cost/mass to None armor type
             {
                 armorMass = (Armor / 1000) * armorVolume * Density / 1000; //armor mass in tons
@@ -1266,6 +1270,8 @@ namespace BDArmory.Damage
                 SelectedArmorType = "None";
                 armorCost = (Armor / 1000) * armorVolume * armorInfo.Cost;
             }
+            totalArmorQty = armorMass; //grabbing a copy of unmodified armorMAss so it can be used in armorMass' place for armor reduction without having to un/re-modify the mass before and after armor hits
+            armorMass *= BDArmorySettings.ARMOR_MASS_MOD;
             //part.RefreshAssociatedWindows(); //having this fire every time a change happens prevents sliders from being used. Add delay timer?
             if (OldArmorType != ArmorTypeNum || oldArmorMass != armorMass)
             {

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -166,6 +166,7 @@ Localization
         #LOC_BDArmory_Settings_ImplosiveDamageMultiplier = Implosive Damage Multiplier
         #LOC_BDArmory_Settings_SecondaryEffectDuration = Special Weapon Effects Duration
         #LOC_BDArmory_Settings_BallisticTrajectorSimulationMultiplier = Ballistic Traj. Sim. Multiplier
+        #LOC_BDArmory_Settings_ArmorMassMultiplier = Armor Mass Multiplier
         #LOC_BDArmory_Settings_DebrisCleanUpDelay = Debris Removal Delay
         #LOC_BDArmory_Settings_Scoring_HeadShot = Head-Shot Time Limit
         #LOC_BDArmory_Settings_Scoring_KillSteal = Kill-Steal Time Limit

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -246,10 +246,13 @@ namespace BDArmory.FX
                             }
                             else
                             {
-                                DestructibleBuilding building = SChit.collider.gameObject.GetComponentUpwards<DestructibleBuilding>();
-                                if (building != null)
+                                if (!BDArmorySettings.PAINTBALL_MODE)
                                 {
-                                    ProjectileUtils.CheckBuildingHit(SChit, Power * 0.0555f, Direction.normalized * 4000f, 1);
+                                    DestructibleBuilding building = SChit.collider.gameObject.GetComponentUpwards<DestructibleBuilding>();
+                                    if (building != null)
+                                    {
+                                        ProjectileUtils.CheckBuildingHit(SChit, Power * 0.0555f, Direction.normalized * 4000f, 1);
+                                    }
                                 }
                             }
                         }
@@ -646,7 +649,7 @@ namespace BDArmory.FX
             DestructibleBuilding building = eventToExecute.Building;
             //building.damageDecay = 600f;
 
-            if(building && building.IsIntact)
+            if(building && building.IsIntact && !BDArmorySettings.PAINTBALL_MODE)
             {
                 var distanceFactor = Mathf.Clamp01((Range - eventToExecute.Distance) / Range);
                 float blastMod = 1;
@@ -670,7 +673,7 @@ namespace BDArmory.FX
                 damageToBuilding *= BDArmorySettings.BUILDING_DMG_MULTIPLIER;
                 //building.AddDamage(damageToBuilding); 
                 building.FacilityDamageFraction += damageToBuilding;
-
+                //based on testing, I think facilityDamageFraction starts at 100, and demolisheds the building if it hits 0 - which means it will work great as a HP value in the other direction
                 if (building.FacilityDamageFraction > building.impactMomentumThreshold * 2)
                 {
                     if (BDArmorySettings.DEBUG_DAMAGE) Debug.Log("[BDArmory.ExplosionFX]: Building " + building.name + " demolished due to Explosive damage! Dmg to building: " + building.Damage);

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -673,6 +673,7 @@ namespace BDArmory.FX
                 damageToBuilding /= 2;
                 damageToBuilding *= BDArmorySettings.BUILDING_DMG_MULTIPLIER;
                 //building.AddDamage(damageToBuilding); 
+                BuildingDamage.RegisterDamage(building);
                 building.FacilityDamageFraction += damageToBuilding;
                 //based on testing, I think facilityDamageFraction starts at 100, and demolished the building if it hits 0 - which means it will work great as a HP value in the other direction
                 if (building.FacilityDamageFraction > building.impactMomentumThreshold * 2)

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -247,8 +247,10 @@ namespace BDArmory.FX
                             else
                             {
                                 DestructibleBuilding building = SChit.collider.gameObject.GetComponentUpwards<DestructibleBuilding>();
-
-                                ProjectileUtils.CheckBuildingHit(SChit, Power * 0.0555f, Direction.normalized * 4000f, 1);
+                                if (building != null)
+                                {
+                                    ProjectileUtils.CheckBuildingHit(SChit, Power * 0.0555f, Direction.normalized * 4000f, 1);
+                                }
                             }
                         }
                     }
@@ -642,7 +644,7 @@ namespace BDArmory.FX
             //TODO: Review if the damage is sensible after so many changes
             //buildings
             DestructibleBuilding building = eventToExecute.Building;
-            building.damageDecay = 600f;
+            //building.damageDecay = 600f;
 
             if(building && building.IsIntact)
             {
@@ -663,23 +665,22 @@ namespace BDArmory.FX
                         blastMod = BDArmorySettings.EXP_DMG_MOD_BATTLE_DAMAGE;
                         break;
                 }
-                float damageToBuilding = (BDArmorySettings.DMG_MULTIPLIER / 100) * blastMod * Power * distanceFactor;
-
-                damageToBuilding *= 2f;
+                float damageToBuilding = (BDArmorySettings.DMG_MULTIPLIER / 100) * blastMod * (Power * distanceFactor);
+                damageToBuilding /= 2;
                 damageToBuilding *= BDArmorySettings.BUILDING_DMG_MULTIPLIER;
+                //building.AddDamage(damageToBuilding); 
+                building.FacilityDamageFraction += damageToBuilding;
 
-                building.AddDamage(damageToBuilding);
-
-                if (building.Damage > building.impactMomentumThreshold)
+                if (building.FacilityDamageFraction > building.impactMomentumThreshold * 2)
                 {
-                    if (BDArmorySettings.DEBUG_DAMAGE) Debug.Log("[BDArmory.ExplosionFX]: Building demolished due to Explosive damage! Dmg to building: " + building.Damage);
+                    if (BDArmorySettings.DEBUG_DAMAGE) Debug.Log("[BDArmory.ExplosionFX]: Building " + building.name + " demolished due to Explosive damage! Dmg to building: " + building.Damage);
                     building.Demolish();
                 }
                 if (BDArmorySettings.DEBUG_DAMAGE)
                 {
-                    Debug.Log("[BDArmory.ExplosionFX]: Explosion hit destructible building! Hitpoints Applied: " + Mathf.Round(damageToBuilding) +
-                             ", Building Damage : " + Mathf.Round(building.Damage) +
-                             " Building Threshold : " + building.impactMomentumThreshold +
+                    Debug.Log("[BDArmory.ExplosionFX]: Explosion hit destructible building " + building.name + "! Hitpoints Applied: " + Mathf.Round(damageToBuilding) +
+                             ", Building Damage : " + building.FacilityDamageFraction +
+                             " Building Threshold : " + building.impactMomentumThreshold * 2 +
                              $", (Range: {Range}, Distance: {eventToExecute.Distance}, Factor: {distanceFactor}, Power: {Power})");
 
                 }

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -333,8 +333,9 @@ namespace BDArmory.FX
                             }
                         }
                     }
-                    catch
+                    catch (Exception e)
                     {
+                        Debug.LogError($"[BDArmory.ExplosionFX]: Exception in overlapSphereColliders processing: {e.Message}\n{e.StackTrace}");
                     }
                 }
             }
@@ -673,7 +674,7 @@ namespace BDArmory.FX
                 damageToBuilding *= BDArmorySettings.BUILDING_DMG_MULTIPLIER;
                 //building.AddDamage(damageToBuilding); 
                 building.FacilityDamageFraction += damageToBuilding;
-                //based on testing, I think facilityDamageFraction starts at 100, and demolisheds the building if it hits 0 - which means it will work great as a HP value in the other direction
+                //based on testing, I think facilityDamageFraction starts at 100, and demolished the building if it hits 0 - which means it will work great as a HP value in the other direction
                 if (building.FacilityDamageFraction > building.impactMomentumThreshold * 2)
                 {
                     if (BDArmorySettings.DEBUG_DAMAGE) Debug.Log("[BDArmory.ExplosionFX]: Building " + building.name + " demolished due to Explosive damage! Dmg to building: " + building.Damage);
@@ -681,7 +682,7 @@ namespace BDArmory.FX
                 }
                 if (BDArmorySettings.DEBUG_DAMAGE)
                 {
-                    Debug.Log("[BDArmory.ExplosionFX]: Explosion hit destructible building " + building.name + "! Hitpoints Applied: " + Mathf.Round(damageToBuilding) +
+                    Debug.Log("[BDArmory.ExplosionFX]: Explosion hit destructible building " + building.name + "! Hitpoints Applied: " + damageToBuilding.ToString("F3") +
                              ", Building Damage : " + building.FacilityDamageFraction +
                              " Building Threshold : " + building.impactMomentumThreshold * 2 +
                              $", (Range: {Range}, Distance: {eventToExecute.Distance}, Factor: {distanceFactor}, Power: {Power})");

--- a/BDArmory/FX/NukeFX.cs
+++ b/BDArmory/FX/NukeFX.cs
@@ -217,8 +217,9 @@ namespace BDArmory.FX
                             }
                         }
                     }
-                    catch
+                    catch (Exception e)
                     {
+                        Debug.LogError($"[BDArmory.ExplosionFX]: Exception in overlapSphereColliders processing: {e.Message}\n{e.StackTrace}");
                     }
                 }
             }

--- a/BDArmory/FX/NukeFX.cs
+++ b/BDArmory/FX/NukeFX.cs
@@ -204,7 +204,7 @@ namespace BDArmory.FX
                                     RaycastHit rayHit;
                                     if (Physics.Raycast(ray, out rayHit, thermalRadius, explosionLayerMask))
                                     {
-                                        DestructibleBuilding destructibleBuilding = rayHit.collider.gameObject.GetComponentUpwards<DestructibleBuilding>();
+                                        //DestructibleBuilding destructibleBuilding = rayHit.collider.gameObject.GetComponentUpwards<DestructibleBuilding>();
 
                                         distance = Vector3.Distance(Position, rayHit.point);
                                         if (building.IsIntact)

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -147,7 +147,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static bool EXTRA_DAMAGE_SLIDERS = false;
         [BDAPersistentSettingsField] public static float WEAPON_FX_DURATION = 15;               //how long do weapon secondary effects(EMP/choker/gravitic/etc) last
         [BDAPersistentSettingsField] public static float ZOMBIE_DMG_MULT = 0.1f;
-
+        [BDAPersistentSettingsField] public static float ARMOR_MASS_MOD = 1f;                   //Armor mass multiplier
         // FX
         [BDAPersistentSettingsField] public static bool FIRE_FX_IN_FLIGHT = false;
         [BDAPersistentSettingsField] public static int MAX_FIRES_PER_VESSEL = 10;                 //controls fx for penetration only for landed or splashed //this is only for physical missile collisons into fueltanks - SI

--- a/BDArmory/UI/BDAEditorArmorWindow.cs
+++ b/BDArmory/UI/BDAEditorArmorWindow.cs
@@ -530,8 +530,9 @@ namespace BDArmory.UI
                                 armor.ArmorModified(null, null);
                                 modified = true;
                             }
-                            totalArmorMass += armor.armorMass;
-                            totalArmorCost += armor.armorCost;
+                            StartCoroutine(calcArmorMassAndCost());
+                            //totalArmorMass += armor.armorMass; //these aren't updating due to ArmorModified getting called next Update tick, so armorMass/Cost hasn't updated yet for grabbing the new value
+                            //totalArmorCost += armor.armorCost;
                         }
                         else
                         {
@@ -584,6 +585,23 @@ namespace BDArmory.UI
                     }
                 }
             wingLoading = totalLift / EditorLogic.fetch.ship.GetTotalMass();
+        }
+
+        IEnumerator calcArmorMassAndCost()
+        {
+            yield return new WaitForEndOfFrame();
+            yield return new WaitForEndOfFrame();
+            using (List<Part>.Enumerator parts = EditorLogic.fetch.ship.Parts.GetEnumerator())
+                while (parts.MoveNext())
+                {
+                    if (parts.Current.IsMissile()) continue;
+                    HitpointTracker armor = parts.Current.GetComponent<HitpointTracker>();
+                    if (armor != null)
+                    {
+                        totalArmorMass += armor.armorMass;
+                        totalArmorCost += armor.armorCost;
+                    }
+                }
         }
 
         void Visualize()

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -3082,8 +3082,10 @@ namespace BDArmory.UI
                 BDArmorySettings.WAYPOINTS_MODE = GUI.Toggle(SLeftRect(++line), BDArmorySettings.WAYPOINTS_MODE, Localizer.Format("#LOC_BDArmory_Settings_WaypointsMode"));
                 if (BDArmorySettings.ADVANDED_USER_SETTINGS)
                 {
-                    BDArmorySettings.RUNWAY_PROJECT = GUI.Toggle(SLeftRect(++line), BDArmorySettings.RUNWAY_PROJECT, Localizer.Format("#LOC_BDArmory_Settings_RunwayProject"));//Runway Project
-
+                    if (BDArmorySettings.RUNWAY_PROJECT != (BDArmorySettings.RUNWAY_PROJECT = GUI.Toggle(SLeftRect(++line), BDArmorySettings.RUNWAY_PROJECT, Localizer.Format("#LOC_BDArmory_Settings_RunwayProject"))))//Runway Project
+                    {
+                        if (EditorLogic.fetch is not null && EditorLogic.fetch.ship is not null) GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
+                    }
                     if (BDArmorySettings.RUNWAY_PROJECT)
                     {
                         GUI.Label(SLeftSliderRect(++line), $"{Localizer.Format("#LOC_BDArmory_Settings_RunwayProjectRound")}: ({(BDArmorySettings.RUNWAY_PROJECT_ROUND > 10 ? $"S{(BDArmorySettings.RUNWAY_PROJECT_ROUND - 1) / 10}R{(BDArmorySettings.RUNWAY_PROJECT_ROUND - 1) % 10 + 1}" : "—")})", leftLabel); // RWP round

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -2769,6 +2769,9 @@ namespace BDArmory.UI
 
                         GUI.Label(SLeftSliderRect(++line), $"{Localizer.Format("#LOC_BDArmory_Settings_BallisticTrajectorSimulationMultiplier")}:  ({BDArmorySettings.BALLISTIC_TRAJECTORY_SIMULATION_MULTIPLIER})", leftLabel);
                         BDArmorySettings.BALLISTIC_TRAJECTORY_SIMULATION_MULTIPLIER = Mathf.RoundToInt(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.BALLISTIC_TRAJECTORY_SIMULATION_MULTIPLIER, 1f, 256f));
+
+                        GUI.Label(SLeftSliderRect(++line), $"{Localizer.Format("#LOC_BDArmory_Settings_ArmorMassMultiplier")}:  ({BDArmorySettings.ARMOR_MASS_MOD})", leftLabel);
+                        BDArmorySettings.ARMOR_MASS_MOD = Mathf.Round((GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.ARMOR_MASS_MOD * 20f, 1f, 40f))) / 20f; //armor mult cannot be zero, else things break
                     }
                 }
 

--- a/BDArmory/Utils/ProjectileUtils.cs
+++ b/BDArmory/Utils/ProjectileUtils.cs
@@ -858,18 +858,21 @@ namespace BDArmory.Utils
                 damageToBuilding /= 8f;
                 damageToBuilding *= BDArmorySettings.BUILDING_DMG_MULTIPLIER; 
                 building.FacilityDamageFraction += damageToBuilding;
-                //building.AddDamage(damageToBuilding);
-                //if (building.Damage > building.impactMomentumThreshold * 150)
-                //building.AddDamage(damageToBuilding); //the AddDamage() function will only add damage if the value is >= 100
-                //if (damageHelper) building.AddDamage(-100);
-                //if (building.Damage > building.impactMomentumThreshold * 150) //I suspect the building demolishes itself when damage exceeds a certain amount before this can get called...
+                try
+                {
+                    BuildingDamage.RegisterDamage(building);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning("[BDArmory.ProjectileUtils]: Exception thrown in register building Damage: " + e.Message + "\n" + e.StackTrace);
+                }
                 if (building.FacilityDamageFraction > (building.impactMomentumThreshold * 2))
                 {
                     if (BDArmorySettings.DEBUG_DAMAGE) Debug.Log("[BDArmory.ProjectileUtils]: Building demolished due to ballistic damage! Dmg to building: " + building.Damage);
                     building.Demolish();
                 }
                 if (BDArmorySettings.DEBUG_DAMAGE)
-                    Debug.Log("[BDArmory.ProjectileUtils]: Ballistic hit destructible building " + building.name +"! Hitpoints Applied: " + Mathf.Round(damageToBuilding) +
+                    Debug.Log("[BDArmory.ProjectileUtils]: Ballistic hit destructible building " + building.name +"! Hitpoints Applied: " + damageToBuilding.ToString("F3") +
                              ", Building Damage : " + building.FacilityDamageFraction +
                              " Building Threshold : " + building.impactMomentumThreshold * 2);
 

--- a/BDArmory/Utils/ProjectileUtils.cs
+++ b/BDArmory/Utils/ProjectileUtils.cs
@@ -842,8 +842,8 @@ namespace BDArmory.Utils
             try
             {
                 building = hit.collider.gameObject.GetComponentUpwards<DestructibleBuilding>();
-                if (building != null)
-                    building.damageDecay = 600f;
+                //if (building != null)
+                //   building.damageDecay = 600f; //check if new method is still subject to building regen
             }
             catch (Exception e)
             {
@@ -856,27 +856,22 @@ namespace BDArmory.Utils
                             * (BDArmorySettings.DMG_MULTIPLIER / 100) * DmgMult * BDArmorySettings.BALLISTIC_DMG_FACTOR
                             * 1e-4f);
                 damageToBuilding /= 8f;
-                /*bool damageHelper = false;
-                if (damageToBuilding < 100)
-                {
-                    damageToBuilding += 100;
-                    damageHelper = true;
-                }
-                */
-                damageToBuilding *= BDArmorySettings.BUILDING_DMG_MULTIPLIER; //this isn't going to do anything, unless shooting at buildings with really big shells
-                building.AddDamage(damageToBuilding);
-                if (building.Damage > building.impactMomentumThreshold * 150)
-                    building.AddDamage(damageToBuilding); //the AddDamage() function will only add damage if the value is >= 100
+                damageToBuilding *= BDArmorySettings.BUILDING_DMG_MULTIPLIER; 
+                building.FacilityDamageFraction += damageToBuilding;
+                //building.AddDamage(damageToBuilding);
+                //if (building.Damage > building.impactMomentumThreshold * 150)
+                    //building.AddDamage(damageToBuilding); //the AddDamage() function will only add damage if the value is >= 100
                 //if (damageHelper) building.AddDamage(-100);
-                if (building.Damage > building.impactMomentumThreshold * 150) //I suspect the building demolishes itself when damage exceeds a certain amount before this can get called...
+                //if (building.Damage > building.impactMomentumThreshold * 150) //I suspect the building demolishes itself when damage exceeds a certain amount before this can get called...
+                if (building.FacilityDamageFraction > (building.impactMomentumThreshold * 2))
                 {
                     if (BDArmorySettings.DEBUG_DAMAGE) Debug.Log("[BDArmory.ProjectileUtils]: Building demolished due to ballistic damage! Dmg to building: " + building.Damage);
-                    building.Demolish(); //no. this is not getting called; building destructs from some function inside DestructableBuilding before this condition is reached
+                    building.Demolish();
                 }
                 if (BDArmorySettings.DEBUG_DAMAGE)
-                    Debug.Log("[BDArmory.ProjectileUtils]: Ballistic hit destructible building! Hitpoints Applied: " + Mathf.Round(damageToBuilding) +
-                             ", Building Damage : " + building.Damage +
-                             " Building Threshold : " + building.impactMomentumThreshold);
+                    Debug.Log("[BDArmory.ProjectileUtils]: Ballistic hit destructible building " + building.name +"! Hitpoints Applied: " + Mathf.Round(damageToBuilding) +
+                             ", Building Damage : " + building.FacilityDamageFraction +
+                             " Building Threshold : " + building.impactMomentumThreshold * 2);
 
                 return true;
             }

--- a/BDArmory/Utils/ProjectileUtils.cs
+++ b/BDArmory/Utils/ProjectileUtils.cs
@@ -860,7 +860,7 @@ namespace BDArmory.Utils
                 building.FacilityDamageFraction += damageToBuilding;
                 //building.AddDamage(damageToBuilding);
                 //if (building.Damage > building.impactMomentumThreshold * 150)
-                    //building.AddDamage(damageToBuilding); //the AddDamage() function will only add damage if the value is >= 100
+                //building.AddDamage(damageToBuilding); //the AddDamage() function will only add damage if the value is >= 100
                 //if (damageHelper) building.AddDamage(-100);
                 //if (building.Damage > building.impactMomentumThreshold * 150) //I suspect the building demolishes itself when damage exceeds a certain amount before this can get called...
                 if (building.FacilityDamageFraction > (building.impactMomentumThreshold * 2))

--- a/BDArmory/Utils/ProjectileUtils.cs
+++ b/BDArmory/Utils/ProjectileUtils.cs
@@ -857,15 +857,8 @@ namespace BDArmory.Utils
                             * 1e-4f);
                 damageToBuilding /= 8f;
                 damageToBuilding *= BDArmorySettings.BUILDING_DMG_MULTIPLIER; 
+                BuildingDamage.RegisterDamage(building);
                 building.FacilityDamageFraction += damageToBuilding;
-                try
-                {
-                    BuildingDamage.RegisterDamage(building);
-                }
-                catch (Exception e)
-                {
-                    Debug.LogWarning("[BDArmory.ProjectileUtils]: Exception thrown in register building Damage: " + e.Message + "\n" + e.StackTrace);
-                }
                 if (building.FacilityDamageFraction > (building.impactMomentumThreshold * 2))
                 {
                     if (BDArmorySettings.DEBUG_DAMAGE) Debug.Log("[BDArmory.ProjectileUtils]: Building demolished due to ballistic damage! Dmg to building: " + building.Damage);

--- a/BDArmory/Utils/ProjectileUtils.cs
+++ b/BDArmory/Utils/ProjectileUtils.cs
@@ -853,17 +853,26 @@ namespace BDArmory.Utils
             if (building != null && building.IsIntact)
             {
                 float damageToBuilding = ((0.5f * (projMass * (currentVelocity.magnitude * currentVelocity.magnitude)))
-                            * (BDArmorySettings.DMG_MULTIPLIER / 100) * DmgMult
+                            * (BDArmorySettings.DMG_MULTIPLIER / 100) * DmgMult * BDArmorySettings.BALLISTIC_DMG_FACTOR
                             * 1e-4f);
                 damageToBuilding /= 8f;
-                building.AddDamage(damageToBuilding);
-                if (building.Damage > building.impactMomentumThreshold * 150)
+                /*bool damageHelper = false;
+                if (damageToBuilding < 100)
                 {
-                    building.Demolish();
+                    damageToBuilding += 100;
+                    damageHelper = true;
                 }
-                if (BDArmorySettings.DEBUG_WEAPONS)
+                */
+                building.AddDamage(damageToBuilding); //the AddDamage() function will only add damage if the value is >= 100
+                //if (damageHelper) building.AddDamage(-100);
+                if (building.Damage > building.impactMomentumThreshold * 150) //I suspect the building demolishes itself when damage exceeds a certain amount before this can get called...
+                {
+                    if (BDArmorySettings.DEBUG_DAMAGE) Debug.Log("[BDArmory.ProjectileUtils]: Building demolished due to ballistic damage! Dmg to building: " + building.Damage);
+                    building.Demolish(); //no. this is not getting called; building destructs from some function inside DestructableBuilding before this condition is reached
+                }
+                if (BDArmorySettings.DEBUG_DAMAGE)
                     Debug.Log("[BDArmory.ProjectileUtils]: Ballistic hit destructible building! Hitpoints Applied: " + Mathf.Round(damageToBuilding) +
-                             ", Building Damage : " + Mathf.Round(building.Damage) +
+                             ", Building Damage : " + building.Damage +
                              " Building Threshold : " + building.impactMomentumThreshold);
 
                 return true;

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -1186,14 +1186,18 @@ namespace BDArmory.Weapons
                                         validAmmo = true;
                                         break;
                                     }
-                                    if (!validAmmo) customAmmoBelt[i] = testAmmo[0];
+                                    if (!validAmmo)
+                                    {
+                                        customAmmoBelt[i] = testAmmo[0];
+                                        Debug.LogWarning("[BDArmory.ModuleWeapon] Invalid ammo type " + customAmmoBelt[i] + " in ammo belt! reverting to valid ammo type " + testAmmo[0]);
+                                    }
                                 }
                             }
                             baseBulletVelocity = BulletInfo.bullets[customAmmoBelt[0].ToString()].bulletVelocity;
                         }
-                        else
+                        else //belt is empty/"def" reset useAmmoBelt
                         {
-                            customAmmoBelt = BDAcTools.ParseNames(bulletType);
+                            useCustomBelt = false;
                         }
                     }
                 }
@@ -1300,6 +1304,18 @@ namespace BDArmory.Weapons
                 if (fireTransforms.Length == 0) Debug.LogError("[BDArmory.ModuleWeapon] Weapon missing fireTransform [" + fireTransformName + "]! Please fix your model");
                 WeaponNameWindow.OnActionGroupEditorOpened.Add(OnActionGroupEditorOpened);
                 WeaponNameWindow.OnActionGroupEditorClosed.Add(OnActionGroupEditorClosed);
+                if (useCustomBelt)
+                {
+                    if (!string.IsNullOrEmpty(ammoBelt) && ammoBelt != "def")
+                    {
+                        customAmmoBelt = BDAcTools.ParseNames(ammoBelt);                        
+                        baseBulletVelocity = BulletInfo.bullets[customAmmoBelt[0].ToString()].bulletVelocity;
+                    }
+                    else
+                    {
+                        useCustomBelt = false;
+                    }
+                }
             }
             //turret setup
             List<ModuleTurret>.Enumerator turr = part.FindModulesImplementing<ModuleTurret>().GetEnumerator();
@@ -5181,7 +5197,6 @@ namespace BDArmory.Weapons
                     {
                         baseBulletVelocity = BulletInfo.bullets[customAmmoBelt[0].ToString()].bulletVelocity;
                     }
-
                 }
             }
             if (eWeaponType == WeaponTypes.Rocket)


### PR DESCRIPTION
makes building damage event use the proper multipliers, mostly
Switches SC plasmajet impacts over to ballistic impact
standardizes debug categorization

NEW
Switches over to new damage method
-damage no longer gated behind >= 100 threshold, guns can now death-of-a-thousand-cuts buildings 
-ImpactMomentumThreshold is no longer modified/used, so shouldn't impact vessel-> building collision demolitions
-ImpactMomentumThreshold no longer inflating every time main menu is visited

NEW - building regen and misc.
-Re-adds building regen, currently 1 HP per sec
-Hopefully fix rippleIndex issue for good this time
-Fix Armor tool armor mass/cost readout giving incorrect values when using the global armor type select
-Add proper armor mass mult to fix issues with third party implementation