### PR TITLE
v1.5.6.2 + Other Fixes

### DIFF
--- a/BDArmory/Competition/BDACompetitionMode.cs
+++ b/BDArmory/Competition/BDACompetitionMode.cs
@@ -428,7 +428,8 @@ namespace BDArmory.Competition
                     IBDAIControl pilot = VesselModuleRegistry.GetModule<IBDAIControl>(loadedVessels.Current);
                     if (pilot == null || !pilot.weaponManager || pilot.weaponManager.Team.Neutral)
                         continue;
-
+                    //so, for NPC on NPC violence prevention - have NPCs set to be allies of each other, or set to the same team? Should also probably have a toggle for if NPCs are friends w/ each other
+                    if(!String.IsNullOrEmpty(BDArmorySettings.REMOTE_ORC_NPCS_TEAM) && loadedVessels.Current.GetName().Contains(BDArmorySettings.REMOTE_ORCHESTRATION_NPC_SWAPPER)) pilot.weaponManager.SetTeam(BDTeam.Get(BDArmorySettings.REMOTE_ORC_NPCS_TEAM));
                     if (!pilots.TryGetValue(pilot.weaponManager.Team, out List<IBDAIControl> teamPilots))
                     {
                         teamPilots = new List<IBDAIControl>();

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -3294,7 +3294,7 @@ namespace BDArmory.Control
                         if (!VesselModuleRegistry.ignoredVesselTypes.Contains(vs.Current.vesselType))
                         {
                             var ibdaiControl = VesselModuleRegistry.GetModule<IBDAIControl>(vs.Current);
-                            if (ibdaiControl != null && ibdaiControl.commandLeader != null && ibdaiControl.commandLeader.vessel == vessel) continue;
+                            if (ibdaiControl != null && ibdaiControl.currentCommand == PilotCommands.Follow && ibdaiControl.commandLeader != null && ibdaiControl.commandLeader.vessel == vessel) continue;
                         }
                         vesselCollision = true;
                         collisionVesselType = vs.Current.vesselType;

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -5716,7 +5716,7 @@ namespace BDArmory.Control
                     heatTarget.predictedPosition - CurrentMissile.MissileReferenceTransform.position
                     : CurrentMissile.GetForwardTransform();
 
-                heatTarget = BDATargetManager.GetHeatTarget(vessel, vessel, new Ray(CurrentMissile.MissileReferenceTransform.position + (50 * CurrentMissile.GetForwardTransform()), direction), TargetSignatureData.noTarget, scanRadius, CurrentMissile.heatThreshold, CurrentMissile.uncagedLock, CurrentMissile.lockedSensorFOVBias, CurrentMissile.lockedSensorVelocityBias, this, currentTarget);
+                heatTarget = BDATargetManager.GetHeatTarget(vessel, vessel, new Ray(CurrentMissile.MissileReferenceTransform.position + (50 * CurrentMissile.GetForwardTransform()), direction), TargetSignatureData.noTarget, scanRadius, CurrentMissile.heatThreshold, CurrentMissile.frontAspectHeatModifier, CurrentMissile.uncagedLock, CurrentMissile.lockedSensorFOVBias, CurrentMissile.lockedSensorVelocityBias, this, currentTarget);
             }
         }
 

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -549,6 +549,9 @@ namespace BDArmory.Control
         [KSPField(isPersistant = true)]
         public bool targetMass = false;
 
+        [KSPField(isPersistant = true)]
+        public bool targetRandom = false;
+
         [KSPField(guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_targetSetting")]//Target Setting
         public string targetingString = StringUtils.Localize("#LOC_BDArmory_TargetCOM");
         [KSPEvent(guiActive = true, guiActiveEditor = true, active = true, guiName = "#LOC_BDArmory_Selecttargeting")]//Select Targeting Option
@@ -1191,7 +1194,8 @@ namespace BDArmory.Control
                 + (targetMass ? StringUtils.Localize("#LOC_BDArmory_Mass") + "; " : "")
                 + (targetCommand ? StringUtils.Localize("#LOC_BDArmory_Command") + "; " : "")
                 + (targetEngine ? StringUtils.Localize("#LOC_BDArmory_Engines") + "; " : "")
-                + (targetWeapon ? StringUtils.Localize("#LOC_BDArmory_Weapons") + "; " : "");
+                + (targetWeapon ? StringUtils.Localize("#LOC_BDArmory_Weapons") + "; " : "")
+                + (targetRandom ? StringUtils.Localize("#LOC_BDArmory_Random") + "; " : "");
         }
 
         void OnPartDie()
@@ -5716,7 +5720,7 @@ namespace BDArmory.Control
                     heatTarget.predictedPosition - CurrentMissile.MissileReferenceTransform.position
                     : CurrentMissile.GetForwardTransform();
 
-                heatTarget = BDATargetManager.GetHeatTarget(vessel, vessel, new Ray(CurrentMissile.MissileReferenceTransform.position + (50 * CurrentMissile.GetForwardTransform()), direction), TargetSignatureData.noTarget, scanRadius, CurrentMissile.heatThreshold, CurrentMissile.frontAspectHeatModifier, CurrentMissile.uncagedLock, CurrentMissile.lockedSensorFOVBias, CurrentMissile.lockedSensorVelocityBias, this, currentTarget);
+                heatTarget = BDATargetManager.GetHeatTarget(vessel, vessel, new Ray(CurrentMissile.MissileReferenceTransform.position + (50 * CurrentMissile.GetForwardTransform()), direction), TargetSignatureData.noTarget, scanRadius, CurrentMissile.heatThreshold, CurrentMissile.frontAspectHeatModifier, CurrentMissile.uncagedLock, CurrentMissile.lockedSensorFOVBias, CurrentMissile.lockedSensorVelocityBias, this, guardMode ? currentTarget : null);
             }
         }
 
@@ -6240,6 +6244,7 @@ namespace BDArmory.Control
                         weapon.Current.targetEngines = false;
                         weapon.Current.targetWeapons = false;
                         weapon.Current.targetMass = false;
+                        weapon.Current.targetRandom = false;
                     }
                     else
                     {
@@ -6247,6 +6252,7 @@ namespace BDArmory.Control
                         weapon.Current.targetEngines = targetEngine;
                         weapon.Current.targetWeapons = targetWeapon;
                         weapon.Current.targetMass = targetMass;
+                        weapon.Current.targetRandom = targetRandom;
                     }
 
                     weapon.Current.autoFireTimer = Time.time;

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -1008,6 +1008,8 @@ namespace BDArmory.Damage
                 Armor = ArmorThickness > 0 ? ArmorThickness : 2;
             }
             if (!_finished_setting_up && _armorConfigured && _hullConfigured) _hpConfigured = true;
