### PR TITLE
Radar fixes and other stuff

### DIFF
--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -1754,31 +1754,11 @@ namespace BDArmory.Control
 
                     if (weaponManager)
                     {
-                        if (weaponManager.rwr != null ? weaponManager.rwr.rwrEnabled : false) //use rwr to check missile threat direction
+                        if (weaponManager.incomingMissileVessel)
                         {
-                            Vector3 missileThreat = Vector3.zero;
-                            bool missileThreatDetected = false;
-                            float closestMissileThreat = float.MaxValue;
-                            for (int i = 0; i < weaponManager.rwr.pingsData.Length; i++)
-                            {
-                                TargetSignatureData threat = weaponManager.rwr.pingsData[i];
-                                if (threat.exists && threat.signalStrength == (float)RadarWarningReceiver.RWRThreatTypes.MissileLock)
-                                {
-                                    missileThreatDetected = true;
-                                    float dist = (weaponManager.rwr.pingWorldPositions[i] - vesselTransform.position).sqrMagnitude;
-                                    if (dist < closestMissileThreat)
-                                    {
-                                        closestMissileThreat = dist;
-                                        missileThreat = weaponManager.rwr.pingWorldPositions[i];
-                                    }
-                                }
-                            }
-                            if (missileThreatDetected)
-                            {
-                                threatRelativePosition = missileThreat - vesselTransform.position;
-                                if (extending)
-                                    StopExtending("missile threat"); // Don't keep trying to extend if under fire from missiles
-                            }
+                            threatRelativePosition = weaponManager.incomingThreatPosition - vesselTransform.position;
+                            if (extending)
+                                StopExtending("missile threat"); // Don't keep trying to extend if under fire from missiles
                         }
 
                         if (weaponManager.underFire)

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -11,7 +11,7 @@
 	- AI will no longer dive into missiles approaching from directly below.
 	- Reset the auto-tune PID values to the best ones when lowering the learning rate.
 - Detectors
-	- Fix radars with ability to lock targets with a signature of 0 not being able to lock targets with a signature of 0.
+	- Fix radars/IRSTs with ability to detect/lock targets with a signature of 0 not being able to detect/lock targets with a signature of 0.
 	- Fix a division by zero in the standoff jamming effect calculation when the radar signature is 0.
 - Weapons:
 	- Fix bug in nuke impulse calculation and some NREs.

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -12,14 +12,15 @@
 	- Fix NRE when adjusting autotuning fields in the SPH.
 	- AI will no longer dive into missiles approaching from directly below.
 	- Reset the auto-tune PID values to the best ones when lowering the learning rate.
-  - Add a keybind for arming/disarming the WM.
+	- Add a keybind for arming/disarming the WM.
 - Detectors
 	- Fix radars/IRSTs with ability to detect/lock targets with a signature of 0 not being able to detect/lock targets with a signature of 0.
 	- Fix a division by zero in the standoff jamming effect calculation when the radar signature is 0.
 - Weapons:
 	- Fix bug in nuke impulse calculation and some NREs.
 	- Add new engineFailureRate (default is 0, max is 1) config file variable for missiles. This is the probability the missile engine will fail to start. It is evaluated once on missile launch.
-	- Add new guidanceFailureRate (default is 0, max is 1) config file variable for missiles. This is the probability missile guidance will fail. It is evaluated every frame after launch.
+	- Add new guidanceFailureRate (default is 0, max is 1) config file variable for missiles. This is the probability per second the missile guidance will fail (0-1). It is evaluated every frame after launch.
+	- Add new fuseFailureRate (default is 0, max is 1) config file variable for BDExplosivePart modules. This is the probability the explosive fuse will fail. It is evaluated once when an explosive attempts to detonate.
 - RWP:
 	- Reset the killer GM between competitions and don't enable the killer GM for S5R3 (the altitude limit is still active).
 

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -6,6 +6,9 @@
 	- Fix max collision avoidance strength in AI GUI.
 	- Fix NRE when adjusting autotuning fields in the SPH.
 	- AI will no longer dive into missiles approaching from directly below.
+- Detectors
+	- Fix radars with ability to lock targets with a signature of 0 not being able to lock targets with a signature of 0.
+	- Fix a division by zero in the standoff jamming effect calculation when the radar signature is 0.
 - Weapons:
 	- Fix bug in nuke impulse calculation and some NREs.
 - RWP:

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -15,6 +15,8 @@
 	- Fix a division by zero in the standoff jamming effect calculation when the radar signature is 0.
 - Weapons:
 	- Fix bug in nuke impulse calculation and some NREs.
+	- Add new engineFailureRate (default is 0, max is 1) config file variable for missiles. This is the probability the missile engine will fail to start. It is evaluated once on missile launch.
+	- Add new guidanceFailureRate (default is 0, max is 1) config file variable for missiles. This is the probability missile guidance will fail. It is evaluated every frame after launch.
 - RWP:
 	- Reset the killer GM between competitions and don't enable the killer GM for S5R3 (the altitude limit is still active).
 

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/aim-120/amraam.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/aim-120/amraam.cfg
@@ -60,7 +60,7 @@ PART
 		decoupleSpeed = 5
 
 		engineFailureRate = 0    // Probability the missile engine will fail to start (0-1), evaluated once on missile launch
-		guidanceFailureRate = 0  // Probability the missile guidance will fail (0-1), evaluated every frame after launch
+		guidanceFailureRate = 0  // Probability the missile guidance will fail per second (0-1), evaluated every frame after launch
 
 		audioClipPath = BDArmory/Sounds/rocketLoop
 		exhaustPrefabPath = BDArmory/Models/exhaust/smallExhaust
@@ -104,5 +104,6 @@ PART
 		name = BDExplosivePart
 		tntMass = 25
 		warheadType = ContinuousRod
+		fuseFailureRate = 0	// How often the explosive fuse will fail to detonate (0-1), evaluated once on detonation trigger
 	}
 }

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/aim-120/amraam.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/aim-120/amraam.cfg
@@ -59,6 +59,9 @@ PART
 
 		decoupleSpeed = 5
 
