### PR TITLE
Reloadable missile overhaul

### DIFF
--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -357,7 +357,7 @@ namespace BDArmory.Bullets
                 if (isAPSprojectile)
                 {
                     if (HEType != PooledBulletTypes.Explosive && tntMass > 0)
-                        ExplosionFx.CreateExplosion(currPosition, tntMass, explModelPath, explSoundPath, ExplosionSourceType.Bullet, caliber, null, sourceVesselName, null, currentVelocity, -1, true);
+                        ExplosionFx.CreateExplosion(currPosition, tntMass, explModelPath, explSoundPath, ExplosionSourceType.Bullet, caliber, null, sourceVesselName, null, default, -1, true);
                 }
                 return;
             }
@@ -428,7 +428,7 @@ namespace BDArmory.Bullets
             {
                 //detonate
                 if (HEType != PooledBulletTypes.Slug)
-                    ExplosionFx.CreateExplosion(currPosition, tntMass, explModelPath, explSoundPath, ExplosionSourceType.Bullet, caliber, null, sourceVesselName, null, currentVelocity, -1, false, bulletMass, -1, dmgMult);
+                    ExplosionFx.CreateExplosion(currPosition, tntMass, explModelPath, explSoundPath, ExplosionSourceType.Bullet, caliber, null, sourceVesselName, null, default, -1, false, bulletMass, -1, dmgMult);
                 if (nuclear)
                     NukeFX.CreateExplosion(currPosition, ExplosionSourceType.Bullet, sourceVesselName, bullet.DisplayName, 0, tntMass * 200, tntMass, tntMass, EMP, blastSoundPath, flashModelPath, shockModelPath, blastModelPath, plumeModelPath, debrisModelPath, "", "");
                 if (beehive)
@@ -1468,7 +1468,7 @@ namespace BDArmory.Bullets
                     else
                     {
                         if (HEType != PooledBulletTypes.Slug)
-                            ExplosionFx.CreateExplosion(hit.point - (ray.direction * 0.1f), GetExplosivePower(), explModelPath, explSoundPath, ExplosionSourceType.Bullet, caliber, null, sourceVesselName, null, ray.direction, -1, false, bulletMass, -1, dmgMult, HEType == PooledBulletTypes.Shaped ? "shapedcharge" : "standard", penetratingHit ? hitPart : null);
+                            ExplosionFx.CreateExplosion(hit.point - (ray.direction * 0.1f), GetExplosivePower(), explModelPath, explSoundPath, ExplosionSourceType.Bullet, caliber, null, sourceVesselName, null, default, -1, false, bulletMass, -1, dmgMult, HEType == PooledBulletTypes.Shaped ? "shapedcharge" : "standard", penetratingHit ? hitPart : null);
                         if (nuclear)
                             NukeFX.CreateExplosion(currPosition, ExplosionSourceType.Bullet, sourceVesselName, bullet.DisplayName, 0, tntMass * 200, tntMass, tntMass, EMP, blastSoundPath, flashModelPath, shockModelPath, blastModelPath, plumeModelPath, debrisModelPath, "", "");
                     }

--- a/BDArmory/BDArmory.csproj
+++ b/BDArmory/BDArmory.csproj
@@ -385,10 +385,12 @@
     <None Include="Distribution\GameData\BDArmory\MMPatches\000000_HitpointModule_PartFixes.cfg" />
     <None Include="Distribution\GameData\BDArmory\MMPatches\10_bdac_stealth.cfg" />
     <None Include="Distribution\GameData\BDArmory\MMPatches\Armor_CVE.cfg" />
+    <None Include="Distribution\GameData\BDArmory\MMPatches\BDA_battledamage.cfg" />
     <None Include="Distribution\GameData\BDArmory\MMPatches\BDA_GroundRadar.cfg" />
     <None Include="Distribution\GameData\BDArmory\MMPatches\BDA_TweakScale.cfg" />
     <None Include="Distribution\GameData\BDArmory\MMPatches\bdmk22_cockpit.cfg" />
     <None Include="Distribution\GameData\BDArmory\MMPatches\Explode_Mode_Squad_Tanks.cfg" />
+    <None Include="Distribution\GameData\BDArmory\MMPatches\StructPWing.cfg" />
     <None Include="Distribution\GameData\BDArmory\Models\bulletDecal\BulletDecal1.mu" />
     <None Include="Distribution\GameData\BDArmory\Models\bulletDecal\BulletDecal2.mu" />
     <None Include="Distribution\GameData\BDArmory\Models\bulletDecal\BulletDecal2b.mu" />

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -3969,7 +3969,7 @@ namespace BDArmory.Control
             //2. highest priority non-targeted target
             //3. closest non-targeted target
 
-            for (int i = 0; i < multiTargetNum; i++)
+            for (int i = 0; i < Math.Max(multiTargetNum, multiMissileTgtNum); i++)
             {
                 TargetInfo potentialMissileTarget = null;
                 //=========MISSILES=============
@@ -3998,7 +3998,7 @@ namespace BDArmory.Control
                 }
             }
 