+            if (BDArmorySettings.HP_CLAMP >= 100)
+                hitpoints = Mathf.Min(hitpoints, BDArmorySettings.HP_CLAMP);
             return hitpoints;
         }
 

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -396,8 +396,8 @@ namespace BDArmory.Damage
                 if (part.IsMissile() || part.IsWeapon() || ArmorPanel || isAI || BDArmorySettings.LEGACY_ARMOR || BDArmorySettings.RESET_HULL || ProjectileUtils.isMaterialBlackListpart(this.part))
                 {
                     HullTypeNum = HullInfo.materials.FindIndex(t => t.name == "Aluminium") + 1;
-                    HTrangeEditor.minValue = 2;
-                    HTrangeEditor.maxValue = 2;
+                    HTrangeEditor.minValue = HullTypeNum;
+                    HTrangeEditor.maxValue = HullTypeNum;
                     Fields["HullTypeNum"].guiActiveEditor = false;
                     Fields["HullTypeNum"].guiActive = false;
                     Fields["guiHullTypeString"].guiActiveEditor = false;
@@ -1449,13 +1449,19 @@ namespace BDArmory.Damage
                 _hullConfigured = true;
                 return;
             }
-            if (isAI || ArmorPanel || BDArmorySettings.RESET_HULL || BDArmorySettings.LEGACY_ARMOR) HullTypeNum = HullInfo.materials.FindIndex(t => t.name == "Aluminium");
-
-            if (OldHullType != HullTypeNum)
+            if (isAI || ArmorPanel || ProjectileUtils.isMaterialBlackListpart(this.part))
             {
-                if ((HullTypeNum - 1) > HullInfo.materialNames.Count) //in case of trying to load a craft using a mod hull type that isn't installed and having a hullTypeNum larger than the index size
+                _hullConfigured = true;
+                return;
+                //HullTypeNum = HullInfo.materials.FindIndex(t => t.name == "Aluminium");
+            }
+
+            if (OldHullType != HullTypeNum || (BDArmorySettings.RESET_HULL || BDArmorySettings.LEGACY_ARMOR))
+
+            {
+                if ((HullTypeNum - 1) > HullInfo.materialNames.Count || (BDArmorySettings.RESET_HULL || BDArmorySettings.LEGACY_ARMOR)) //in case of trying to load a craft using a mod hull type that isn't installed and having a hullTypeNum larger than the index size
                 {
-                    if (HullInfo.materialNames.Contains("Aluminium")) Debug.LogError("[BDArmory.HitpointTracker] BD_Materials.cfg missing! Please fix your BDA insteall");
+                    if (!HullInfo.materialNames.Contains("Aluminium")) Debug.LogError("[BDArmory.HitpointTracker] BD_Materials.cfg missing! Please fix your BDA insteall");
                     HullTypeNum = HullInfo.materials.FindIndex(t => t.name == "Aluminium") + 1;
                 }
 
@@ -1477,8 +1483,8 @@ namespace BDArmory.Damage
             }
             else
             {
-                part.maxTemp = part.partInfo.partPrefab.maxTemp;
-                part.skinMaxTemp = part.partInfo.partPrefab.skinMaxTemp;
+                part.maxTemp = part.partInfo.partPrefab.maxTemp > 0 ? part.partInfo.partPrefab.maxTemp : 2500; //kerbal flags apparently starting with -1 maxtemp
+                part.skinMaxTemp = part.partInfo.partPrefab.skinMaxTemp > 0 ? part.partInfo.partPrefab.skinMaxTemp : 2500;
             }
             ignitionTemp = hullInfo.ignitionTemp;
             part.crashTolerance = part.partInfo.partPrefab.crashTolerance * hullInfo.ImpactMod;

--- a/BDArmory/Distribution/GameData/BDArmory/BDArmory.version
+++ b/BDArmory/Distribution/GameData/BDArmory/BDArmory.version
@@ -13,7 +13,7 @@
         "MAJOR":1,
         "MINOR":5,
         "PATCH":6,
-        "BUILD":0
+        "BUILD":1
     },
     "KSP_VERSION":
     {

--- a/BDArmory/Distribution/GameData/BDArmory/BDArmory.version
+++ b/BDArmory/Distribution/GameData/BDArmory/BDArmory.version
@@ -13,7 +13,7 @@
         "MAJOR":1,
         "MINOR":5,
         "PATCH":6,
-        "BUILD":1
+        "BUILD":2
     },
     "KSP_VERSION":
     {

--- a/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Bullets.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Bullets.cfg
@@ -582,8 +582,8 @@ BULLET
     name = 35x228AHEADBullet //oerlikon
 	DisplayName = AHEAD Submunition
 	caliber = 10
-	bulletVelocity = 110 //this is added to parent bulletVelocity
-	bulletMass = 0.015
+	bulletVelocity = 5 //this is added to parent bulletVelocity
+	bulletMass = 0.025
 	//HE Bullet Values
 	explosive = None
 	incendiary = False
@@ -594,8 +594,9 @@ BULLET
 	startColor = 192, 192, 192, 32
 	apBulletMod = 0.8 //21mm
 	bulletDragTypeName = AnalyticEstimate
-	subProjectileCount = 50 //IRL 152!
-	subProjectileDispersion = 7.5
+	subProjectileCount = 30 //IRL 152!
+	subProjectileDispersion = 120 //influenced by bulletVel, lower bV needs higher sPD for similar spread
+
 }
 
 BULLET

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,4 +1,8 @@
-﻿v1.5.6.1
+﻿IMPROVEMENTS / FIXES
+- Add frontAspectHeatModifier variable to missile definitions, explained further in sidewinder.cfg. Allows you to create IR missiles that behave more like early IR rear-aspect/tail-chase missiles.
+- Remove the clamp on heat signature drop-off with range above 6 km. Prior to this change, any heat signatures more than 6 km away were capped at their 6 km value.
+
+v1.5.6.1
 IMPROVEMENTS / FIXES
 - Fix issue causing radars to return a cross-section of 0.0 for all craft.
 

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,6 +1,22 @@
-﻿IMPROVEMENTS / FIXES
-- Add frontAspectHeatModifier variable to missile definitions, explained further in sidewinder.cfg. Allows you to create IR missiles that behave more like early IR rear-aspect/tail-chase missiles.
-- Remove the clamp on heat signature drop-off with range above 6 km. Prior to this change, any heat signatures more than 6 km away were capped at their 6 km value.
+﻿v1.5.6.2
+IMPROVEMENTS / FIXES
+- General:
+	- Fix kerbal flags exploding from overheat when placed.
+	- Add some missing parts to HPFixes patch.
+- UI:
+	- Fix IRSTs not responding to Radar Display hotkeys.
+	- Fix Radar Analysis Window Radar select UX.
+- AI/WM:
+	- Add 'Random Part' subsystem targeting option.
+- Weapons:
+	- Nukes now work in space again.
+	- Fix IR missiles not locking on when manually firing.
+	- Fix Lasers not hitting missiles.
+	- Tweaks Oerlikon Millennium turret to improve missile interception ability, reduce lag.
+	- Add frontAspectHeatModifier variable to missile definitions, explained further in sidewinder.cfg. Allows you to create IR missiles that behave more like early IR rear-aspect/tail-chase missiles.
+	- Remove the clamp on heat signature drop-off with range above 6 km. Prior to this change, any heat signatures more than 6 km away were capped at their 6 km value.
+- RWP
+	- Add option for setting NPCs to a single team to Settings.cfg - REMOTE_ORC_NPCS_TEAM = [Teamname]. Leave blank for FFA NPCs.
 
 v1.5.6.1
 IMPROVEMENTS / FIXES

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,5 +1,6 @@
 ﻿IMPROVEMENTS / FIXES
 - Add option in BDA settings menu to set a max HP limit for parts.