+		engineFailureRate = 0    // Probability the missile engine will fail to start (0-1), evaluated once on missile launch
+		guidanceFailureRate = 0  // Probability the missile guidance will fail (0-1), evaluated every frame after launch
+
 		audioClipPath = BDArmory/Sounds/rocketLoop
 		exhaustPrefabPath = BDArmory/Models/exhaust/smallExhaust
 		boostExhaustPrefabPath = BDArmory/Models/exhaust/mediumExhaust

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/sidewinder/sidewinder.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/sidewinder/sidewinder.cfg
@@ -72,7 +72,7 @@ PART
         torqueRampUp = 50
 
         engineFailureRate = 0    // Probability the missile engine will fail to start (0-1), evaluated once on missile launch
-		guidanceFailureRate = 0  // Probability the missile guidance will fail (0-1), evaluated every frame after launch
+		guidanceFailureRate = 0  // Probability the missile guidance will fail per second (0-1), evaluated every frame after launch
 
         homingType = aam
         missileType = missile
@@ -144,5 +144,6 @@ PART
         name = BDExplosivePart
         tntMass = 15
         warheadType = ContinuousRod
+        fuseFailureRate = 0	// How often the explosive fuse will fail to detonate (0-1), evaluated once on detonation trigger
     }
 }

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/sidewinder/sidewinder.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/sidewinder/sidewinder.cfg
@@ -71,6 +71,9 @@ PART
         //aeroSteerDamping = 4.5
         torqueRampUp = 50
 
