### PR TITLE
RWP tweaks

### DIFF
--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -896,7 +896,7 @@ namespace BDArmory.Bullets
                 KillBullet();
                 return true; //impulse rounds shouldn't penetrate/do damage
             }
-            float anglemultiplier = Mathf.Abs((float)Math.Cos(Math.PI * hitAngle / 180.0));
+            float anglemultiplier = (float)Math.Cos(Math.PI * hitAngle / 180.0);
             //calculate armor thickness
             float thickness = ProjectileUtils.CalculateThickness(hitPart, anglemultiplier);
             //calculate armor strength

--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -785,8 +785,9 @@ namespace BDArmory.Bullets
                     //if ((distanceTraveled + hit.distance - distanceLastHit) * 1000f > (7f * caliber * 10f))
 
                     // Changed from the previous 7 * caliber * 10 maximum to just > caliber since that no longer exists.
-                    if ((distanceTraveled + hit.distance - distanceLastHit) * 1000f > caliber)
-                    {
+                    //if ((distanceTraveled + hit.distance - distanceLastHit) * 1000f > caliber)
+                    if ((hit.distance - distanceLastHit) * 1000f > caliber) //why is distanceTravelled included? That's total flight distance the bullet's gone from the muzzle - SI
+                        {
                         // The formula is based on distance and the caliber of the shaped charge, now since in our case we are talking
                         // about projectiles rather than shaped charges we'll take the projectile diameter and call that the jet size.
                         // Shaped charge jets have a diameter generally around 5% of the shaped charge's caliber, however in our case
@@ -796,7 +797,9 @@ namespace BDArmory.Bullets
                         //float kTerm = ((float)(distanceTraveled + hit.distance - distanceLastHit) * 1000f - 7f * 10f *caliber) / (14f * 10f * caliber);
                         // Modified this from the original formula, commented out above to remove the standoff distance required for jet formation.
                         // Just makes more sense to me not to have it in there.
-                        float kTerm = ((float)(distanceTraveled + hit.distance - distanceLastHit) * 1000f) / (14f * 10f * caliber);
+                        //float kTerm = ((float)(distanceTraveled + hit.distance - distanceLastHit) * 1000f) / (14f * 10f * caliber);
+                        float kTerm = ((float)(hit.distance - distanceLastHit) * 1000f) / (14f * 10f * caliber);
+
                         kDist = 1f / (kDist * (1f + kTerm * kTerm)); // Then using it in the formula
 
                         // If the projectile gets too small things go wonky with the formulas for penetration
@@ -820,14 +823,15 @@ namespace BDArmory.Bullets
 
                         if (BDArmorySettings.DEBUG_WEAPONS)
                         {
-                            Debug.Log("[BDArmory.PooledBullet] kDist: " + kDist + ". Distance Since Last Hit: " + (distanceTraveled + hit.distance - distanceLastHit) + " m.");
+                            Debug.Log("[BDArmory.PooledBullet] kDist: " + kDist + ". Distance Since Last Hit: " + (hit.distance - distanceLastHit) + " m.");
                         }
                     }
 
                     if (double.IsPositiveInfinity(distanceLastHit))
                     {
                         // Add the distance since this hit so the next part that gets hit has the proper distance
-                        distanceLastHit = distanceTraveled + hit.distance;
+                        //distanceLastHit = distanceTraveled + hit.distance;
+                        distanceLastHit = hit.distance;
                     }
                 }
             }
@@ -892,7 +896,7 @@ namespace BDArmory.Bullets
                 KillBullet();
                 return true; //impulse rounds shouldn't penetrate/do damage
             }
-            float anglemultiplier = (float)Math.Cos(Math.PI * hitAngle / 180.0);
+            float anglemultiplier = Mathf.Abs((float)Math.Cos(Math.PI * hitAngle / 180.0));
             //calculate armor thickness
             float thickness = ProjectileUtils.CalculateThickness(hitPart, anglemultiplier);
             //calculate armor strength
@@ -1362,10 +1366,10 @@ namespace BDArmory.Bullets
                     sFuze = PooledBullet.BulletFuzeTypes.Impact;
                     break;
                 case "none":
-                    sFuze = PooledBullet.BulletFuzeTypes.None;
+                    sFuze = PooledBullet.BulletFuzeTypes.Impact;
                     break;
                 default:
-                    sFuze = PooledBullet.BulletFuzeTypes.Impact;
+                    sFuze = PooledBullet.BulletFuzeTypes.None;
                     break;
             }
             for (int s = 0; s < subMunitionType.subProjectileCount; s++)
@@ -1482,7 +1486,7 @@ namespace BDArmory.Bullets
 
             if (fuzeType == BulletFuzeTypes.Timed || fuzeType == BulletFuzeTypes.Flak)
             {
-                if (distanceFromStart > (beehive ? maxAirDetonationRange - 100 : maxAirDetonationRange) || distanceFromStart > (beehive ? defaultDetonationRange - 100 : defaultDetonationRange))
+                if (distanceFromStart > (beehive ? maxAirDetonationRange - detonationRange : maxAirDetonationRange) || distanceFromStart > (beehive ? defaultDetonationRange - detonationRange : defaultDetonationRange))
                 {
                     return detonate = true;
                 }
@@ -1594,7 +1598,7 @@ namespace BDArmory.Bullets
                     {
                         Debug.Log("[BDArmory.PooledBullet]: Detonation Triggered | penetration: " + hasPenetrated + " penTick: " + penTicker + " airDet: " + (fuzeType == BulletFuzeTypes.Timed || fuzeType == BulletFuzeTypes.Flak));
                     }
-                    if (fuzeType == BulletFuzeTypes.Timed || fuzeType == BulletFuzeTypes.Flak)
+                    if ((fuzeType == BulletFuzeTypes.Timed || fuzeType == BulletFuzeTypes.Flak) || HEType == PooledBulletTypes.Shaped)
                     {
                         if (HEType != PooledBulletTypes.Slug)
                             ExplosionFx.CreateExplosion(hit.point, GetExplosivePower(), explModelPath, explSoundPath, ExplosionSourceType.Bullet, caliber, null, sourceVesselName, null, HEType == PooledBulletTypes.Explosive ? default : ray.direction, -1, false, bulletMass, -1, dmgMult, HEType == PooledBulletTypes.Shaped ? "shapedcharge" : "standard", null, HEType == PooledBulletTypes.Shaped ? apBulletMod : 1f);

--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -785,8 +785,7 @@ namespace BDArmory.Bullets
                     //if ((distanceTraveled + hit.distance - distanceLastHit) * 1000f > (7f * caliber * 10f))
 
                     // Changed from the previous 7 * caliber * 10 maximum to just > caliber since that no longer exists.
-                    //if ((distanceTraveled + hit.distance - distanceLastHit) * 1000f > caliber)
-                    if ((hit.distance - distanceLastHit) * 1000f > caliber) //why is distanceTravelled included? That's total flight distance the bullet's gone from the muzzle - SI
+                    if ((distanceTraveled + hit.distance - distanceLastHit) * 1000f > caliber)
                         {
                         // The formula is based on distance and the caliber of the shaped charge, now since in our case we are talking
                         // about projectiles rather than shaped charges we'll take the projectile diameter and call that the jet size.
@@ -797,8 +796,7 @@ namespace BDArmory.Bullets
                         //float kTerm = ((float)(distanceTraveled + hit.distance - distanceLastHit) * 1000f - 7f * 10f *caliber) / (14f * 10f * caliber);
                         // Modified this from the original formula, commented out above to remove the standoff distance required for jet formation.
                         // Just makes more sense to me not to have it in there.
-                        //float kTerm = ((float)(distanceTraveled + hit.distance - distanceLastHit) * 1000f) / (14f * 10f * caliber);
-                        float kTerm = ((float)(hit.distance - distanceLastHit) * 1000f) / (14f * 10f * caliber);
+                        float kTerm = ((float)(distanceTraveled + hit.distance - distanceLastHit) * 1000f) / (14f * 10f * caliber);
 
                         kDist = 1f / (kDist * (1f + kTerm * kTerm)); // Then using it in the formula
 
@@ -823,15 +821,14 @@ namespace BDArmory.Bullets
 
                         if (BDArmorySettings.DEBUG_WEAPONS)
                         {
-                            Debug.Log("[BDArmory.PooledBullet] kDist: " + kDist + ". Distance Since Last Hit: " + (hit.distance - distanceLastHit) + " m.");
+                            Debug.Log("[BDArmory.PooledBullet] kDist: " + kDist + ". Distance Since Last Hit: " + (distanceTraveled + hit.distance - distanceLastHit) + " m.");
                         }
                     }
 
                     if (double.IsPositiveInfinity(distanceLastHit))
                     {
                         // Add the distance since this hit so the next part that gets hit has the proper distance
-                        //distanceLastHit = distanceTraveled + hit.distance;
-                        distanceLastHit = hit.distance;
+                        distanceLastHit = distanceTraveled + hit.distance;
                     }
                 }
             }