+- Fix bug in collision avoidance that sometimes resulted in more collisions between teammates.
 
 v1.5.6.2
 IMPROVEMENTS / FIXES

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,4 +1,7 @@
-﻿v1.5.6.2
+﻿IMPROVEMENTS / FIXES
+- Add option in BDA settings menu to set a max HP limit for parts.
+
+v1.5.6.2
 IMPROVEMENTS / FIXES
 - General:
 	- Fix kerbal flags exploding from overheat when placed.

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,4 +1,8 @@
-﻿v1.5.6.0
+﻿v1.5.6.1
+IMPROVEMENTS / FIXES
+- Fix issue causing radars to return a cross-section of 0.0 for all craft.
+
+v1.5.6.0
 IMPROVEMENTS / FIXES
 - General:
 	- Russian localisation thanks to user Akteon_.

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,6 +1,8 @@
 ﻿IMPROVEMENTS / FIXES
 - Add option in BDA settings menu to set a max HP limit for parts.
 - Fix bug in collision avoidance that sometimes resulted in more collisions between teammates.
+- Fix anti-aliasing settings affecting craft RCS. Craft will have consistent RCS regardless oF MSAA settings, note that craft may have slightly different RCS across different GPUs/graphics APIs.
+- Adjust RCS scaling value to give 1 m^2 cross-section for a 1 m^2 cross-section sphere (a 25% increase). This setting was most likely previously set with MSAA enabled, so it was set incorrectly.
 
 v1.5.6.2
 IMPROVEMENTS / FIXES

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -251,6 +251,7 @@ Localization
         #LOC_BDArmory_Engines = Engines
         #LOC_BDArmory_Command = Cockpits
         #LOC_BDArmory_Mass = Heaviest Parts
+        #LOC_BDArmory_Random = Random Parts
 
         #LOC_BDArmory_Ammo_Setup = Ammo Loadout Configuration
         #LOC_BDArmory_Ammo_Weapon = Selected Weapon:

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -182,6 +182,7 @@ Localization
         #LOC_BDArmory_Settings_CameraSwitchFrequency = Camera Switch Frequency
         #LOC_BDArmory_Settings_DeathCameraInhibitPeriod = Death Camera Inhibit Period
         #LOC_BDArmory_Settings_Max_PWing_HP = HP Scaling Threshold
+        #LOC_BDArmory_Settings_HP_Clamp = Max HP Limit
         #LOC_BDArmory_Settings_DisableRamming = Disable Ramming
         #LOC_BDArmory_Settings_DefaultFFATargeting = Default FFA Targeting
         #LOC_BDArmory_Settings_TagMode = Tag Mode

--- a/BDArmory/Distribution/GameData/BDArmory/MMPatches/000000_HitpointModule_PartFixes.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/MMPatches/000000_HitpointModule_PartFixes.cfg
@@ -604,6 +604,25 @@
 		ExplodeMode = Never
 	}
 }
+@PART[M2X_TurbofanMk2] //JE-1 Mule
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 2500 //clamping from 36k
+		ExplodeMode = Never
+	}
+}
+
+@PART[M3X_Turbofan] //JE-4 Buffalo
+{
+	%MODULE[HitpointTracker]
+	{
+		ArmorThickness = 10
+		maxHitPoints = 4000 //claming from 52k
+		ExplodeMode = Never
+	}
+}
 
 @PART[M2X_EngineShroud] //Mk2 Engine Shroud
 {
@@ -2571,6 +2590,14 @@
 	{
 		ExplodeMode = Never
 		armorVolume = 33.75
+	}
+}
+@PART[parachuteSingle]
+{
+	%MODULE[HitpointTracker]
+	{
+		ExplodeMode = Never
+		maxHitPoints = 150
 	}
 }
 

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/oMillennium/oMillennium.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/oMillennium/oMillennium.cfg
@@ -83,10 +83,11 @@ PART
 		spinDownAnimation = false
 
 		roundsPerMinute = 850
-		maxDeviation = 0.47
+		maxDeviation = 0.27
 		maxTargetingRange = 3800
 
 		airDetonation = true
+		detonationRange = 150
 		maxEffectiveDistance = 3800
 
 		weaponType = ballistic

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/sidewinder/sidewinder.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/sidewinder/sidewinder.cfg
@@ -75,6 +75,9 @@ PART
         missileType = missile
         targetingType = heat
         heatThreshold = 50   // Distance-adjusted heat of target in order to be detected by missile, lower value results in better detection range
+        frontAspectHeatModifier = 1 // Modifies the heat signature of craft when ASPECTED_IR_SEEKERS = true in BDA settings.cfg. Useful for making rear-aspect only heaters (set frontAspectHeatModifier < 1), ex:
+        // Heat value within 50 deg cone of non-prop engine exhaust: (Engine Heat)
+        // Heat value outside of 50 deg cone of engine exhaust (or a prop engine): (Engine Heat) * frontAspectHeatModifier * (Internally Calculated Occlusion Factor)
         maxOffBoresight = 90 //maximum angle, from the boresight, that the missile can track the target. This also controls how the missile can launch off boresight. When launched from the air at another air target with uncagedLock = false, launch off boresight is at 0.35*maxOffBoresight, otherwise it is at 0.75*,maxOffBoresight (uncagedLock = true OR either launching craft or target is landed/splashed).
 		uncagedLock = false // true: Allows missile to be cued to a radar target, also controls launch conditions, see above
         // allAspect = false // DEPRECATED - use uncagedLock instead

