### PR TITLE
Lift stacking calc update

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -7,6 +7,7 @@
 	- Add a keybind for targeting the next GPS target.
 	- Add labels to the vessel switcher score entries for rockets, missiles, rams and tag.
 	- Parts with zero lift now appear as grey in the lift visualizer.
+	- Fix issues with wing stacking calculation. Calculation now returns ratio of vertically stacked lift area to total lift area (capped at 100%), regardless of distance between wings (biplanes/triplanes will have a non-zero stack value).
 - AI / WM:
 	- AI will start evading missiles once the missile engine activates instead of waiting for 1 second after launch.
 

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -7,7 +7,7 @@
 	- Add a keybind for targeting the next GPS target.
 	- Add labels to the vessel switcher score entries for rockets, missiles, rams and tag.
 	- Parts with zero lift now appear as grey in the lift visualizer.
-	- Fix issues with wing stacking calculation. Calculation now returns ratio of vertically stacked lift area to total lift area (capped at 100%), regardless of distance between wings (biplanes/triplanes will have a non-zero stack value).
+	- Fix issues with wing stacking calculation. Calculation now returns ratio of non-separated vertically stacked lift area to total lift area (capped at 100%). Wings spaced sufficiently apart will not contribute to the stacking value.
 - AI / WM:
 	- AI will start evading missiles once the missile engine activates instead of waiting for 1 second after launch.
 

--- a/BDArmory/UI/BDAEditorArmorWindow.cs
+++ b/BDArmory/UI/BDAEditorArmorWindow.cs
@@ -682,7 +682,6 @@ namespace BDArmory.UI
                                     float v_dist = Vector3.Distance(Vector3.Project(col1Pos, Vector3.up),Vector3.Project(col2Pos, Vector3.up));
                                     float l_spacing = Mathf.Round(Mathf.Max(lift1area, lift2area, 0.25f)*100f)/100f; // Round lift to nearest 0.01
                                     float v_factor = Mathf.Pow(Mathf.Clamp01((BDAMath.Sqrt(2 * l_spacing) - v_dist) / (BDAMath.Sqrt(2 * l_spacing) - BDAMath.Sqrt(l_spacing))), 0.1f);
-                                    Debug.Log("[BDSPACE]: dist: " + v_dist + ", v_factor: " + v_factor + ", l_spacing: " + l_spacing);
 
                                     // Add overlapping area
                                     liftStackedAll += a * v_factor;


### PR DESCRIPTION
- Fix issues with wing stacking calculation. Calculation now returns ratio of non-separated vertically stacked lift area to total lift area (capped at 100%). Wings spaced sufficiently apart (sqrt(2*lift)) will not contribute to the stacking value.