--- a/BDArmory/Competition/BDACompetitionMode.cs
+++ b/BDArmory/Competition/BDACompetitionMode.cs
@@ -521,6 +521,10 @@ namespace BDArmory.Competition
                 {
                     SpawnUtils.HackIntakes(pilot.vessel, true);
                 }
+                if (BDArmorySettings.RUNWAY_PROJECT)
+                {
+                    SpawnUtils.HackActuators(pilot.vessel, true);
+                }
             }
 
             //clear target database so pilots don't attack yet
@@ -1487,6 +1491,10 @@ namespace BDArmory.Competition
                                         {
                                             MM.EnableMutator(); //random mutator
                                         }
+                                    }
+                                    if (BDArmorySettings.RUNWAY_PROJECT)
+                                    {
+                                        SpawnUtils.HackActuators(pilot.vessel, true);
                                     }
                                     if (BDArmorySettings.ENABLE_HOS && BDArmorySettings.HALL_OF_SHAME_LIST.Count > 0)
                                     {

--- a/BDArmory/Competition/BDACompetitionMode.cs
+++ b/BDArmory/Competition/BDACompetitionMode.cs
@@ -1095,7 +1095,7 @@ namespace BDArmory.Competition
                             "5:ToggleGuard:1", // t=65, Enable guard mode
                         };
                         break;
-                    case 60: //change this later (orbital deployment)
+                    case 53: //change this later (orbital deployment)
                         commandSequence = new List<string>{
                             "0:ActionGroup:13:1", // t=0, AG4 - Enable SAS
                             "0:ActionGroup:16:0", // t=0, Retract gear (if it's not retracted)

--- a/BDArmory/Competition/RemoteOrchestration/BDAScoreClient.cs
+++ b/BDArmory/Competition/RemoteOrchestration/BDAScoreClient.cs
@@ -359,9 +359,9 @@ namespace BDArmory.Competition.RemoteOrchestration
                 Debug.LogWarning(string.Format("[BDArmory.BDAScoreClient] Failed to parse heat vessel collection: {0}", response));
                 return;
             }
+            SwapCraftFiles();
             foreach (VesselModel vesselModel in collection)
             {
-                SwapCraftFiles();
                 activeVessels.Add(vesselModel.id);
             }
             Debug.Log(string.Format("[BDArmory.BDAScoreClient] Active vessels: {0}", activeVessels.Count));