--- a/BDArmory/FX/NukeFX.cs
+++ b/BDArmory/FX/NukeFX.cs
@@ -386,7 +386,7 @@ namespace BDArmory.FX
             if (building && building.IsIntact)
             {
                 var distToEpicenter = Mathf.Max((transform.position - building.transform.position).magnitude, 1f);
-                var blastImpulse = Mathf.Pow(3.01f * 1100f / distToEpicenter, 1.25f) * 6.894f * lastValidAtmDensity * yieldCubeRoot;
+                var blastImpulse = Mathf.Pow(3.01f * 1100f / distToEpicenter, 1.25f) * 6.894f * lastValidAtmDensity > 0.05f ? lastValidAtmDensity: 0.05f * yieldCubeRoot;
                 //Debug.Log("[BDArmory.NukeFX]: Building hit; distToG0: " + distToEpicenter + ", yield: " + yield + ", building: " + building.name);
 
                 if (!double.IsNaN(blastImpulse)) //140kPa, level at which reinforced concrete structures are destroyed
@@ -420,7 +420,7 @@ namespace BDArmory.FX
                     {
                         Debug.Log($"[BDArmory.NukeFX]: radiative area of part {part} was NaN, using approximate area {radiativeArea} instead.");
                     }
-                    double blastImpulse = Mathf.Pow(3.01f * 1100f / realDistance, 1.25f) * 6.894f * lastValidAtmDensity * yieldCubeRoot; // * (radiativeArea / 3f); pascals/m isn't going to increase if a larger surface area, it's still going go be same force
+                    double blastImpulse = Mathf.Pow(3.01f * 1100f / realDistance, 1.25f) * 6.894f * lastValidAtmDensity > 0.05f ? lastValidAtmDensity : 0.05f * yieldCubeRoot; // * (radiativeArea / 3f); pascals/m isn't going to increase if a larger surface area, it's still going go be same force
                     if (blastImpulse > 0)
                     {
                         float damage = 0;
@@ -504,7 +504,7 @@ namespace BDArmory.FX
                         Debug.Log("[BDArmory.NukeFX]: Part " + part.name + " at distance " + realDistance + "m took no damage");
                     }
                     //part.skinTemperature += fluence * 3370000000 / (4 * Math.PI * (realDistance * realDistance)) * radiativeArea / 2; // Fluence scales linearly w/ yield, 1 Kt will produce between 33 TJ and 337 kJ at 0-1000m,
-                    part.skinTemperature += (fluence * (337000000 * BDArmorySettings.EXP_DMG_MOD_MISSILE) / (4 * Math.PI * (realDistance * realDistance))) * lastValidAtmDensity; // everything gets heated via atmosphere
+                    part.skinTemperature += (fluence * (337000000 * BDArmorySettings.EXP_DMG_MOD_MISSILE) / (4 * Math.PI * (realDistance * realDistance))) * lastValidAtmDensity > 0.05f ? lastValidAtmDensity : 0.05f; // everything gets heated via atmosphere
                     if (isEMP)
                     {
                         if (part == part.vessel.rootPart) //don't apply EMP buildup per part

--- a/BDArmory/FX/NukeFX.cs
+++ b/BDArmory/FX/NukeFX.cs
@@ -420,7 +420,7 @@ namespace BDArmory.FX
                     {
                         Debug.Log($"[BDArmory.NukeFX]: radiative area of part {part} was NaN, using approximate area {radiativeArea} instead.");
                     }
-                    double blastImpulse = Mathf.Pow(3.01f * 1100f / realDistance, 1.25f) * 6.894f * lastValidAtmDensity > 0.05f ? lastValidAtmDensity : 0.05f * yieldCubeRoot; // * (radiativeArea / 3f); pascals/m isn't going to increase if a larger surface area, it's still going go be same force
+                    double blastImpulse = Mathf.Pow(3.01f * 1100f / realDistance, 1.25f) * 6.894f * lastValidAtmDensity > 0.1f ? lastValidAtmDensity : 0.1f * yieldCubeRoot; // * (radiativeArea / 3f); pascals/m isn't going to increase if a larger surface area, it's still going go be same force
                     if (blastImpulse > 0)
                     {
                         float damage = 0;
@@ -504,7 +504,7 @@ namespace BDArmory.FX
                         Debug.Log("[BDArmory.NukeFX]: Part " + part.name + " at distance " + realDistance + "m took no damage");
                     }
                     //part.skinTemperature += fluence * 3370000000 / (4 * Math.PI * (realDistance * realDistance)) * radiativeArea / 2; // Fluence scales linearly w/ yield, 1 Kt will produce between 33 TJ and 337 kJ at 0-1000m,
-                    part.skinTemperature += (fluence * (337000000 * BDArmorySettings.EXP_DMG_MOD_MISSILE) / (4 * Math.PI * (realDistance * realDistance))) * lastValidAtmDensity > 0.05f ? lastValidAtmDensity : 0.05f; // everything gets heated via atmosphere
+                    part.skinTemperature += (fluence * (337000000 * BDArmorySettings.EXP_DMG_MOD_MISSILE) / (4 * Math.PI * (realDistance * realDistance))) * (lastValidAtmDensity > 0.25f ? lastValidAtmDensity : 0.25f); // everything gets heated via atmosphere
                     if (isEMP)
                     {
                         if (part == part.vessel.rootPart) //don't apply EMP buildup per part

--- a/BDArmory/Properties/AssemblyInfo.cs
+++ b/BDArmory/Properties/AssemblyInfo.cs
@@ -17,8 +17,8 @@ using System.Runtime.InteropServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("1.5.6.1")]
-[assembly: AssemblyFileVersion("1.5.6.1")]
+[assembly: AssemblyVersion("1.5.6.2")]
+[assembly: AssemblyFileVersion("1.5.6.2")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/BDArmory/Properties/AssemblyInfo.cs
+++ b/BDArmory/Properties/AssemblyInfo.cs
@@ -17,8 +17,8 @@ using System.Runtime.InteropServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("1.5.6.0")]
-[assembly: AssemblyFileVersion("1.5.6.0")]
+[assembly: AssemblyVersion("1.5.6.1")]
+[assembly: AssemblyFileVersion("1.5.6.1")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -148,6 +148,11 @@ namespace BDArmory.Radar
             //1. baseSig = GetVesselRadarCrossSection
             TargetInfo ti = GetVesselRadarCrossSection(v);
 
+            //2. modifiedSig = GetVesselModifiedSignature(baseSig)    //ECM-jammers with rcs reduction effect; other rcs reductions (stealth)
+            ti.radarRCSReducedSignature = ti.radarBaseSignature; //These are needed for Radar functions to work!
+            ti.radarModifiedSignature = ti.radarBaseSignature;
+            //ti.radarLockbreakFactor = 1;
+
             return ti;
         }
 

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -1257,7 +1257,7 @@ namespace BDArmory.Radar
                         {
                             tInfo = loadedvessels.Current.gameObject.AddComponent<TargetInfo>();
                         }
-                        float signature = BDATargetManager.GetVesselHeatSignature(loadedvessels.Current, irst.referenceTransform.position, irst.TempSensitivityCurve) * (irst.boresightScan ? Mathf.Clamp01(15 / angle) : 1);
+                        float signature = BDATargetManager.GetVesselHeatSignature(loadedvessels.Current, irst.referenceTransform.position, 1f, irst.TempSensitivityCurve) * (irst.boresightScan ? Mathf.Clamp01(15 / angle) : 1);
                         //signature *= (1400 * 1400) / Mathf.Clamp((loadedvessels.Current.CoM - referenceTransform.position).sqrMagnitude, 90000, 36000000); //300 to 6000m - clamping sig past 6km; Commenting out as it makes tuning detection curves much easier
 
                         signature *= Mathf.Clamp(Vector3.Angle(loadedvessels.Current.transform.position - referenceTransform.position, -VectorUtils.GetUpDirection(referenceTransform.position)) / 90, 0.5f, 1.5f);

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -65,7 +65,7 @@ namespace BDArmory.Radar
 
         internal static float rcsTotal;               // dito
 
-        internal const float RCS_NORMALIZATION_FACTOR = 3.8f;       //IMPORTANT FOR RCS CALCULATION! DO NOT CHANGE! (sphere with 1m^2 cross section should have 1m^2 RCS)
+        internal const float RCS_NORMALIZATION_FACTOR = 3.04f;       //IMPORTANT FOR RCS CALCULATION! DO NOT CHANGE! (sphere with 1m^2 cross section should have 1m^2 RCS)
         internal const float RCS_MISSILES = 999f;                    //default rcs value for missiles if not configured in the part config
         internal const float RWR_PING_RANGE_FACTOR = 2.0f;
         internal const float RADAR_IGNORE_DISTANCE_SQR = 100f;
@@ -609,6 +609,7 @@ namespace BDArmory.Radar
         {
             // Render one snapshop pass:
             // setup camera FOV
+            radarCam.allowMSAA = false; // Don't allow MSAA with RCS render as this significantly affects results!
             radarCam.transform.position = vesselbounds.center + cameraDirection * radarDistance;
             radarCam.transform.LookAt(vesselbounds.center, -t.forward);
             float distanceToShip = Vector3.Distance(radarCam.transform.position, vesselbounds.center);

--- a/BDArmory/Radar/VesselRadarData.cs
+++ b/BDArmory/Radar/VesselRadarData.cs
@@ -580,7 +580,7 @@ namespace BDArmory.Radar
 
         private void Update()
         {
-            if (radarCount > 0)
+            if (radarCount + irstCount > 0)
             {
                 UpdateInputs();
             }
@@ -2366,24 +2366,34 @@ namespace BDArmory.Radar
                 ShowSelector();
                 SlewSelector(Vector2.up);
             }
-
-            if (BDInputUtils.GetKeyDown(BDInputSettingsFields.RADAR_LOCK))
+            if (radarCount > 0)
             {
-                if (showSelector)
+                if (BDInputUtils.GetKeyDown(BDInputSettingsFields.RADAR_LOCK))
                 {
-                    TryLockViaSelector();
+                    if (showSelector)
+                    {
+                        TryLockViaSelector();
+                    }
+                    ShowSelector();
                 }
-                ShowSelector();
-            }
 
-            if (BDInputUtils.GetKeyDown(BDInputSettingsFields.RADAR_CYCLE_LOCK))
-            {
-                if (locked)
+                if (BDInputUtils.GetKeyDown(BDInputSettingsFields.RADAR_CYCLE_LOCK))
                 {
-                    CycleActiveLock();
+                    if (locked)
+                    {
+                        CycleActiveLock();
+                    }
+                }
+
+                if (BDInputUtils.GetKeyDown(BDInputSettingsFields.RADAR_TARGET_NEXT))
+                {
+                    TargetNext();
+                }
+                else if (BDInputUtils.GetKeyDown(BDInputSettingsFields.RADAR_TARGET_PREV))
+                {
+                    TargetPrev();
                 }
             }
-
             if (BDInputUtils.GetKeyDown(BDInputSettingsFields.RADAR_SCAN_MODE))
             {
                 if (!locked && radarCount + irstCount > 0 && !omniDisplay)
@@ -2392,7 +2402,14 @@ namespace BDArmory.Radar
                     availableIRSTs[0].boresightScan = !availableIRSTs[0].boresightScan;
                 }
             }
-
+            if (BDInputUtils.GetKeyDown(BDInputSettingsFields.RADAR_RANGE_UP))
+            {
+                IncreaseRange();
+            }
+            else if (BDInputUtils.GetKeyDown(BDInputSettingsFields.RADAR_RANGE_DN))
+            {
+                DecreaseRange();
+            }
             if (BDInputUtils.GetKeyDown(BDInputSettingsFields.RADAR_TURRETS))
             {
                 if (slaveTurrets)
@@ -2403,24 +2420,6 @@ namespace BDArmory.Radar
                 {
                     SlaveTurrets();
                 }
-            }
-
-            if (BDInputUtils.GetKeyDown(BDInputSettingsFields.RADAR_RANGE_UP))
-            {
-                IncreaseRange();
-            }
-            else if (BDInputUtils.GetKeyDown(BDInputSettingsFields.RADAR_RANGE_DN))
-            {
-                DecreaseRange();
-            }
-
-            if (BDInputUtils.GetKeyDown(BDInputSettingsFields.RADAR_TARGET_NEXT))
-            {
-                TargetNext();
-            }
-            else if (BDInputUtils.GetKeyDown(BDInputSettingsFields.RADAR_TARGET_PREV))
-            {
-                TargetPrev();
             }
         }
 

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -244,6 +244,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static float REMOTE_INTERHEAT_DELAY = 30;                                     // Delay between heats.
         [BDAPersistentSettingsField] public static int RUNWAY_PROJECT_ROUND = 10;                                         // RWP round index.
         [BDAPersistentSettingsField] public static string REMOTE_ORCHESTRATION_NPC_SWAPPER = "Rammer";
+        [BDAPersistentSettingsField] public static string REMOTE_ORC_NPCS_TEAM = "";
 
         // Spawner settings
         [BDAPersistentSettingsField] public static bool SHOW_SPAWN_OPTIONS = true;                 // Show spawn options.

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -129,6 +129,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_BIAS = 0.16f;
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_HIT_MULTIPLIER = 2f;
         [BDAPersistentSettingsField] public static float HP_THRESHOLD = 0;                  //HP above this value will be scaled to a logarithmic value
+        [BDAPersistentSettingsField] public static float HP_CLAMP = 0;                  //HP will be clamped to this value
         [BDAPersistentSettingsField] public static bool PWING_EDGE_LIFT = true;                  //Toggle lift on PWing edges for balance with stock wings/remove edge abuse
         // Physics constants
         [BDAPersistentSettingsField] public static float GLOBAL_LIFT_MULTIPLIER = 0.25f;

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -29,7 +29,7 @@ namespace BDArmory.Targeting
         public bool radarBaseSignatureNeedsUpdate = true;
         public float radarRCSReducedSignature;
         public float radarModifiedSignature;
-        public float radarLockbreakFactor;
+        public float radarLockbreakFactor = 1;
         public float radarJammingDistance;
         public bool alreadyScheduledRCSUpdate = false;
         public float radarMassAtUpdate = 0f;

--- a/BDArmory/UI/BDAEditorAnalysisWindow.cs
+++ b/BDArmory/UI/BDAEditorAnalysisWindow.cs
@@ -199,7 +199,7 @@ namespace BDArmory.UI
                 FillRadarList();
                 GUIStyle listStyle = new GUIStyle(BDArmorySetup.BDGuiSkin.button);
                 listStyle.fixedHeight = 18; //make list contents slightly smaller
-                radarBox = new BDGUIComboBox(new Rect(10, 350, 600, 20), new Rect(10, 350, 250, 20), radarBoxText, radarsGUI, 124, listStyle);
+                radarBox = new BDGUIComboBox(new Rect(10, 350, 450, 20), new Rect(10, 350, 450, 20), radarBoxText, radarsGUI, 124, listStyle);
             }
 
             int selected_index = radarBox.Show();