+        engineFailureRate = 0    // Probability the missile engine will fail to start (0-1), evaluated once on missile launch
+		guidanceFailureRate = 0  // Probability the missile guidance will fail (0-1), evaluated every frame after launch
+
         homingType = aam
         missileType = missile
         targetingType = heat

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/smallWarhead/part.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/smallWarhead/part.cfg
@@ -53,6 +53,7 @@ maxTemp = 3400
 	{
 		name = BDExplosivePart
 		tntMass = 150
+		fuseFailureRate = 0	// How often the explosive fuse will fail to detonate (0-1), evaluated once on detonation trigger
 	}
 
 }

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -799,6 +799,7 @@ namespace BDArmory.Radar
         public static float GetStandoffJammingModifier(Vessel v, Competition.BDTeam team, Vector3 position, Vessel targetV, float signature)
         {
             if (!VesselModuleRegistry.GetModule<MissileFire>(targetV)) return 1f; // Don't evaluate SOJ effects for targets without weapons managers
+            if (signature == 0) return 1f; // Don't evaluate SOJ effects for targets with 0 signature
 
             float standOffJammingMod = 0f;
             string debugSOJ = "Standoff Jammer Lockbreak Strengths: \n";
@@ -842,7 +843,7 @@ namespace BDArmory.Radar
 
             if ((BDArmorySettings.DEBUG_RADAR) && (modifiedSignature != signature)) Debug.Log("[BDArmory.RadarUtils]: Standoff Jamming: " + targetV.GetDisplayName() + " signature relative to " + v.GetDisplayName() + " modified from " + signature + " to " + modifiedSignature + "\n" + debugSOJ);
 
-            return modifiedSignature / (signature == 0f ? 1f : signature);
+            return modifiedSignature / signature;
         }
 
         /// <summary>

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -842,7 +842,7 @@ namespace BDArmory.Radar
 
             if ((BDArmorySettings.DEBUG_RADAR) && (modifiedSignature != signature)) Debug.Log("[BDArmory.RadarUtils]: Standoff Jamming: " + targetV.GetDisplayName() + " signature relative to " + v.GetDisplayName() + " modified from " + signature + " to " + modifiedSignature + "\n" + debugSOJ);
 
-            return modifiedSignature / signature;
+            return modifiedSignature / (signature == 0f ? 1f : signature);
         }
 
         /// <summary>