@@ -493,9 +493,11 @@ namespace BDArmory.Competition.RemoteOrchestration
         public void SwapCraftFiles()
         {
             DirectoryInfo info = new DirectoryInfo(vesselStagingPath);
-            FileInfo[] craftFiles = info.GetFiles("*.craft")
-                .Where(e => e.Extension == ".craft")
-                .ToArray();
+            FileInfo[] craftFiles = info.GetFiles("*.craft");
+                //.Where(e => e.Extension == ".craft").ToArray();
+            DirectoryInfo NPCinfo = new DirectoryInfo(NPCPath);
+            FileInfo[] NPCFiles = NPCinfo.GetFiles("*.craft");
+               // .Where(e => e.Extension == ".craft").ToArray();
             foreach (FileInfo file in craftFiles)
             {
                 if (file.Name.Contains(BDArmorySettings.REMOTE_ORCHESTRATION_NPC_SWAPPER))
@@ -504,10 +506,7 @@ namespace BDArmory.Competition.RemoteOrchestration
                     string filename = string.Format("{0}/{1}", vesselStagingPath, vesselname);
                     vesselname = vesselname.Remove(vesselname.Length - 6, 6); //cull the .craft from the string
                     Debug.Log("[BDArmory.BDAScoreClient] Swapping existing craft " + vesselname + " in spawn directory");
-                    DirectoryInfo NPCinfo = new DirectoryInfo(NPCPath);
-                    FileInfo[] NPCFiles = NPCinfo.GetFiles("*.craft")
-                        .Where(e => e.Extension == ".craft")
-                        .ToArray();
+                    
                     int i;
                     i = (int)UnityEngine.Random.Range(0, NPCFiles.Count() - 1);
                     Debug.Log(string.Format("[BDArmory.BDAScoreClient] {0} craft, selected number {1}", NPCFiles.Count(), i));

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,6 +1,22 @@
-﻿IMPROVEMENTS / FIXES
-- Add frontAspectHeatModifier variable to missile definitions, explained further in sidewinder.cfg. Allows you to create IR missiles that behave more like early IR rear-aspect/tail-chase missiles.
-- Remove the clamp on heat signature drop-off with range above 6 km. Prior to this change, any heat signatures more than 6 km away were capped at their 6 km value.
+﻿v1.5.6.2
+IMPROVEMENTS / FIXES
+- General:
+	- Fix kerbal flags exploding from overheat when placed.
+	- Add some missing parts to HPFixes patch.
+- UI:
+	- Fix IRSTs not responding to Radar Display hotkeys.
+	- Fix Radar Analysis Window Radar select UX.
+- AI/WM:
+	- Add 'Random Part' subsystem targeting option.
+- Weapons:
+	- Nukes now work in space again.
+	- Fix IR missiles not locking on when manually firing.
+	- Fix Lasers not hitting missiles.
+	- Tweaks Oerlikon Millennium turret to improve missile interception ability, reduce lag.
+	- Add frontAspectHeatModifier variable to missile definitions, explained further in sidewinder.cfg. Allows you to create IR missiles that behave more like early IR rear-aspect/tail-chase missiles.
+	- Remove the clamp on heat signature drop-off with range above 6 km. Prior to this change, any heat signatures more than 6 km away were capped at their 6 km value.
+- RWP
+	- Add option for setting NPCs to a single team to Settings.cfg - REMOTE_ORC_NPCS_TEAM = [Teamname]. Leave blank for FFA NPCs.
 
 v1.5.6.1
 IMPROVEMENTS / FIXES

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,4 +1,23 @@
-﻿v1.5.6.2
+﻿IMPROVEMENTS / FIXES
+- General:
+	- Add option in BDA settings menu to set a max HP limit for parts.
+- AI / WM:
+	- Fix bug in collision avoidance that sometimes resulted in more collisions between teammates.
+- Detectors:
+	- Fix anti-aliasing settings affecting craft RCS. Craft will have consistent RCS regardless oF MSAA settings, note that craft may have slightly different RCS across different GPUs/graphics APIs.
+	- Adjust RCS scaling value to give 1 m^2 cross-section for a 1 m^2 cross-section sphere (a 25% increase). This setting was most likely previously set with MSAA enabled, so it was set incorrectly.
+- Weapons:
+	- Fix a bug in bullet hit calculations within the initial bullet offset distance.
+	-Fix AP rounds not penetrating rear side of parts they penetrate.
+	-Beehive ammo deployment range now adjustable.
+	-Fix ExplosionFX spawnpoint for Shaped Charge bullets.
+	-Some fixes to nuke behavior in space.
+ - RWP
+	-Update NPC Swap code to work with current web API.
+	-Fix AIs chasing GM killed planes.
+	-Runway_Project toggle now sets all control surface actuation speeds to 30 deg/s.
+
+v1.5.6.2
 IMPROVEMENTS / FIXES
 - General:
 	- Fix kerbal flags exploding from overheat when placed.
@@ -6,7 +25,7 @@ IMPROVEMENTS / FIXES
 - UI:
 	- Fix IRSTs not responding to Radar Display hotkeys.
 	- Fix Radar Analysis Window Radar select UX.
-- AI/WM:
+- AI / WM:
 	- Add 'Random Part' subsystem targeting option.
 - Weapons:
 	- Nukes now work in space again.

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -3308,17 +3308,17 @@ namespace BDArmory.UI
                 {
                     if (BDArmorySettings.RUNWAY_PROJECT != (BDArmorySettings.RUNWAY_PROJECT = GUI.Toggle(SLeftRect(++line), BDArmorySettings.RUNWAY_PROJECT, StringUtils.Localize("#LOC_BDArmory_Settings_RunwayProject"))))//Runway Project
                     {
-                        if (HighLogic.LoadedSceneIsEditor && EditorLogic.fetch.ship is not null) GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship); if (oldSpaceHacks != BDArmorySettings.SPACE_HACKS)
-
+                        if (HighLogic.LoadedSceneIsFlight)
+                        {
                             SpawnUtils.HackActuatorsOnNewVessels(BDArmorySettings.RUNWAY_PROJECT);
-                            if (BDArmorySettings.RUNWAY_PROJECT) // Add the hack to all in-game intakes.
+
+                            foreach (var vessel in FlightGlobals.Vessels)
                             {
-                                foreach (var vessel in BDATargetManager.LoadedVessels)
-                                {
-                                    if (vessel == null || !vessel.loaded) continue;
-                                    SpawnUtils.HackActuators(vessel, true);
-                                }
+                                if (vessel == null || !vessel.loaded) continue;
+                                SpawnUtils.HackActuators(vessel, BDArmorySettings.RUNWAY_PROJECT);
                             }
+                        }
+                        if (HighLogic.LoadedSceneIsEditor && EditorLogic.fetch.ship is not null) GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
                     }
                     if (BDArmorySettings.RUNWAY_PROJECT)
                     {

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -3308,7 +3308,17 @@ namespace BDArmory.UI
                 {
                     if (BDArmorySettings.RUNWAY_PROJECT != (BDArmorySettings.RUNWAY_PROJECT = GUI.Toggle(SLeftRect(++line), BDArmorySettings.RUNWAY_PROJECT, StringUtils.Localize("#LOC_BDArmory_Settings_RunwayProject"))))//Runway Project
                     {
-                        if (HighLogic.LoadedSceneIsEditor && EditorLogic.fetch.ship is not null) GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
+                        if (HighLogic.LoadedSceneIsEditor && EditorLogic.fetch.ship is not null) GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship); if (oldSpaceHacks != BDArmorySettings.SPACE_HACKS)
+
+                            SpawnUtils.HackActuatorsOnNewVessels(BDArmorySettings.RUNWAY_PROJECT);
+                            if (BDArmorySettings.RUNWAY_PROJECT) // Add the hack to all in-game intakes.
+                            {
+                                foreach (var vessel in BDATargetManager.LoadedVessels)
+                                {
+                                    if (vessel == null || !vessel.loaded) continue;
+                                    SpawnUtils.HackActuators(vessel, true);
+                                }
+                            }
                     }
                     if (BDArmorySettings.RUNWAY_PROJECT)
                     {

--- a/BDArmory/Utils/VesselUtils.cs
+++ b/BDArmory/Utils/VesselUtils.cs
@@ -5,6 +5,7 @@ using KSP.UI.Screens;
 using BDArmory.Control;
 using BDArmory.Extensions;
 using BDArmory.FX;
+using BDArmory.Targeting;
 
 namespace BDArmory.Utils
 {
@@ -23,6 +24,12 @@ namespace BDArmory.Utils
             {
                 PartExploderSystem.AddPartToExplode(missileFire.part);
                 ExplosionFx.CreateExplosion(missileFire.part.transform.position, 1f, explModelPath, explSoundPath, ExplosionSourceType.Other, 0, missileFire.part);
+                TargetInfo tInfo;
+                v.vesselType = VesselType.Debris;
+                if (tInfo = v.gameObject.GetComponent<TargetInfo>())
+                {
+                    UI.BDATargetManager.RemoveTarget(tInfo); //prevent other craft from chasing GM killed craft (in case of maxAltitude or similar
+                }
             }
         }
 


### PR DESCRIPTION
-Fix AP rounds not penetrating rear side of parts they penetrate
-Beehive ammo deployment range now adjustable.
-Fix ExplosionFX spawnpoint for Shaped Charge bullets
-Update NPC Swap code to work with current API.
-Fix AIs chasing GM killed planes
-Runway_Project toggle now sets all control surface actuation speeds to 30 deg/s
-some fixes to nuke behavior in space