@@ -316,7 +316,7 @@ namespace BDArmory.UI
                 FillRadarList();
                 GUIStyle listStyle = new GUIStyle(BDArmorySetup.BDGuiSkin.button);
                 listStyle.fixedHeight = 18; //make list contents slightly smaller
-                radarBox = new BDGUIComboBox(new Rect(10, 350, 600, 20), new Rect(10, 350, 250, 20), radarBoxText, radarsGUI, 124, listStyle);
+                radarBox = new BDGUIComboBox(new Rect(10, 350, 450, 20), new Rect(10, 350, 450, 20), radarBoxText, radarsGUI, 124, listStyle);
             }
 
             int selected_index = radarBox.Show();

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -535,7 +535,7 @@ namespace BDArmory.UI
                             finalData = new TargetSignatureData(vessel, score);
                         }
                     }
-                    Debug.Log($"[IR DEBUG] heatscore of {vessel.GetName()} is {score}");
+                    //Debug.Log($"[IR DEBUG] heatscore of {vessel.GetName()} is {score}");
                 }
             }
 

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -3020,6 +3020,11 @@ namespace BDArmory.UI
                 {
                     if (HighLogic.LoadedSceneIsEditor && EditorLogic.fetch.ship is not null) GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
                 }
+                GUI.Label(SLeftSliderRect(++line), $"{StringUtils.Localize("#LOC_BDArmory_Settings_HP_Clamp")}:  {(BDArmorySettings.HP_CLAMP >= 100 ? (BDArmorySettings.HP_CLAMP.ToString()) : "Unclamped")}", leftLabel); // HP Scaling Threshold
+                if (BDArmorySettings.HP_CLAMP != (BDArmorySettings.HP_CLAMP = BDAMath.RoundToUnit(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.HP_CLAMP, 0, 25000), 250)))
+                {
+                    if (HighLogic.LoadedSceneIsEditor && EditorLogic.fetch.ship is not null) GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
+                }
 
                 line += 0.5f;
             }

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1483,10 +1483,11 @@ namespace BDArmory.UI
                                 ActiveWeaponManager.targetEngine = false;
                                 ActiveWeaponManager.targetWeapon = false;
                                 ActiveWeaponManager.targetMass = false;
