### PR TITLE
gpsUpdate Fixes

### DIFF
--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -84,6 +84,7 @@ namespace BDArmory.Weapons.Missiles
         [KSPField]
         public bool guidanceActive = true;
 
+        [KSPField]
         public float gpsUpdates = -1f;                              // GPS missiles get updates on target position from source vessel every gpsUpdates >= 0 seconds
 
         [KSPField]
@@ -456,7 +457,7 @@ namespace BDArmory.Weapons.Missiles
             else
             {
                 gpsTargetCoords_ = targetGPSCoords;
-                if (targetVessel && HasFired && (gpsUpdates >= 0f) && VesselModuleRegistry.GetMissileFire(SourceVessel).CanSeeTarget(targetVessel.Vessel))
+                if (targetVessel && HasFired && (gpsUpdates >= 0f) && VesselModuleRegistry.GetMissileFire(SourceVessel).CanSeeTarget(targetVessel))
                 {
                     if (gpsUpdates == 0) // Constant updates
                     {


### PR DESCRIPTION
- Fix missing gpsUpdates not working since it was missing KSPField flag.
- Use newer CanSeeTarget instead of legacy CanSeeTarget for gpsUpdates.