@@ -1068,11 +1068,12 @@ namespace BDArmory.Radar
                             {
                                 //evaluate if we can lock/track such a signature at that range
                                 float minLockSig = radar.radarLockTrackCurve.Evaluate(distance);
+                                
                                 signature *= ti.radarLockbreakFactor;    //multiply lockbreak factor from active ecm
                                                                          //do not multiply chaff factor here
                                 signature *= GetStandoffJammingModifier(radar.vessel, radar.weaponManager.Team, position, loadedvessels.Current, signature);
-
-                                if (signature > minLockSig && RadarCanDetect(radar, signature, distance)) // Must be able to detect and lock to lock targets
+                                
+                                if (signature >= minLockSig && RadarCanDetect(radar, signature, distance)) // Must be able to detect and lock to lock targets
                                 {
                                     // detected by radar
                                     if (myWpnManager != null)
@@ -1192,8 +1193,8 @@ namespace BDArmory.Radar
                 {
                     //evaluate if we can detect such a signature at that range
                     float minTrackSig = radar.radarLockTrackCurve.Evaluate(distance);
-
-                    if ((signature > minTrackSig) && (RadarCanDetect(radar, signature, distance)))
+                    
+                    if ((signature >= minTrackSig) && (RadarCanDetect(radar, signature, distance)))
                     {
                         // can be tracked
                         radar.ReceiveContactData(new TargetSignatureData(lockedVessel, signature), locked);
@@ -1311,8 +1312,8 @@ namespace BDArmory.Radar
                 float minDetectSig = radar.radarDetectionCurve.Evaluate(distance);
                 //do not consider lockbreak factor from active ecm here!
                 //do not consider chaff here
-
-                if (signature > minDetectSig)
+                
+                if (signature >= minDetectSig)
                 {
                     detected = true;
                 }

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -1281,7 +1281,7 @@ namespace BDArmory.Radar
                             //evaluate if we can detect or lock such a signature at that range
                             float minDetectSig = irst.DetectionCurve.Evaluate(distance / attenuationFactor);
 
-                            if (signature > minDetectSig)
+                            if (signature >= minDetectSig)
                             {
                                 // detected by irst
                                 if (myWpnManager != null)

--- a/BDArmory/Radar/VesselRadarData.cs
+++ b/BDArmory/Radar/VesselRadarData.cs
@@ -776,7 +776,7 @@ namespace BDArmory.Radar
                 radar.canLock
                 && (!radar.locked || radar.currentLocks < radar.maxLocks)
                 && RadarUtils.RadarCanDetect(radar, radarTarget.targetData.signalStrength, (radarTarget.targetData.predictedPosition - radar.transform.position).magnitude / 1000f)
-                && radarTarget.targetData.signalStrength > radar.radarLockTrackCurve.Evaluate((radarTarget.targetData.predictedPosition - radar.transform.position).magnitude / 1000f)
+                && radarTarget.targetData.signalStrength >= radar.radarLockTrackCurve.Evaluate((radarTarget.targetData.predictedPosition - radar.transform.position).magnitude / 1000f)
                 &&
                 (radar.omnidirectional ||
                  Vector3.Angle(radar.transform.up, radarTarget.targetData.predictedPosition - radar.transform.position) <

--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -92,7 +92,9 @@ namespace BDArmory.Weapons.Missiles
         public float engineFailureRate = 0f;                              // How often the missile engine will fail to start (0-1), evaluated once on missile launch
 
         [KSPField]
-        public float guidanceFailureRate = 0f;                              // How often the missile guidance will fail (0-1), evaluated every frame after launch
+        public float guidanceFailureRate = 0f;                              // Probability the missile guidance will fail per second (0-1), evaluated every frame after launch
+
+        public float guidanceFailureRatePerFrame = 0f;                      // guidanceFailureRate (per second) converted to per frame probability
 
         [KSPField]
         public bool guidanceActive = true;
@@ -262,6 +264,8 @@ namespace BDArmory.Weapons.Missiles
         public Vessel SourceVessel { get; set; } = null;
 
         public bool HasExploded { get; set; } = false;
+
+        public bool FuseFailed { get; set; } = false;
 
         public bool HasDied { get; set; } = false;
 

--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -89,6 +89,12 @@ namespace BDArmory.Weapons.Missiles
         }
 
         [KSPField]
+        public float engineFailureRate = 0f;                              // How often the missile engine will fail to start (0-1), evaluated once on missile launch
+
+        [KSPField]
+        public float guidanceFailureRate = 0f;                              // How often the missile guidance will fail (0-1), evaluated every frame after launch
+
+        [KSPField]
         public bool guidanceActive = true;
 
         [KSPField]

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -1094,7 +1094,6 @@ namespace BDArmory.Weapons.Missiles
 
                 StartCoroutine(MissileRoutine());
                 if (BDArmorySettings.DEBUG_MISSILES) Debug.Log("[BDArmory.MissileLauncher]: Missile Launched!");
-
             }
             catch (Exception e)
             {
@@ -1350,6 +1349,14 @@ namespace BDArmory.Weapons.Missiles
         string debugGuidanceTarget;
         void UpdateGuidance()
         {
+            if (guidanceActive && guidanceFailureRate > 0f)
+                if (UnityEngine.Random.Range(0f, 1f) < guidanceFailureRate)
+                {
+                    guidanceActive = false;
+                    BDATargetManager.FiredMissiles.Remove(this);
+                    if (BDArmorySettings.DEBUG_MISSILES) Debug.Log("[BDArmory.MissileLauncher]: Missile Guidance Failed!");
+                }     
+
             if (guidanceActive)
             {
                 switch (TargetingMode)
@@ -1678,6 +1685,15 @@ namespace BDArmory.Weapons.Missiles
         IEnumerator MissileRoutine()
         {
             MissileState = MissileStates.Drop;
+            if (engineFailureRate > 0f)
+                if (UnityEngine.Random.Range(0f, 1f) < engineFailureRate)
+                {
+                    if (BDArmorySettings.DEBUG_MISSILES) Debug.Log("[BDArmory.MissileLauncher]: Missile Engine Failed on Launch!");
+                    yield return new WaitForSecondsFixed(2f); // Pilot reaction time
+                    BDATargetManager.FiredMissiles.Remove(this);
+                    yield break;
+                }
+
             StartCoroutine(DeployAnimRoutine());
             yield return new WaitForSecondsFixed(dropTime);
             yield return StartCoroutine(BoostRoutine());

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -1351,8 +1351,8 @@ namespace BDArmory.Weapons.Missiles
         string debugGuidanceTarget;
         void UpdateGuidance()
         {
-            if (guidanceActive && guidanceFailureRate > 0f)
-                if (UnityEngine.Random.Range(0f, 1f) < guidanceFailureRate)
+            if (guidanceActive && guidanceFailureRatePerFrame > 0f)
+                if (UnityEngine.Random.Range(0f, 1f) < guidanceFailureRatePerFrame)
                 {
                     guidanceActive = false;
                     BDATargetManager.FiredMissiles.Remove(this);

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -646,6 +646,7 @@ namespace BDArmory.Weapons.Missiles
             InitializeEngagementRange(minStaticLaunchRange, maxStaticLaunchRange);
             SetInitialDetonationDistance();
             uncagedLock = (allAspect) ? allAspect : uncagedLock;
+            guidanceFailureRatePerFrame = (guidanceFailureRate >= 1) ? 1f : 1f - Mathf.Exp(Mathf.Log(1f - guidanceFailureRate) * Time.fixedDeltaTime); // Convert from per-second failure rate to per-frame failure rate
             if (multiLauncher != null)
             {
                 if (multiLauncher.isClusterMissile)
@@ -1338,6 +1339,7 @@ namespace BDArmory.Weapons.Missiles
 
                     var distThreshold = 0.5f * GetBlastRadius();
                     if (sqrDist < distThreshold * distThreshold) part.Destroy();
+                    if (FuseFailed) part.Destroy();
 
                     isTimed = true;
                     detonationTime = TimeIndex + 1.5f;
@@ -2244,7 +2246,7 @@ namespace BDArmory.Weapons.Missiles
 
         public override void Detonate()
         {
-            if (HasExploded || !HasFired) return;
+            if (HasExploded || FuseFailed || !HasFired) return;
 
             if (BDArmorySettings.DEBUG_MISSILES) Debug.Log("[BDArmory.MissileLauncher]: Detonate Triggered");
 
@@ -2286,6 +2288,10 @@ namespace BDArmory.Weapons.Missiles
                     var tnt = part.FindModuleImplementing<BDExplosivePart>();
                     tnt.sourcevessel = SourceVessel;
                     tnt.DetonateIfPossible();
+                    FuseFailed = tnt.fuseFailed;
+                    guidanceActive = false;
+                    if (FuseFailed)
+                        HasExploded = false;
                 }
                 else if (warheadType == WarheadTypes.Nuke)
                 {
@@ -2298,7 +2304,7 @@ namespace BDArmory.Weapons.Missiles
 
                     ExplosionFx.CreateExplosion(position, blastPower, explModelPath, explSoundPath, ExplosionSourceType.Missile, 0, part, SourceVessel.vesselName, GetShortName(), default(Vector3), -1, false, part.mass * 1000);
                 }
-                if (part != null)
+                if (part != null && !FuseFailed)
                 {
                     DestroyMissile(); //splitting this off to a separate function so the clustermissile MultimissileLaunch can call it when the MML launch ienumerator is done
                 }


### PR DESCRIPTION
- Fix radars/IRSTs with ability to lock targets with a signature of 0 not being able to lock targets with a signature of 0.
- Fix a division by zero in the standoff jamming effect calculation when the radar signature is 0.
- Add option to set missile failure rates for engine and guidance in the missile config file.
- Add option to set fuse failure rate for BDExplosivePart modules.
- Depreciate old code in Pilot AI with RWR dependency.