+                                ActiveWeaponManager.targetRandom = false;
                             }
-                            if (!ActiveWeaponManager.targetCoM && (!ActiveWeaponManager.targetWeapon && !ActiveWeaponManager.targetEngine && !ActiveWeaponManager.targetCommand && !ActiveWeaponManager.targetMass))
+                            if (!ActiveWeaponManager.targetCoM && (!ActiveWeaponManager.targetWeapon && !ActiveWeaponManager.targetEngine && !ActiveWeaponManager.targetCommand && !ActiveWeaponManager.targetMass && !ActiveWeaponManager.targetRandom))
                             {
-                                ActiveWeaponManager.targetMass = true;
+                                ActiveWeaponManager.targetRandom = true;
                             }
                         }
                         TargetLines += 1.1f;
@@ -1500,7 +1501,7 @@ namespace BDArmory.UI
                             {
                                 ActiveWeaponManager.targetCoM = false;
                             }
-                            if (!ActiveWeaponManager.targetCoM && (!ActiveWeaponManager.targetWeapon && !ActiveWeaponManager.targetEngine && !ActiveWeaponManager.targetCommand && !ActiveWeaponManager.targetMass))
+                            if (!ActiveWeaponManager.targetCoM && (!ActiveWeaponManager.targetWeapon && !ActiveWeaponManager.targetEngine && !ActiveWeaponManager.targetCommand && !ActiveWeaponManager.targetMass && !ActiveWeaponManager.targetRandom))
                             {
                                 ActiveWeaponManager.targetCoM = true;
                             }
@@ -1515,7 +1516,7 @@ namespace BDArmory.UI
                             {
                                 ActiveWeaponManager.targetCoM = false;
                             }
-                            if (!ActiveWeaponManager.targetCoM && (!ActiveWeaponManager.targetWeapon && !ActiveWeaponManager.targetEngine && !ActiveWeaponManager.targetCommand && !ActiveWeaponManager.targetMass))
+                            if (!ActiveWeaponManager.targetCoM && (!ActiveWeaponManager.targetWeapon && !ActiveWeaponManager.targetEngine && !ActiveWeaponManager.targetCommand && !ActiveWeaponManager.targetMass && !ActiveWeaponManager.targetRandom))
                             {
                                 ActiveWeaponManager.targetCoM = true;
                             }