-            for (int i = 0; i < multiTargetNum; i++)
+            for (int i = 0; i < Math.Max(multiTargetNum, multiMissileTgtNum); i++)
             {
                 TargetInfo potentialTarget = null;
                 //============VESSEL THREATS============
@@ -5692,7 +5692,7 @@ namespace BDArmory.Control
             else if (ml.TargetingMode == MissileBase.TargetingModes.Heat && heatTarget.exists)
             {
                 ml.heatTarget = heatTarget;
-                MissileLauncher mml = CurrentMissile as MissileLauncher;
+                MissileLauncher mml = ml as MissileLauncher;
                 if (!mml.multiLauncher) heatTarget = TargetSignatureData.noTarget;
                 if (BDArmorySettings.DEBUG_MISSILES)
                     Debug.Log("[BDArmory.MissileData]: Sending targetInfo to heat Missile...");

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -4295,6 +4295,7 @@ namespace BDArmory.Control
                             {
                                 if (mlauncher.TargetingMode == MissileBase.TargetingModes.Radar && radars.Count <= 0) continue; //dont select RH missiles when no radar aboard
                                 if (mlauncher.TargetingMode == MissileBase.TargetingModes.Laser && targetingPods.Count <= 0) continue; //don't select LH missiles when no FLIR aboard
+                                if (mlauncher.reloadableRail != null && (mlauncher.reloadableRail.ammoCount < 1 && !BDArmorySettings.INFINITE_ORDINANCE)) continue; //don't select when out of ordinance
                                 candidateDetDist = mlauncher.DetonationDistance;
                                 candidateAccel = mlauncher.thrust / mlauncher.part.mass; //for anti-missile, prioritize proxidetonation and accel
                                 bool EMP = mlauncher.warheadType == MissileBase.WarheadTypes.EMP;
@@ -4595,6 +4596,7 @@ namespace BDArmory.Control
                             {
                                 if (mlauncher.TargetingMode == MissileBase.TargetingModes.Radar && radars.Count <= 0) continue; //dont select RH missiles when no radar aboard
                                 if (mlauncher.TargetingMode == MissileBase.TargetingModes.Laser && targetingPods.Count <= 0) continue; //don't select LH missiles when no FLIR aboard
+                                if (mlauncher.reloadableRail != null && (mlauncher.reloadableRail.ammoCount < 1 && !BDArmorySettings.INFINITE_ORDINANCE)) continue; //don't select when out of ordinance
                                 candidateDetDist = mlauncher.DetonationDistance;
                                 candidateTurning = mlauncher.maxTurnRateDPS; //for anti-aircraft, prioritize detonation dist and turn capability
                                 candidatePriority = Mathf.RoundToInt(mlauncher.priority);
@@ -4834,6 +4836,7 @@ namespace BDArmory.Control
                         {
                             MissileLauncher Bomb = item.Current as MissileLauncher;
                             if (targetWeapon != null && targetWeapon.GetWeaponClass() == WeaponClasses.Missile) continue;
+                            if (Bomb.reloadableRail != null && (Bomb.reloadableRail.ammoCount < 1 && !BDArmorySettings.INFINITE_ORDINANCE)) continue; //don't select when out of ordinance
                             //if (firedMissiles >= maxMissilesOnTarget) continue;// Max missiles are fired, try another weapon
                             // only useful if we are flying
                             float candidateYield = Bomb.GetBlastRadius();
@@ -4924,6 +4927,7 @@ namespace BDArmory.Control
                             MissileLauncher Missile = item.Current as MissileLauncher;
                             if (Missile.TargetingMode == MissileBase.TargetingModes.Radar && radars.Count <= 0) continue; //dont select RH missiles when no radar aboard
                             if (Missile.TargetingMode == MissileBase.TargetingModes.Laser && targetingPods.Count <= 0) continue; //don't select LH missiles when no FLIR aboard
+                            if (Missile.reloadableRail != null && (Missile.reloadableRail.ammoCount < 1 && !BDArmorySettings.INFINITE_ORDINANCE)) continue; //don't select when out of ordinance
                             if (vessel.Splashed && FlightGlobals.getAltitudeAtPos(item.Current.GetPart().transform.position) < -2) continue;
                             //if (firedMissiles >= maxMissilesOnTarget) continue;// Max missiles are fired, try another weapon
                             float candidateYield = Missile.GetBlastRadius();
@@ -5000,6 +5004,7 @@ namespace BDArmory.Control
                         {
                             //if (firedMissiles >= maxMissilesOnTarget) continue;// Max missiles are fired, try another weapon
                             MissileLauncher SLW = item.Current as MissileLauncher;
+                            if (SLW.reloadableRail != null && (SLW.reloadableRail.ammoCount < 1 && !BDArmorySettings.INFINITE_ORDINANCE)) continue; //don't select when out of ordinance
                             float candidateYield = SLW.GetBlastRadius();
                             bool EMP = SLW.warheadType == MissileBase.WarheadTypes.EMP;
                             int candidatePriority = Mathf.RoundToInt(SLW.priority);
@@ -5040,6 +5045,7 @@ namespace BDArmory.Control
                             MissileLauncher SLW = item.Current as MissileLauncher;
                             if (SLW.TargetingMode == MissileBase.TargetingModes.Radar && radars.Count <= 0) continue; //dont select RH missiles when no radar aboard
                             if (SLW.TargetingMode == MissileBase.TargetingModes.Laser && targetingPods.Count <= 0) continue; //don't select LH missiles when no FLIR aboard
+                            if (SLW.reloadableRail != null && (SLW.reloadableRail.ammoCount < 1 && !BDArmorySettings.INFINITE_ORDINANCE)) continue; //don't select when out of ordinance
                             float candidateYield = SLW.GetBlastRadius();
                             bool EMP = SLW.warheadType == MissileBase.WarheadTypes.EMP;
                             int candidatePriority = Mathf.RoundToInt(SLW.priority);

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -6531,7 +6531,7 @@ namespace BDArmory.Control
                         }
                         else
                         {
-                            if (!weapon.Current.isAPS) weapon.Current.DisableWeapon();
+                            if (!weapon.Current.isAPS || weapon.Current.isAPS && (weapon.Current.ammoCount <= 0 && !BDArmorySettings.INFINITE_AMMO)) weapon.Current.DisableWeapon();
                         }
                     }
                     else

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -5637,7 +5637,7 @@ namespace BDArmory.Control
                     heatTarget.predictedPosition - CurrentMissile.MissileReferenceTransform.position
                     : CurrentMissile.GetForwardTransform();
 
-                heatTarget = BDATargetManager.GetHeatTarget(vessel, vessel, new Ray(CurrentMissile.MissileReferenceTransform.position + (50 * CurrentMissile.GetForwardTransform()), direction), TargetSignatureData.noTarget, scanRadius, CurrentMissile.heatThreshold, CurrentMissile.uncagedLock, CurrentMissile.lockedSensorFOVBias, CurrentMissile.lockedSensorVelocityBias, this);
+                heatTarget = BDATargetManager.GetHeatTarget(vessel, vessel, new Ray(CurrentMissile.MissileReferenceTransform.position + (50 * CurrentMissile.GetForwardTransform()), direction), TargetSignatureData.noTarget, scanRadius, CurrentMissile.heatThreshold, CurrentMissile.uncagedLock, CurrentMissile.lockedSensorFOVBias, CurrentMissile.lockedSensorVelocityBias, this, currentTarget);
             }
         }
 
@@ -5692,7 +5692,8 @@ namespace BDArmory.Control
             else if (ml.TargetingMode == MissileBase.TargetingModes.Heat && heatTarget.exists)
             {
                 ml.heatTarget = heatTarget;
-                heatTarget = TargetSignatureData.noTarget;
+                MissileLauncher mml = CurrentMissile as MissileLauncher;
+                if (!mml.multiLauncher) heatTarget = TargetSignatureData.noTarget;
                 if (BDArmorySettings.DEBUG_MISSILES)
                     Debug.Log("[BDArmory.MissileData]: Sending targetInfo to heat Missile...");
                 ml.targetVessel = ml.heatTarget.vessel.gameObject.GetComponent<TargetInfo>();

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -929,6 +929,7 @@ namespace BDArmory.Control
                         if (weapon.Current.GetWeaponClass() == WeaponClasses.Gun || weapon.Current.GetWeaponClass() == WeaponClasses.Rocket || weapon.Current.GetWeaponClass() == WeaponClasses.DefenseLaser)
                         {
                             var gun = weapon.Current.GetPart().FindModuleImplementing<ModuleWeapon>();
+                            sw = weapon.Current; //check against salvofiring turrets - if all guns overheat at the same time, turrets get stuck in standby mode
                             if (gun.isReloading || gun.isOverheated || gun.pointingAtSelf || !(gun.ammoCount > 0 || BDArmorySettings.INFINITE_AMMO)) continue; //instead of returning the first weapon in a weapon group, return the first weapon in a group that actually can fire
                         }
                         if (weapon.Current.GetWeaponClass() == WeaponClasses.Missile || weapon.Current.GetWeaponClass() == WeaponClasses.Bomb || weapon.Current.GetWeaponClass() == WeaponClasses.SLW)
@@ -3969,7 +3970,7 @@ namespace BDArmory.Control
             //2. highest priority non-targeted target
             //3. closest non-targeted target
 
-            for (int i = 0; i < Math.Max(multiTargetNum, multiMissileTgtNum); i++)
+            for (int i = 0; i < Math.Max(multiTargetNum, multiMissileTgtNum) - 1; i++)
             {
                 TargetInfo potentialMissileTarget = null;
                 //=========MISSILES=============
@@ -3979,7 +3980,7 @@ namespace BDArmory.Control
                 {
                     missilesAssigned.Add(potentialMissileTarget);
                     targetsTried.Add(potentialMissileTarget);
-                    return;
+                    //return;
                 }
                 //then provide point defense umbrella
                 potentialMissileTarget = BDATargetManager.GetClosestMissileTarget(this);
@@ -3987,18 +3988,18 @@ namespace BDArmory.Control
                 {
                     missilesAssigned.Add(potentialMissileTarget);
                     targetsTried.Add(potentialMissileTarget);
-                    return;
+                    //return;
                 }
                 potentialMissileTarget = BDATargetManager.GetUnengagedMissileTarget(this);
                 if (potentialMissileTarget)
                 {
                     missilesAssigned.Add(potentialMissileTarget);
                     targetsTried.Add(potentialMissileTarget);
-                    return;
+                    //return;
                 }
             }
 
-            for (int i = 0; i < Math.Max(multiTargetNum, multiMissileTgtNum); i++)
+            for (int i = 0; i < Math.Max(multiTargetNum, multiMissileTgtNum) - 1; i++) //primary target already added, so subtract 1 from nultitargetnum
             {
                 TargetInfo potentialTarget = null;
                 //============VESSEL THREATS============
@@ -4010,7 +4011,7 @@ namespace BDArmory.Control
                     {
                         targetsAssigned.Add(potentialTarget);
                         targetsTried.Add(potentialTarget);
-                        return;
+                        //return;
                     }
                     potentialTarget = BDATargetManager.GetClosestTarget(this);
                     if (BDArmorySettings.DEFAULT_FFA_TARGETING)
@@ -4021,7 +4022,7 @@ namespace BDArmory.Control
                     {
                         targetsAssigned.Add(potentialTarget);
                         targetsTried.Add(potentialTarget);
-                        return;
+                        //return;
                     }
                 }
                 using (List<TargetInfo>.Enumerator finalTargets = BDATargetManager.GetAllTargetsExcluding(targetsTried, this).GetEnumerator())
@@ -4029,7 +4030,8 @@ namespace BDArmory.Control
                     {
                         if (finalTargets.Current == null) continue;
                         targetsAssigned.Add(finalTargets.Current);
-                        return;
+                        targetsTried.Add(finalTargets.Current);
+                        //return;
                     }
                 //else
                 if (potentialTarget == null)

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -1398,7 +1398,7 @@ namespace BDArmory.Damage
             {
                 HullMassAdjust = 0;
                 guiHullTypeString = StringUtils.Localize("#LOC_BDArmory_Aluminium");
-                //removing maxtemp from aluminium and steel to prevent hull type from causing issues with, say, spacecraft re-entry on installs with BDA not used exclusively for BDA
+                part.maxTemp = part.partInfo.partPrefab.maxTemp; //reset maxTemp to .cfg value
                 HullCostAdjust = 0;
             }
             else //hulltype 3
@@ -1406,6 +1406,7 @@ namespace BDArmory.Damage
                 HullMassAdjust = partMass;
                 guiHullTypeString = StringUtils.Localize("#LOC_BDArmory_Steel");
                 HullCostAdjust = Mathf.Min(((part.partInfo.cost + part.partInfo.variant.Cost) - (float)resourceCost) * 2, ((part.partInfo.cost + part.partInfo.variant.Cost) - (float)resourceCost) + 1500); //make steel parts rather more expensive
+                //part.maxTemp = 3000? 3200?
             }
             if (OldHullType != HullTypeNum || OldHullMassAdjust != HullMassAdjust)
             {

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -3,7 +3,7 @@ IMPROVEMENTS / FIXES
 - General:
 	- Use an alternative method of calculating vessel bounds to get the vessel radius. — Fixes some weird results with parasite fighters from KSP's internal function for this.
 	- Missile and countermeasure settings are now accessible in the Gameplay Settings section of the BDA Settings menu.
-	- Animate animations in the physics update so that the work with time-scaling.
+	- Animate animations in the physics update so that they work with time-scaling.
 	- Localisation corrections/updates. Also in German.
 	- Lots of optimisations.
 	- Add Notes.md for devs with notes on optimisation and the current branches.
@@ -15,6 +15,8 @@ IMPROVEMENTS / FIXES
 	- Rework how damage is applied to buildings and how they regenerate.
 	- Add a building damage multiplier.
 	- Fix reverse raycasts that were using the wrong rays.
+	- Fix detonate direction in BDExplosive part, missiles/rockets with ContinuousRod/ShapedCharge warheads should now have properly oriented AoEs.
+	- EMP warheads can now be set to be hard/soft EMP in their configs.
 - AI / WM:
 	- Add a "Debug Extending" button when AI debugging is enabled that prints extending debug info when clicked if the active vessel is extending.
 	- Fix GPS missiles not obeying max missile per target setting when the target is traveling at high speeds.
@@ -26,6 +28,13 @@ IMPROVEMENTS / FIXES
 	- Random position noise due to chaff no longer scales with RCS, is instead fixed to a random number between 16 and 256.
 - Weapons:
 	- Fixed bug where the target velocity and acceleration was not being reset once a target was no longer tracked which resulted in lead being erroneously compensated for while mouse aiming.
+	- Reworks ModuleMissileRearm, now works, integrated with WM, etc.
+	- Missiles with a ModuleMissileRearm can now have reloads, be affected by Infinite Ammo.
+	- Adds MultiMissileLauncher module.
+	- Adds new Infinite Ordinance toggle, for missiles with MultiMissileLauncher.
+	- Armor Tools now displays total wing srf. area, and wingloading kg/m2.
+	- Fixes NRE with APS missile interception.
+	- Fixes Max Turret Targets not targeting more than 2 vessels.
 
 v1.5.2.1
 IMPROVEMENTS / FIXES

--- a/BDArmory/Extensions/VesselExtensions.cs
+++ b/BDArmory/Extensions/VesselExtensions.cs
@@ -89,7 +89,7 @@ namespace BDArmory.Extensions
 #if DEBUG
                 if (radius < bounds.x / 2f && radius < bounds.y / 2f && radius < bounds.z / 2f) Debug.LogWarning($"DEBUG Radius {radius} of {vessel.vesselName} is less than half its minimum bounds {bounds}");
 #endif
-                return Mathf.Max(radius, Mathf.Max(Mathf.Max(vessel.vesselSize.x, vessel.vesselSize.y), vessel.vesselSize.z) / 2f); // clamp bounds to vesselsize
+                return Mathf.Min(radius, (Mathf.Max(Mathf.Max(vessel.vesselSize.x, vessel.vesselSize.y), vessel.vesselSize.z) / 2f) * 1.41f); // clamp bounds to vesselsize in case of Bounds erroneously reporting vessel sizes that are impossibly large
             }
         }
 

--- a/BDArmory/Extensions/VesselExtensions.cs
+++ b/BDArmory/Extensions/VesselExtensions.cs
@@ -89,7 +89,7 @@ namespace BDArmory.Extensions
 #if DEBUG
                 if (radius < bounds.x / 2f && radius < bounds.y / 2f && radius < bounds.z / 2f) Debug.LogWarning($"DEBUG Radius {radius} of {vessel.vesselName} is less than half its minimum bounds {bounds}");
 #endif
-                return Mathf.Min(radius, (Mathf.Max(Mathf.Max(vessel.vesselSize.x, vessel.vesselSize.y), vessel.vesselSize.z) / 2f) * 1.41f); // clamp bounds to vesselsize in case of Bounds erroneously reporting vessel sizes that are impossibly large
+                return Mathf.Min(radius, (Mathf.Max(Mathf.Max(vessel.vesselSize.x, vessel.vesselSize.y), vessel.vesselSize.z) / 2f) * 1.732f); // clamp bounds to vesselsize in case of Bounds erroneously reporting vessel sizes that are impossibly large
             }
         }
 

