### PR TITLE
Updates

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -5,6 +5,9 @@
 	- Remove HP rounding and lower HP limit for MM-patched parts. Apply health modifier after applying rounding and lower HP limit for non-MM-patched parts.
 - UI:
 	- Add a keybind for targeting the next GPS target.
+	- Parts with zero lift now appear as grey in the lift visualizer.
+- AI / WM:
+	- AI will start evading missiles once the missile engine activates instead of waiting for 1 second after launch.
 
 v1.5.8.0
 IMPROVEMENTS / FIXES

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -1479,7 +1479,7 @@ namespace BDArmory.Radar
                 var missileBlastRadiusSqr = 3f * missile.GetBlastRadius();
                 missileBlastRadiusSqr *= missileBlastRadiusSqr;
 
-                return (missile.HasFired && missile.TimeIndex > missile.dropTime && approaching &&
+                return (missile.HasFired && missile.MissileState > MissileBase.MissileStates.Drop && approaching &&
                             (
                                 (missile.TargetPosition - (mf.vessel.CoM + (mf.vessel.Velocity() * Time.fixedDeltaTime))).sqrMagnitude < missileBlastRadiusSqr || // Target position is within blast radius of missile.
                                 mf.vessel.PredictClosestApproachSqrSeparation(missile.vessel, mf.cmThreshold) < missileBlastRadiusSqr || // Closest approach is within blast radius of missile. 

--- a/BDArmory/UI/BDAEditorArmorWindow.cs
+++ b/BDArmory/UI/BDAEditorArmorWindow.cs
@@ -775,10 +775,10 @@ namespace BDArmory.UI
                             if (LiftVisualizer)
                             {
                                 ModuleLiftingSurface wing = parts.Current.GetComponent<ModuleLiftingSurface>();
-                                if (wing != null)
+                                if (wing != null && wing.deflectionLiftCoeff > 0f)
                                     VisualizerColor = Color.HSVToRGB(Mathf.Clamp01(Mathf.Log10(wing.deflectionLiftCoeff + 1f)) / 3, 1, 1);
                                 else
-                                    VisualizerColor = Color.HSVToRGB(0, 1, 1);
+                                    VisualizerColor = Color.HSVToRGB(0, 0, 0.5f);
                             }
                             var r = parts.Current.GetComponentsInChildren<Renderer>();
                             {


### PR DESCRIPTION
- Parts with zero lift now appear as grey in the lift visualizer.
- Update changelog.
- Use MissileState instead of TimeIndex for checking that missile engine has activated.