@@ -1531,7 +1532,7 @@ namespace BDArmory.UI
                             {
                                 ActiveWeaponManager.targetCoM = false;
                             }
-                            if (!ActiveWeaponManager.targetCoM && (!ActiveWeaponManager.targetWeapon && !ActiveWeaponManager.targetEngine && !ActiveWeaponManager.targetCommand && !ActiveWeaponManager.targetMass))
+                            if (!ActiveWeaponManager.targetCoM && (!ActiveWeaponManager.targetWeapon && !ActiveWeaponManager.targetEngine && !ActiveWeaponManager.targetCommand && !ActiveWeaponManager.targetMass && !ActiveWeaponManager.targetRandom))
                             {
                                 ActiveWeaponManager.targetCoM = true;
                             }
@@ -1546,18 +1547,34 @@ namespace BDArmory.UI
                             {
                                 ActiveWeaponManager.targetCoM = false;
                             }
-                            if (!ActiveWeaponManager.targetCoM && (!ActiveWeaponManager.targetWeapon && !ActiveWeaponManager.targetEngine && !ActiveWeaponManager.targetCommand && !ActiveWeaponManager.targetMass))
+                            if (!ActiveWeaponManager.targetCoM && (!ActiveWeaponManager.targetWeapon && !ActiveWeaponManager.targetEngine && !ActiveWeaponManager.targetCommand && !ActiveWeaponManager.targetMass && !ActiveWeaponManager.targetRandom))
                             {
                                 ActiveWeaponManager.targetCoM = true;
                             }
                         }
                         TargetLines += 1.1f;
-
+                        string Randomlabel = StringUtils.Localize("#LOC_BDArmory_Random", (ActiveWeaponManager.targetRandom ? StringUtils.Localize("#LOC_BDArmory_false") : StringUtils.Localize("#LOC_BDArmory_true")));//"Engage Surface; True, False
+                        if (GUI.Button(new Rect(leftIndent, (TargetLines * entryHeight), ((contentWidth - (2 * leftIndent)) / 2), entryHeight),
+                            Randomlabel, ActiveWeaponManager.targetRandom ? BDGuiSkin.box : BDGuiSkin.button))
+                        {
+                            ActiveWeaponManager.targetRandom = !ActiveWeaponManager.targetRandom;
+                            ActiveWeaponManager.StartGuardTurretFiring();
+                            if (ActiveWeaponManager.targetRandom)
+                            {
+                                ActiveWeaponManager.targetCoM = false;
+                            }
+                            if (!ActiveWeaponManager.targetCoM && (!ActiveWeaponManager.targetWeapon && !ActiveWeaponManager.targetEngine && !ActiveWeaponManager.targetCommand && !ActiveWeaponManager.targetMass && !ActiveWeaponManager.targetRandom))
+                            {
+                                ActiveWeaponManager.targetCoM = true;
+                            }
+                        }
+                        TargetLines += 1.1f;
                         ActiveWeaponManager.targetingString = (ActiveWeaponManager.targetCoM ? StringUtils.Localize("#LOC_BDArmory_TargetCOM") + "; " : "")
                             + (ActiveWeaponManager.targetMass ? StringUtils.Localize("#LOC_BDArmory_Mass") + "; " : "")
                             + (ActiveWeaponManager.targetCommand ? StringUtils.Localize("#LOC_BDArmory_Command") + "; " : "")
                             + (ActiveWeaponManager.targetEngine ? StringUtils.Localize("#LOC_BDArmory_Engines") + "; " : "")
-                            + (ActiveWeaponManager.targetWeapon ? StringUtils.Localize("#LOC_BDArmory_Weapons") + "; " : "");
+                            + (ActiveWeaponManager.targetWeapon ? StringUtils.Localize("#LOC_BDArmory_Weapons") + "; " : "")
+                            + (ActiveWeaponManager.targetWeapon ? StringUtils.Localize("#LOC_BDArmory_Random") + "; " : "");
                         GUI.EndGroup();
                         TargetLines += 0.1f;
                     }