--- a/BDArmory/Extensions/VesselExtensions.cs
+++ b/BDArmory/Extensions/VesselExtensions.cs
@@ -89,7 +89,7 @@ namespace BDArmory.Extensions
 #if DEBUG
                 if (radius < bounds.x / 2f && radius < bounds.y / 2f && radius < bounds.z / 2f) Debug.LogWarning($"DEBUG Radius {radius} of {vessel.vesselName} is less than half its minimum bounds {bounds}");
 #endif
-                return radius;
+                return Mathf.Max(radius, Mathf.Max(Mathf.Max(vessel.vesselSize.x, vessel.vesselSize.y), vessel.vesselSize.z) / 2f); // clamp bounds to vesselsize
             }
         }
 

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -199,7 +199,7 @@ namespace BDArmory.FX
                 switch (ExplosionSource)
                 {
                     case ExplosionSourceType.Missile:
-                        var explosivePart = ExplosivePart ? ExplosivePart.FindModuleImplementing<BDExplosivePart>() : null;
+                        var explosivePart = ExplosivePart ? ExplosivePart.FindModuleImplementing<BDExplosivePart>() : null; //isn't this already set in the explosion setup?
                         sourceVesselName = explosivePart ? explosivePart.sourcevessel.GetName() : SourceVesselName;
                         break;
                     default: // Everything else.
@@ -317,6 +317,7 @@ namespace BDArmory.FX
                         if (partHit != null)
                         {
                             if (ProjectileUtils.IsIgnoredPart(partHit)) continue; // Ignore ignored parts.
+                            if (partHit.name == ExplosivePart.name) continue; //don't fratricide fellow missiles/bombs in a launched salvo when the first detonates
                             if (partHit.mass > 0 && !explosionEventsPartsAdded.Contains(partHit))
                             {
                                 var damaged = ProcessPartEvent(partHit, sourceVesselName, explosionEventsPreProcessing, explosionEventsPartsAdded);
@@ -795,7 +796,7 @@ namespace BDArmory.FX
                     {
                         blastInfo = BlastPhysicsUtils.CalculatePartBlastEffects(part, realDistance, vesselMass * 1000f, Power, Range);
                     }
-                    else //majority of force concentrated in blast cone for shaped warheads, not going to apply much force to stuff outside 
+                    else //majority of force concentrated in blast AoE for shaped warheads, not going to apply much force to stuff outside 
                     {
                         if (realDistance < Range / 2) //further away than half the blast range, falloff blast effect outside primary AoE
                         {

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -317,7 +317,7 @@ namespace BDArmory.FX
                         if (partHit != null)
                         {
                             if (ProjectileUtils.IsIgnoredPart(partHit)) continue; // Ignore ignored parts.
-                            if (partHit.name == ExplosivePart.name) continue; //don't fratricide fellow missiles/bombs in a launched salvo when the first detonates
+                            if (ExplosivePart != null && partHit.name == ExplosivePart.name) continue; //don't fratricide fellow missiles/bombs in a launched salvo when the first detonates
                             if (partHit.mass > 0 && !explosionEventsPartsAdded.Contains(partHit))
                             {
                                 var damaged = ProcessPartEvent(partHit, sourceVesselName, explosionEventsPreProcessing, explosionEventsPartsAdded);

--- a/BDArmory/Radar/VesselRadarData.cs
+++ b/BDArmory/Radar/VesselRadarData.cs
@@ -585,7 +585,7 @@ namespace BDArmory.Radar
                 UpdateInputs();
             }
 
-            drawGUI = (HighLogic.LoadedSceneIsFlight && FlightGlobals.ready && !vessel.packed && rCount > 0 &&
+            drawGUI = (HighLogic.LoadedSceneIsFlight && FlightGlobals.ready && !vessel.packed && rCount + iCount > 0 &&
                        vessel.isActiveVessel && BDArmorySetup.GAME_UI_ENABLED && !MapView.MapIsEnabled);
         }
 
@@ -1162,7 +1162,7 @@ namespace BDArmory.Radar
                 GUI.matrix = Matrix4x4.identity;
             }
 
-            if (noData)
+            if (noData && iCount == 0)
             {
                 GUI.Label(RadarDisplayRect, "NO DATA\n", lockStyle);
             }

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -437,7 +437,7 @@ namespace BDArmory.UI
             return flareTarget;
         }
 
-        public static TargetSignatureData GetHeatTarget(Vessel sourceVessel, Vessel missileVessel, Ray ray, TargetSignatureData priorHeatTarget, float scanRadius, float highpassThreshold, bool uncagedLock, FloatCurve lockedSensorFOVBias, FloatCurve lockedSensorVelocityBias, MissileFire mf = null)
+        public static TargetSignatureData GetHeatTarget(Vessel sourceVessel, Vessel missileVessel, Ray ray, TargetSignatureData priorHeatTarget, float scanRadius, float highpassThreshold, bool uncagedLock, FloatCurve lockedSensorFOVBias, FloatCurve lockedSensorVelocityBias, MissileFire mf = null, TargetInfo desiredTarget = null)
         {
             float minMass = 0.05f;  //otherwise the RAMs have trouble shooting down incoming missiles
             TargetSignatureData finalData = TargetSignatureData.noTarget;
@@ -454,8 +454,11 @@ namespace BDArmory.UI
                     continue;
                 if (vessel.vesselType == VesselType.Debris)
                     continue;
-                if (mf != null && mf.guardMode && (mf.currentTarget == null || mf.currentTarget.Vessel != vessel)) //clamp heaters to desired target
+                if (mf != null && mf.guardMode && (desiredTarget == null || desiredTarget.Vessel != vessel)) //clamp heaters to desired target  
+                {             
+                    //Debug.Log($"[BDATargetManager] looking at {vessel.GetName()}; has MF: {mf}; Guardmode: {(mf != null ? mf.guardMode.ToString() : "N/A")}");
                     continue;
+                }
 
                 TargetInfo tInfo = vessel.gameObject.GetComponent<TargetInfo>();
 

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -1036,7 +1036,7 @@ namespace BDArmory.UI
                 while (target.MoveNext())
                 {
                     if (target.Current == null) continue;
-                    if ((mf.multiTargetNum > 1 || mf.multiMissileTgtNum > 1) && mf.targetsAssigned.Contains(target.Current)) continue;
+                    //if ((mf.multiTargetNum > 1 || mf.multiMissileTgtNum > 1) && mf.targetsAssigned.Contains(target.Current)) continue;
                     if (target.Current && target.Current.Vessel && mf.CanSeeTarget(target.Current) && !excluding.Contains(target.Current))
                     {
                         finalTargets.Add(target.Current);
@@ -1101,6 +1101,7 @@ namespace BDArmory.UI
             using (var target = TargetList(mf.Team).GetEnumerator())
                 while (target.MoveNext())
                 {
+                    if (target.Current == null) continue;
                     //Debug.Log("[BDArmory.BDATargetmanager]: evaluating " + target.Current.Vessel.GetName());
                     if ((mf.multiTargetNum > 1 || mf.multiMissileTgtNum > 1) && mf.targetsAssigned.Contains(target.Current)) continue;
                     if (target.Current != null && target.Current.Vessel && mf.CanSeeTarget(target.Current) && !target.Current.isMissile && target.Current.isThreat)

--- a/BDArmory/Utils/ProjectileUtils.cs
+++ b/BDArmory/Utils/ProjectileUtils.cs
@@ -29,6 +29,7 @@ namespace BDArmory.Utils
         static HashSet<string> armorParts;
         public static bool IsArmorPart(Part part)
         {
+            if (BDArmorySettings.LEGACY_ARMOR) return false;
             if (armorParts == null)
             {
                 armorParts = PartLoader.LoadedPartsList.Select(p => p.partPrefab.partInfo.name).Where(name => name.ToLower().Contains("armor")).ToHashSet();

--- a/BDArmory/WeaponMounts/MissileTurret.cs
+++ b/BDArmory/WeaponMounts/MissileTurret.cs
@@ -529,13 +529,13 @@ namespace BDArmory.WeaponMounts
                     wm.PreviousMissile = missileChildren[index];
                 }
                 missileChildren[index].FireMissile();
-                StartCoroutine(MissileRailRoutine(missileChildren[index]));
+                StartCoroutine(MissileRailRoutine(missileChildren[index])); //turret is stil getting thrusted away despite this being behind a !relaodableRail conditional. investigate
                 if (wm)
                 {
                     wm.UpdateList();
                 }
 
-                UpdateMissileChildren();
+                if (!missileChildren[index].reloadableRail) UpdateMissileChildren();
 
                 timeFired = Time.time;
             }
@@ -578,8 +578,8 @@ namespace BDArmory.WeaponMounts
                 //Vector3 projVel = Vector3.Project(ml.vessel.Velocity-railVel, ray.direction);
 
                 ml.vessel.SetPosition(projPos);
-                ml.vessel.SetWorldVelocity(railVel + (forwardSpeed * ray.direction));
-
+                if (!ml.reloadableRail) ml.vessel.SetWorldVelocity(railVel + (forwardSpeed * ray.direction)); //this is still imparting veloctity on spawned missiles? Can function without, as long as missile turret is a static SAM site or similar
+                //else ml.reloadableRail.SpawnedMissile.vessel.SetWorldVelocity(railVel + (forwardSpeed * ray.direction));
                 yield return wait;
 
                 ray.origin = turret.pitchTransform.TransformPoint(localOrigin);
@@ -634,7 +634,7 @@ namespace BDArmory.WeaponMounts
 
             for (int i = 0; i < missileCount; i++)
             {
-                if ((missileChildren[i]) && missileChildren[i].part.name == ml.part.name)
+                if ((missileChildren[i]) && missileChildren[i].part.name == ml.part.name && !missileChildren[i].HasFired)
                 {
                     return true;
                 }

--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -571,7 +571,7 @@ namespace BDArmory.Weapons.Missiles
                 DrawDebugLine(lookRay.origin, lookRay.origin + lookRay.direction * 10000, Color.magenta);
 
                 // Update heat target
-                heatTarget = BDATargetManager.GetHeatTarget(SourceVessel, vessel, lookRay, predictedHeatTarget, lockedSensorFOV / 2, heatThreshold, uncagedLock, lockedSensorFOVBias, lockedSensorVelocityBias, (SourceVessel == null ? null : SourceVessel.gameObject == null ? null : SourceVessel.gameObject.GetComponent<MissileFire>()));
+                heatTarget = BDATargetManager.GetHeatTarget(SourceVessel, vessel, lookRay, predictedHeatTarget, lockedSensorFOV / 2, heatThreshold, uncagedLock, lockedSensorFOVBias, lockedSensorVelocityBias, (SourceVessel == null ? null : SourceVessel.gameObject == null ? null : SourceVessel.gameObject.GetComponent<MissileFire>()), targetVessel);
 
                 if (heatTarget.exists)
                 {

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -917,6 +917,7 @@ namespace BDArmory.Weapons.Missiles
                 if (reloadableRail)
                 {
                     if (!(reloadableMissile != null)) reloadableMissile = StartCoroutine(FireReloadableMissile());
+                    launched = true;
                 }
                 else
                 {
@@ -927,9 +928,10 @@ namespace BDArmory.Weapons.Missiles
                     vessel.vesselName = GetShortName();
                     TargetPosition = (multiLauncher ? vessel.ReferenceTransform.position + vessel.ReferenceTransform.up * 5000 : transform.position + transform.forward * 5000); //set initial target position so if no target update, missileBase will count a miss if it nears this point or is flying post-thrust
                     MissileLaunch();
+                    wpm.heatTarget = TargetSignatureData.noTarget;
+                    launched = true;
                 }
             }
-            launched = true;
         }
         IEnumerator FireReloadableMissile()
         {
@@ -943,7 +945,6 @@ namespace BDArmory.Weapons.Missiles
 
             ml.launched = true; 
             var wpm = VesselModuleRegistry.GetMissileFire(SourceVessel, true);
-            if (wpm != null) ml.Team = wpm.Team;
             BDATargetManager.FiredMissiles.Add(ml);
             ml.SourceVessel = SourceVessel;
             ml.GuidanceMode = GuidanceMode;
@@ -975,7 +976,12 @@ namespace BDArmory.Weapons.Missiles
                 ml.maxAltitude = maxAltitude;
             ml.terminalGuidanceShouldActivate = terminalGuidanceShouldActivate;
             ml.guidanceActive = true;
-            wpm.SendTargetDataToMissile(ml);
+            if (wpm != null)
+            {
+                ml.Team = wpm.Team;
+                wpm.SendTargetDataToMissile(ml);
+                wpm.heatTarget = TargetSignatureData.noTarget;
+            }
             ml.TargetPosition = transform.position + (multiLauncher ? vessel.ReferenceTransform.up * 5000 : transform.forward * 5000); //set initial target position so if no target update, missileBase will count a miss if it nears this point or is flying post-thrust
             ml.MissileLaunch();
             if (multiLauncher && multiLauncher.isClusterMissile)

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -908,7 +908,7 @@ namespace BDArmory.Weapons.Missiles
                 //multiLauncher.rippleRPM = wpm.rippleRPM;               
                 //if (wpm.rippleRPM > 0) multiLauncher.rippleRPM = wpm.rippleRPM;
                 multiLauncher.Team = Team;
-                if (reloadableRail.ammoCount > 1 || BDArmorySettings.INFINITE_ORDINANCE) multiLauncher.fireMissile();
+                if (reloadableRail.ammoCount >= 1 || BDArmorySettings.INFINITE_ORDINANCE) multiLauncher.fireMissile();
                 if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileLauncher]: firing Multilauncher! {vessel.vesselName}; {multiLauncher.subMunitionName}");                                    
             }
             else
@@ -920,13 +920,13 @@ namespace BDArmory.Weapons.Missiles
                 }
                 else
                 {
-                    BDATargetManager.FiredMissiles.Add(this);
                     TimeFired = Time.time;
                     part.decouple(0);
                     part.Unpack();
                     vessel.vesselName = GetShortName();
                     TargetPosition = (multiLauncher ? vessel.ReferenceTransform.position + vessel.ReferenceTransform.up * 5000 : transform.position + transform.forward * 5000); //set initial target position so if no target update, missileBase will count a miss if it nears this point or is flying post-thrust
                     MissileLaunch();
+                    BDATargetManager.FiredMissiles.Add(this);
                     wpm.heatTarget = TargetSignatureData.noTarget;
                     launched = true;
                 }
@@ -1015,7 +1015,7 @@ namespace BDArmory.Weapons.Missiles
 
                 if (sfAudioSource == null) SetupAudio();
                 sfAudioSource.PlayOneShot(SoundUtils.GetAudioClip("BDArmory/Sounds/deployClick"));
-                SourceVessel = vessel;
+                //SourceVessel = vessel;
 
                 //TARGETING
                 startDirection = transform.forward;

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -2263,6 +2263,7 @@ namespace BDArmory.Weapons.Missiles
                 if (warheadType == WarheadTypes.Standard || warheadType == WarheadTypes.ContinuousRod)
                 {
                     var tnt = part.FindModuleImplementing<BDExplosivePart>();
+                    tnt.sourcevessel = SourceVessel;
                     tnt.DetonateIfPossible();
                 }
                 else if (warheadType == WarheadTypes.Nuke)

--- a/BDArmory/Weapons/Missiles/ModuleMissileRearm.cs
+++ b/BDArmory/Weapons/Missiles/ModuleMissileRearm.cs
@@ -26,7 +26,7 @@ namespace BDArmory.Weapons.Missiles
 UI_FloatRange(minValue = 1f, maxValue = 4, stepIncrement = 1f, scene = UI_Scene.Editor)]
         public float ammoCount = 1; //need to figure out where ammo is stored, for mass addition/subtraction - in the missile? external missile ammo bin? CoM?
 
-        [KSPField]
+        [KSPField(isPersistant = true)]
         public string MissileName = "bahaAim120";
 
         [KSPField] public float reloadTime = 5f;
@@ -113,14 +113,14 @@ UI_FloatRange(minValue = 1f, maxValue = 4, stepIncrement = 1f, scene = UI_Scene.
             MissileLauncher ml = part.FindModuleImplementing<MissileLauncher>();
             {
                 ml.reloadableRail = this;
-                //Debug.Log("[BDArmory.ModuleMissileRearm]: " + MissileName);
                 using (var parts = PartLoader.LoadedPartsList.GetEnumerator())
                     while (parts.MoveNext())
                     {
                         if (parts.Current.partConfig == null || parts.Current.partPrefab == null)
                             continue;
                         if (!parts.Current.partPrefab.partInfo.name.Contains(MissileName)) continue;
-                        missilePart = parts.Current;                        
+                        missilePart = parts.Current;
+                        Debug.Log($"[BDArmory.ModuleMissileRearm]: looking for {MissileName}; found {missilePart.partPrefab.partInfo.name}");
                         break;
                     }
                 tntmass = missilePart.partPrefab.FindModuleImplementing<BDExplosivePart>().tntMass;

--- a/BDArmory/Weapons/Missiles/ModuleMissileRearm.cs
+++ b/BDArmory/Weapons/Missiles/ModuleMissileRearm.cs
@@ -32,6 +32,7 @@ UI_FloatRange(minValue = 1f, maxValue = 4, stepIncrement = 1f, scene = UI_Scene.
         [KSPField] public float reloadTime = 5f;
         [KSPField] public bool AccountForAmmo = true;
         [KSPField] public float maxAmmo = 20;
+        public float tntmass = 1;
         AvailablePart missilePart;
         public Part SpawnedMissile;
         public void SpawnMissile(Transform MissileTransform, bool offset = false)
@@ -122,6 +123,7 @@ UI_FloatRange(minValue = 1f, maxValue = 4, stepIncrement = 1f, scene = UI_Scene.
                         missilePart = parts.Current;                        
                         break;
                     }
+                tntmass = missilePart.partPrefab.FindModuleImplementing<BDExplosivePart>().tntMass;
                 if (AccountForAmmo)
                 {
                     missileCost = missilePart.partPrefab.partInfo.cost;

--- a/BDArmory/Weapons/Missiles/ModuleMissileRearm.cs
+++ b/BDArmory/Weapons/Missiles/ModuleMissileRearm.cs
@@ -75,7 +75,7 @@ UI_FloatRange(minValue = 1f, maxValue = 4, stepIncrement = 1f, scene = UI_Scene.
             var MML = part.FindModuleImplementing<MultiMissileLauncher>();
 			if (MML == null || MML && MML.isClusterMissile) MissileName = part.name;
             StartCoroutine(GetMissileValues());
-            GameEvents.onEditorShipModified.Add(ShipModified);
+            //GameEvents.onEditorShipModified.Add(ShipModified);
             UI_FloatRange Ammo = (UI_FloatRange)Fields["ammoCount"].uiControlEditor;
             Ammo.maxValue = maxAmmo;
         }
@@ -88,7 +88,8 @@ UI_FloatRange(minValue = 1f, maxValue = 4, stepIncrement = 1f, scene = UI_Scene.
         {
             if (part.parent)
             {
-                if (part.parent.FindModuleImplementing<MissileTurret>()) //turrets work... sorta. Missiles are reloading more or less where they should be, but there's some massive force being imparted on the turret every launch
+                
+                if (part.parent.FindModuleImplementing<MissileTurret>()) //turrets work... sorta. Missiles are reloading where they should be, but there's some massive force being imparted on the turret every launch
                 {// test UpdateMissileChildren fix used for rotary rails?
                     ammoCount = 1;
                     Fields["ammoCount"].guiActiveEditor = false;
@@ -97,6 +98,7 @@ UI_FloatRange(minValue = 1f, maxValue = 4, stepIncrement = 1f, scene = UI_Scene.
                 {
                     Fields["ammoCount"].guiActiveEditor = true;
                 }
+                
             }
         }
 
@@ -110,7 +112,7 @@ UI_FloatRange(minValue = 1f, maxValue = 4, stepIncrement = 1f, scene = UI_Scene.
             MissileLauncher ml = part.FindModuleImplementing<MissileLauncher>();
             {
                 ml.reloadableRail = this;
-                Debug.Log("[BDArmory.ModuleMissileRearm]: " + MissileName);
+                //Debug.Log("[BDArmory.ModuleMissileRearm]: " + MissileName);
                 using (var parts = PartLoader.LoadedPartsList.GetEnumerator())
                     while (parts.MoveNext())
                     {

--- a/BDArmory/Weapons/Missiles/ModuleMissileRearm.cs
+++ b/BDArmory/Weapons/Missiles/ModuleMissileRearm.cs
@@ -35,7 +35,7 @@ UI_FloatRange(minValue = 1f, maxValue = 4, stepIncrement = 1f, scene = UI_Scene.
         public float tntmass = 1;
         AvailablePart missilePart;
         public Part SpawnedMissile;
-        public void SpawnMissile(Transform MissileTransform, bool offset = false)
+        public void SpawnMissile(Transform MissileTransform, float offset = 0)
         {
             if (ammoCount >= 1 || BDArmorySettings.INFINITE_ORDINANCE)
             {
@@ -50,7 +50,7 @@ UI_FloatRange(minValue = 1f, maxValue = 4, stepIncrement = 1f, scene = UI_Scene.
                             var partNode = new ConfigNode();
                             PartSnapshot(missilePart.partPrefab).CopyTo(partNode);
                             //SpawnedMissile = CreatePart(partNode, MissileTransform.transform.position - MissileTransform.TransformDirection(missilePart.partPrefab.srfAttachNode.originalPosition),
-                            SpawnedMissile = CreatePart(partNode, offset ? (MissileTransform.position + MissileTransform.forward * 1.5f) : MissileTransform.transform.position, MissileTransform.rotation, this.part);
+                            SpawnedMissile = CreatePart(partNode, offset > 0 ? (MissileTransform.position + MissileTransform.forward * offset) : MissileTransform.transform.position, MissileTransform.rotation, this.part);
                             var MMR = SpawnedMissile.FindModuleImplementing<ModuleMissileRearm>();
                             if (MMR != null) AccountForAmmo = false;
                             /* //keep the module, can be used for cluster missile submunition creation

--- a/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
@@ -374,6 +374,12 @@ namespace BDArmory.Weapons.Missiles
                 if (!BDArmorySettings.INFINITE_ORDINANCE) missileSpawner.ammoCount--;
                 MissileLauncher ml = missileSpawner.SpawnedMissile.FindModuleImplementing<MissileLauncher>();
                 yield return new WaitUntilFixed(() => ml.SetupComplete); // Wait until missile fully initialized.
+                var tnt = VesselModuleRegistry.GetModule<BDExplosivePart>(vessel, true);
+                if (tnt != null)
+                {
+                    tnt.sourcevessel = missileLauncher.SourceVessel;
+                    tnt.isMissile = true;
+                }
                 ml.Team = Team;
                 ml.SourceVessel = missileLauncher.SourceVessel;
                 if (string.IsNullOrEmpty(ml.GetShortName()))
@@ -403,7 +409,6 @@ namespace BDArmory.Weapons.Missiles
                     ml.CruiseSpeed = missileLauncher.CruiseSpeed;
                     ml.CruisePredictionTime = missileLauncher.CruisePredictionTime;
                 }
-                ml.decoupleForward = missileLauncher.decoupleForward;
                 ml.decoupleSpeed = 5;
                 if (missileLauncher.GuidanceMode == GuidanceModes.AGM)
                     ml.maxAltitude = missileLauncher.maxAltitude;
@@ -690,6 +695,3 @@ namespace BDArmory.Weapons.Missiles
         }
     }
 }
-
-//huh. Vessel is a Monobehavior... Could a Vessel component be added to, say, rockets? if So, going the rocket route for missile pods/reloads would much simpler as most of the targeting code would no longer need to be rewritted to look for TargetInfos instead of Vessels. Would still need to mod the Bullet/Rocket/laser/Explosion hit code, and add an internal HP value, but...
-//performance hit/memleaks from spawning in new parts/vessels? Investigate

--- a/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
@@ -347,7 +347,7 @@ namespace BDArmory.Weapons.Missiles
                                         }
                                     }
                                     ml.targetVessel = wpm.targetsAssigned[TargetID];
-                                    //if (BDArmorySettings.DEBUG_MISSILES)
+                                    if (BDArmorySettings.DEBUG_MISSILES)
                                         Debug.Log($"[BDArmory.MultiMissileLauncher] Assigning target {TargetID}: {wpm.targetsAssigned[TargetID].Vessel.GetName()}; total possible targets {wpm.targetsAssigned.Count}");
                                 }
                                 else //else try remaining targets on the list. 
@@ -385,11 +385,11 @@ namespace BDArmory.Weapons.Missiles
                                                 }
                                             }
                                             ml.targetVessel = wpm.targetsAssigned[t];
-                                            //if (BDArmorySettings.DEBUG_MISSILES)
-                                                Debug.Log($"[BDArmory.MultiMissileLauncher] Assigning backup target (taretID {TargetID}) {wpm.targetsAssigned[t].Vessel.GetName()}");
+                                            if (BDArmorySettings.DEBUG_MISSILES)
+                                                Debug.Log($"[BDArmory.MultiMissileLauncher] Assigning backup target (targetID {TargetID}) {wpm.targetsAssigned[t].Vessel.GetName()}");
                                         }
                                     }
-                                    //if (BDArmorySettings.DEBUG_MISSILES) 
+                                    if (BDArmorySettings.DEBUG_MISSILES) 
                                     Debug.Log($"[BDArmory.MultiMissileLauncher] Couldn't assign valid target, trying from beginning of target list");
                                     if (ml.targetVessel == null) //check targets that were already assigned and passed. using the above iterator to prevent all targets outisde allowed FoV or engagement enveolpe from being assigned the firest possible target by checking later ones first
                                     { 
@@ -424,7 +424,7 @@ namespace BDArmory.Weapons.Missiles
                                                         }
                                                     }
                                                     ml.targetVessel = item.Current;
-                                                    //if (BDArmorySettings.DEBUG_MISSILES)
+                                                    if (BDArmorySettings.DEBUG_MISSILES)
                                                     Debug.Log($"[BDArmory.MultiMissileLauncher] original target out of sensor range; engaging {item.Current.Vessel.GetName()}");
                                                     break;
                                                 }

--- a/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
@@ -37,13 +37,14 @@ namespace BDArmory.Weapons.Missiles
         [KSPField] public float rippleRPM = 650;
         [KSPField] public string deployAnimationName;
         [KSPField] public string RailNode = "rail"; //name of attachnode for VLS MMLs to set missile loadout
+        [KSPField] public float tntMass = 1; //for MissileLauncher GetInfo()
         AnimationState deployState;
         ModuleMissileRearm missileSpawner = null;
         MissileLauncher missileLauncher = null;
         MissileFire wpm = null;
         private int tubesFired = 0;
         Part SymPart = null;
-        public BDTeam Team { get; set; } = BDTeam.Get("Neutral");
+        public BDTeam Team = BDTeam.Get("Neutral");
         public void Start()
         {
             MakeMissileArray();

--- a/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
@@ -452,6 +452,7 @@ namespace BDArmory.Weapons.Missiles
                 launchesThisSalvo++;
             }
             wpm.heatTarget = TargetSignatureData.noTarget;
+            missileLauncher.launched = true;
             if (deployState != null)
             {
                 deployState.enabled = true;

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -146,7 +146,7 @@ namespace BDArmory.Weapons
             {
                 var fireTransform = (eWeaponType == WeaponTypes.Rocket && rocketPod) ? rockets[0].parent : fireTransforms[0];
                 var theta = FiringTolerance * targetRadius / (finalAimTarget - fireTransform.position).magnitude + Mathf.Deg2Rad * maxDeviation / 2f; // Approximation to arctan(α*r/d) + θ/2. (arctan(x) = x-x^3/3 + O(x^5))
-                return finalAimTarget.IsZero() ? 1f : 1f - 0.5f * theta * theta; // Approximation to cos(theta). (cos(x) = 1-x^2/2!+O(x^4))
+                return finalAimTarget.IsZero() ? 1f : Mathf.Max(1f - 0.5f * theta * theta, 0); // Approximation to cos(theta). (cos(x) = 1-x^2/2!+O(x^4))
             }
         }
         public Vector3 targetPosition;
@@ -2326,7 +2326,7 @@ namespace BDArmory.Weapons
                                                     if (hitP && hitP != p && hitP.vessel && hitP.vessel != vessel)
                                                     {
                                                         //p.AddDamage(damage);
-                                                        p.AddSkinThermalFlux(damage);
+                                                        p.AddSkinThermalFlux(damage); //add modifier to adjust damage by armor diffusivity value
                                                     }
                                                 }
                                                 if (BDArmorySettings.DEBUG_WEAPONS) Debug.Log($"[BDArmory.ModuleWeapon]: Heatray Applying {damage} heat to target");
@@ -3810,8 +3810,8 @@ namespace BDArmory.Weapons
                 if (autoFire && autofireShotCount >= fireBurstLength)
                 {
                     autoFire = false;
-                    visualTargetVessel = null;
-                    visualTargetPart = null;
+                    //visualTargetVessel = null; //if there's no target, these get nulled in MissileFire. Nulling them here would cause Ai to stop engaging target with longer TargetScanIntervals as 
+                    //visualTargetPart = null; //there's no longer a targetVessel/part to do leadOffset aim calcs for.
                     tgtShell = null;
                     tgtRocket = null;
                     autofireShotCount = 0;
@@ -3836,10 +3836,10 @@ namespace BDArmory.Weapons
                 if (autoFire && Time.time - autoFireTimer > autoFireLength && !isAPS)
                 {
                     autoFire = false;
-                    visualTargetVessel = null;
-                    visualTargetPart = null;
-                    tgtShell = null;
-                    tgtRocket = null;
+                    //visualTargetVessel = null;
+                    //visualTargetPart = null;
+                    //tgtShell = null;
+                    //tgtRocket = null;
                     if (SpoolUpTime > 0)
                     {
                         roundsPerMinute = baseRPM / 10;


### PR DESCRIPTION
-Setting material to wood and then back to Al/steel now properly resets maxTemp to default.
-Add a clamp to vesselRadius
-Fix IRST being unable to activate VRD without a radar enabled
-Add launch offset param to MultiMissileLauncher
-Fix MMLs unable to fire if using salvos smaller than total launcher count
-MML salvoes now add one missile away per target fired on, not just primary target
-MML salvoes no longer labeled as [vesselname] debris
-Fix weapons nulling current target and throwing off lead offset calcs on vessels with long TargetScanIntervals
-Fix accuracy readout in Telemetry debug option
-Armor panels revert to BDAc armor panels use hitpoints instead of integrity if LEGACY_ARMOR enabled
-fix mass for multi missile rails
-finalize multi-launch VLS/missile rail implementation