--- a/BDArmory/Utils/ProjectileUtils.cs
+++ b/BDArmory/Utils/ProjectileUtils.cs
@@ -54,7 +54,7 @@ namespace BDArmory.Utils
             if (IgnoredPartNames == null)
             {
                 IgnoredPartNames = new HashSet<string> { "bdPilotAI", "bdShipAI", "missileController", "bdammGuidanceModule" };
-                IgnoredPartNames.UnionWith(PartLoader.LoadedPartsList.Select(p => p.partPrefab.partInfo.name).Where(name => name.Contains("flagPart")));
+                IgnoredPartNames.UnionWith(PartLoader.LoadedPartsList.Select(p => p.partPrefab.partInfo.name).Where(name => name.Contains("flag")));
                 IgnoredPartNames.UnionWith(PartLoader.LoadedPartsList.Select(p => p.partPrefab.partInfo.name).Where(name => name.Contains("conformaldecals")));
 
                 var fileNode = ConfigNode.Load(settingsConfigURL);

--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -107,6 +107,9 @@ namespace BDArmory.Weapons.Missiles
         public float heatThreshold = 150;
 
         [KSPField]
+        public float frontAspectHeatModifier = 1f;                   // Modifies heat value returned to missiles outside of ~50 deg exhaust cone from non-prop engines. Only takes affect when ASPECTED_IR_SEEKERS = true in settings.cfg
+
+        [KSPField]
         public float chaffEffectivity = 1f;                            // Modifies  how the missile targeting is affected by chaff, 1 is fully affected (normal behavior), lower values mean less affected (0 is ignores chaff), higher values means more affected
 
         [KSPField]
@@ -572,7 +575,7 @@ namespace BDArmory.Weapons.Missiles
                 DrawDebugLine(lookRay.origin, lookRay.origin + lookRay.direction * 10000, Color.magenta);
 
                 // Update heat target
-                heatTarget = BDATargetManager.GetHeatTarget(SourceVessel, vessel, lookRay, predictedHeatTarget, lockedSensorFOV / 2, heatThreshold, uncagedLock, lockedSensorFOVBias, lockedSensorVelocityBias, (SourceVessel == null ? null : SourceVessel.gameObject == null ? null : SourceVessel.gameObject.GetComponent<MissileFire>()), targetVessel);
+                heatTarget = BDATargetManager.GetHeatTarget(SourceVessel, vessel, lookRay, predictedHeatTarget, lockedSensorFOV / 2, heatThreshold, frontAspectHeatModifier, uncagedLock, lockedSensorFOVBias, lockedSensorVelocityBias, (SourceVessel == null ? null : SourceVessel.gameObject == null ? null : SourceVessel.gameObject.GetComponent<MissileFire>()), targetVessel);
 
                 if (heatTarget.exists)
                 {

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -1550,7 +1550,7 @@ namespace BDArmory.Weapons.Missiles
                 {
                     case TargetingModes.Heat:
                         // gets ground heat targets and after locking one, disallows the lock to break to another target
-                        heatTarget = BDATargetManager.GetHeatTarget(SourceVessel, vessel, new Ray(transform.position + (50 * GetForwardTransform()), GetForwardTransform()), heatTarget, lockedSensorFOV / 2, heatThreshold, uncagedLock, lockedSensorFOVBias, lockedSensorVelocityBias, SourceVessel ? VesselModuleRegistry.GetModule<MissileFire>(SourceVessel) : null, targetVessel);
+                        heatTarget = BDATargetManager.GetHeatTarget(SourceVessel, vessel, new Ray(transform.position + (50 * GetForwardTransform()), GetForwardTransform()), heatTarget, lockedSensorFOV / 2, heatThreshold, frontAspectHeatModifier, uncagedLock, lockedSensorFOVBias, lockedSensorVelocityBias, SourceVessel ? VesselModuleRegistry.GetModule<MissileFire>(SourceVessel) : null, targetVessel);
                         if (heatTarget.exists)
                         {
                             if (BDArmorySettings.DEBUG_MISSILES)

--- a/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
@@ -446,7 +446,7 @@ namespace BDArmory.Weapons.Missiles
                                     if (ml.TargetingMode == MissileBase.TargetingModes.Heat) //need to input a heattarget, else this will just return MissileFire.CurrentTarget
                                     {
                                         Vector3 direction = (wpm.targetsAssigned[TargetID].position * wpm.targetsAssigned[TargetID].velocity.magnitude) - missileLauncher.MissileReferenceTransform.position;
-                                        ml.heatTarget = BDATargetManager.GetHeatTarget(ml.SourceVessel, vessel, new Ray(missileLauncher.MissileReferenceTransform.position + (50 * missileLauncher.GetForwardTransform()), direction), TargetSignatureData.noTarget, ml.lockedSensorFOV * 0.5f, ml.heatThreshold, true, ml.lockedSensorFOVBias, ml.lockedSensorVelocityBias, wpm, wpm.targetsAssigned[TargetID]);
+                                        ml.heatTarget = BDATargetManager.GetHeatTarget(ml.SourceVessel, vessel, new Ray(missileLauncher.MissileReferenceTransform.position + (50 * missileLauncher.GetForwardTransform()), direction), TargetSignatureData.noTarget, ml.lockedSensorFOV * 0.5f, ml.heatThreshold, ml.frontAspectHeatModifier, true, ml.lockedSensorFOVBias, ml.lockedSensorVelocityBias, wpm, wpm.targetsAssigned[TargetID]);
                                     }
                                     if (ml.TargetingMode == MissileBase.TargetingModes.Radar)
                                     {
@@ -484,7 +484,7 @@ namespace BDArmory.Weapons.Missiles
                                             if (ml.TargetingMode == MissileBase.TargetingModes.Heat)
                                             {
                                                 Vector3 direction = (wpm.targetsAssigned[t].position * wpm.targetsAssigned[t].velocity.magnitude) - missileLauncher.MissileReferenceTransform.position;
-                                                ml.heatTarget = BDATargetManager.GetHeatTarget(ml.SourceVessel, vessel, new Ray(missileLauncher.MissileReferenceTransform.position + (50 * missileLauncher.GetForwardTransform()), direction), TargetSignatureData.noTarget, ml.lockedSensorFOV * 0.5f, ml.heatThreshold, true, ml.lockedSensorFOVBias, ml.lockedSensorVelocityBias, wpm, wpm.targetsAssigned[t]);
+                                                ml.heatTarget = BDATargetManager.GetHeatTarget(ml.SourceVessel, vessel, new Ray(missileLauncher.MissileReferenceTransform.position + (50 * missileLauncher.GetForwardTransform()), direction), TargetSignatureData.noTarget, ml.lockedSensorFOV * 0.5f, ml.heatThreshold, ml.frontAspectHeatModifier, true, ml.lockedSensorFOVBias, ml.lockedSensorVelocityBias, wpm, wpm.targetsAssigned[t]);
                                             }
                                             if (ml.TargetingMode == MissileBase.TargetingModes.Radar)
                                             {
@@ -523,7 +523,7 @@ namespace BDArmory.Weapons.Missiles
                                                     if (ml.TargetingMode == MissileBase.TargetingModes.Heat)
                                                     {
                                                         Vector3 direction = (item.Current.position * item.Current.velocity.magnitude) - missileLauncher.MissileReferenceTransform.position;
-                                                        ml.heatTarget = BDATargetManager.GetHeatTarget(ml.SourceVessel, vessel, new Ray(missileLauncher.MissileReferenceTransform.position + (50 * missileLauncher.GetForwardTransform()), direction), TargetSignatureData.noTarget, ml.lockedSensorFOV * 0.5f, ml.heatThreshold, true, ml.lockedSensorFOVBias, ml.lockedSensorVelocityBias, wpm, item.Current);
+                                                        ml.heatTarget = BDATargetManager.GetHeatTarget(ml.SourceVessel, vessel, new Ray(missileLauncher.MissileReferenceTransform.position + (50 * missileLauncher.GetForwardTransform()), direction), TargetSignatureData.noTarget, ml.lockedSensorFOV * 0.5f, ml.heatThreshold, ml.frontAspectHeatModifier, true, ml.lockedSensorFOVBias, ml.lockedSensorVelocityBias, wpm, item.Current);
                                                     }
                                                     if (ml.TargetingMode == MissileBase.TargetingModes.Radar)
                                                     {


### PR DESCRIPTION
v1.5.6.2 +
- Add option in BDA settings menu to set a max HP limit for parts.
- Fix bug in collision avoidance that sometimes resulted in more collisions between teammates.
- Fix anti-aliasing settings affecting craft RCS. Craft will have consistent RCS regardless oF MSAA settings, note that craft may have slightly different RCS across different GPUs/graphics APIs.
- Adjust RCS scaling value to give 1 m^2 cross-section for a 1 m^2 cross-section sphere (a 25% increase). This setting was most likely previously set with MSAA enabled, so it was set incorrectly.