### PR TITLE
Fixes and improvements

### DIFF
--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -1658,8 +1658,8 @@ namespace BDArmory.Bullets
                 if (ProjectileUtils.isReportingWeapon(sourceWeapon) && BDACompetitionMode.Instance.competitionIsActive)
                 {
                     string msg = $"{partsHit[0].vessel.GetName()} was nailed by {sourceVesselName}'s {sourceWeapon.partInfo.title} at {initialHitDistance:F3}, damaging {partsHit.Count} parts.";
-                    string message = $"{partsHit[0].vessel.GetName()} was nailed by {sourceVesselName}'s {bullet.DisplayName} at {initialHitDistance:F3}, damaging {partsHit.Count} parts.";
-                    BDACompetitionMode.Instance.competitionStatus.Add(message);
+                    //string message = $"{partsHit[0].vessel.GetName()} was nailed by {sourceVesselName}'s {bullet.DisplayName} at {initialHitDistance:F3}, damaging {partsHit.Count} parts.";
+                    BDACompetitionMode.Instance.competitionStatus.Add(msg);
                 }
             }
             gameObject.SetActive(false);

--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -896,7 +896,7 @@ namespace BDArmory.Bullets
             {
                 distanceTraveled += hit.distance;
                 if (!BDArmorySettings.PAINTBALL_MODE)
-                { hitPart.rb.AddForceAtPosition(impactVelocity.normalized * impulse, hit.point, ForceMode.Acceleration); }
+                { hitPart.rb.AddForceAtPosition(impactVelocity.normalized * impulse, hit.point, ForceMode.Impulse); }
                 ProjectileUtils.ApplyScore(hitPart, sourceVessel.GetName(), distanceTraveled, 0, bullet.DisplayName, ExplosionSourceType.Bullet, true);
                 if (BDArmorySettings.BULLET_HITS)
                 {

--- a/BDArmory/Ammo/PooledRocket.cs
+++ b/BDArmory/Ammo/PooledRocket.cs
@@ -848,7 +848,7 @@ namespace BDArmory.Bullets
                             if (nuclear)
                                 NukeFX.CreateExplosion(currPosition, ExplosionSourceType.Rocket, sourceVesselName, rocket.DisplayName, 0, tntMass * 200, tntMass, tntMass, EMP, blastSoundPath, flashModelPath, shockModelPath, blastModelPath, plumeModelPath, debrisModelPath, "", "");
                             else
-                                ExplosionFx.CreateExplosion(pos, tntMass, explModelPath, explSoundPath, ExplosionSourceType.Rocket, caliber, null, sourceVesselName, null, direction, -1, false, rocketMass * 1000, -1, dmgMult, shaped ? "shapedcharge" : "standard", PenetratingHit,apMod);
+                                ExplosionFx.CreateExplosion(pos, tntMass, explModelPath, explSoundPath, ExplosionSourceType.Rocket, caliber, null, sourceVesselName, null, direction, -1, false, rocketMass * 1000, -1, dmgMult, shaped ? "shapedcharge" : "standard", PenetratingHit,apMod, ProjectileUtils.isReportingWeapon(sourceWeapon) ? (float)distanceFromStart : -1);
                         }
                     }
                 }

--- a/BDArmory/Armor/BDAdjustableArmor.cs
+++ b/BDArmory/Armor/BDAdjustableArmor.cs
@@ -62,7 +62,7 @@ namespace BDArmory.Armor
             }
         }
 
-        [KSPEvent(guiActive = false, guiActiveEditor = true, guiName = "#LOC_BDArmory_UnclampTuning_disabledText", active = true)]//Toggle scale limit
+        [KSPEvent(active = true, guiActive = false, guiActiveEditor = true, guiName = "#LOC_BDArmory_UnclampTuning_disabledText")]//Toggle scale limit
         public void ToggleScaleClamp() => ToggleScaleClampHandler();
         public void ToggleScaleClampHandler(bool applySym = true)
         {

--- a/BDArmory/Competition/BDACompetitionMode.cs
+++ b/BDArmory/Competition/BDACompetitionMode.cs
@@ -1123,7 +1123,6 @@ namespace BDArmory.Competition
                             "0:TimeScale:2", // t=0, scale time for faster falling
                             "0:ToggleGuard:0", // t=0, Disable guard mode (for those who triggered it early)
                             "0:TogglePilot:0", // t=0, Disable pilots (for those who triggered it early)
-                            "0:SetTimeAccel:3", //t=0 set Time Accel to speed up descent
                             "30:HackGravity:1", //t=30, Reset gravity
                             "0:TimeScale:1", // t=0, reset time scaling
                             "0:SetThrottle:100", // t=30, Full throttle

--- a/BDArmory/Competition/BDACompetitionMode.cs
+++ b/BDArmory/Competition/BDACompetitionMode.cs
@@ -1832,7 +1832,7 @@ namespace BDArmory.Competition
                 var limit = (BDArmorySettings.COMPETITION_ALTITUDE_LIMIT_HIGH < 20f ? BDArmorySettings.COMPETITION_ALTITUDE_LIMIT_HIGH / 10f : BDArmorySettings.COMPETITION_ALTITUDE_LIMIT_HIGH < 39f ? BDArmorySettings.COMPETITION_ALTITUDE_LIMIT_HIGH - 18f : (BDArmorySettings.COMPETITION_ALTITUDE_LIMIT_HIGH - 38f) * 5f + 20f) * 1000f;
                 foreach (var weaponManager in LoadedVesselSwitcher.Instance.WeaponManagers.SelectMany(tm => tm.Value).ToList())
                 {
-                    if (alive.Contains(weaponManager.vessel.vesselName) && weaponManager.vessel.radarAltitude > limit)
+                    if (alive.Contains(weaponManager.vessel.vesselName) && BDArmorySettings.COMPETITION_ALTITUDE__LIMIT_ASL ? weaponManager.vessel.altitude > limit : weaponManager.vessel.radarAltitude > limit)
                     {
                         var killerName = Scores.ScoreData[weaponManager.vessel.vesselName].lastPersonWhoDamagedMe;
                         if (killerName == "")
@@ -1866,7 +1866,7 @@ namespace BDArmory.Competition
                 }
                 foreach (var weaponManager in LoadedVesselSwitcher.Instance.WeaponManagers.SelectMany(tm => tm.Value).ToList())
                 {
-                    if (alive.Contains(weaponManager.vessel.vesselName) && weaponManager.vessel.radarAltitude < limit)
+                    if (alive.Contains(weaponManager.vessel.vesselName) && BDArmorySettings.COMPETITION_ALTITUDE__LIMIT_ASL ? weaponManager.vessel.altitude > limit : weaponManager.vessel.radarAltitude > limit)
                     {
                         var killerName = Scores.ScoreData[weaponManager.vessel.vesselName].lastPersonWhoDamagedMe;
                         if (killerName == "")

--- a/BDArmory/Competition/BDACompetitionMode.cs
+++ b/BDArmory/Competition/BDACompetitionMode.cs
@@ -1825,7 +1825,7 @@ namespace BDArmory.Competition
             ResetSpeeds();
         }
 
-        private void CheckAltitudeLimits()
+        private void CheckAltitudeLimits() //have ths start a timer if alt exceeded, instead of immediately kill? Timing/kill elements would need to be moved to MissileFire, but doable.
         {
             if (BDArmorySettings.COMPETITION_ALTITUDE_LIMIT_HIGH < 55f) // Kill off those flying too high.
             {
@@ -1834,6 +1834,11 @@ namespace BDArmory.Competition
                 {
                     if (alive.Contains(weaponManager.vessel.vesselName) && BDArmorySettings.COMPETITION_ALTITUDE__LIMIT_ASL ? weaponManager.vessel.altitude > limit : weaponManager.vessel.radarAltitude > limit)
                     {
+                        if (Scores.ScoreData[weaponManager.vessel.vesselName].AltitudeKillTimer == 0)
+                        {
+                            Scores.ScoreData[weaponManager.vessel.vesselName].AltitudeKillTimer = Planetarium.GetUniversalTime(); ;
+                        }
+                        /*
                         var killerName = Scores.ScoreData[weaponManager.vessel.vesselName].lastPersonWhoDamagedMe;
                         if (killerName == "")
                         {
@@ -1845,6 +1850,18 @@ namespace BDArmory.Competition
                         if (BDArmorySettings.DEBUG_COMPETITION) Debug.Log("[BDArmory.BDACompetitionMode:" + CompetitionID.ToString() + "]: " + weaponManager.vessel.vesselName + ":REMOVED:" + killerName);
                         if (KillTimer.ContainsKey(weaponManager.vessel.vesselName)) KillTimer.Remove(weaponManager.vessel.vesselName);
                         VesselUtils.ForceDeadVessel(weaponManager.vessel);
+                        */
+                    }
+                    else
+                    {
+                        if (Scores.ScoreData[weaponManager.vessel.vesselName].AltitudeKillTimer != 0)
+                        {
+                            // safely below ceiling for 15 seconds
+                            if (Planetarium.GetUniversalTime() - Scores.ScoreData[weaponManager.vessel.vesselName].AltitudeKillTimer > 0)
+                            {
+                                Scores.ScoreData[weaponManager.vessel.vesselName].AltitudeKillTimer = 0;
+                            }
+                        }
                     }
                 }
             }
@@ -1868,6 +1885,11 @@ namespace BDArmory.Competition
                 {
                     if (alive.Contains(weaponManager.vessel.vesselName) && BDArmorySettings.COMPETITION_ALTITUDE__LIMIT_ASL ? weaponManager.vessel.altitude < limit : weaponManager.vessel.radarAltitude < limit)
                     {
+                        if (Scores.ScoreData[weaponManager.vessel.vesselName].AltitudeKillTimer == 0)
+                        {
+                            Scores.ScoreData[weaponManager.vessel.vesselName].AltitudeKillTimer = Planetarium.GetUniversalTime(); ;
+                        }
+                        /*
                         var killerName = Scores.ScoreData[weaponManager.vessel.vesselName].lastPersonWhoDamagedMe;
                         if (killerName == "")
                         {
@@ -1879,6 +1901,19 @@ namespace BDArmory.Competition
                         if (BDArmorySettings.DEBUG_COMPETITION) Debug.Log("[BDArmory.BDACompetitionMode:" + CompetitionID.ToString() + "]: " + weaponManager.vessel.vesselName + ":REMOVED:" + killerName);
                         if (KillTimer.ContainsKey(weaponManager.vessel.vesselName)) KillTimer.Remove(weaponManager.vessel.vesselName);
                         VesselUtils.ForceDeadVessel(weaponManager.vessel);
+                        */
+                    }
+                    else
+                    {
+
+                        if (Scores.ScoreData[weaponManager.vessel.vesselName].AltitudeKillTimer != 0)
+                        {
+                            // safely below ceiling for 15 seconds
+                            if (Planetarium.GetUniversalTime() - Scores.ScoreData[weaponManager.vessel.vesselName].AltitudeKillTimer > 0)
+                            {
+                                Scores.ScoreData[weaponManager.vessel.vesselName].AltitudeKillTimer = 0;
+                            }
+                        }
                     }
                 }
             }
@@ -2305,6 +2340,24 @@ namespace BDArmory.Competition
                                 {
                                     vesselsToKill.Add(mf.vessel);
                                 }
+                            }
+                        }
+                        if (vData.AltitudeKillTimer > 0 && BDArmorySettings.COMPETITION_KILL_TIMER > 0)
+                        {
+                            KillTimer[vesselName] = (int)(now - vData.AltitudeKillTimer);
+                            if (now - vData.AltitudeKillTimer > BDArmorySettings.COMPETITION_KILL_TIMER)
+                            {
+                                var killerName = Scores.ScoreData[vesselName].lastPersonWhoDamagedMe;
+                                if (killerName == "")
+                                {
+                                    killerName = "Restricted Altitude!";
+                                    Scores.ScoreData[vesselName].lastPersonWhoDamagedMe = killerName;
+                                }
+                                Scores.RegisterDeath(vesselName, GMKillReason.GM);
+                                competitionStatus.Add(vesselName + " no fly zone!");
+                                if (BDArmorySettings.DEBUG_COMPETITION) Debug.Log("[BDArmory.BDACompetitionMode:" + CompetitionID.ToString() + "]: " + vesselName + ":REMOVED:" + killerName);
+                                if (KillTimer.ContainsKey(vesselName)) KillTimer.Remove(vesselName);
+                                VesselUtils.ForceDeadVessel(vessel);
                             }
                         }
                         else if (KillTimer.ContainsKey(vesselName))

--- a/BDArmory/Competition/BDACompetitionMode.cs
+++ b/BDArmory/Competition/BDACompetitionMode.cs
@@ -1866,7 +1866,7 @@ namespace BDArmory.Competition
                 }
                 foreach (var weaponManager in LoadedVesselSwitcher.Instance.WeaponManagers.SelectMany(tm => tm.Value).ToList())
                 {
-                    if (alive.Contains(weaponManager.vessel.vesselName) && BDArmorySettings.COMPETITION_ALTITUDE__LIMIT_ASL ? weaponManager.vessel.altitude > limit : weaponManager.vessel.radarAltitude > limit)
+                    if (alive.Contains(weaponManager.vessel.vesselName) && BDArmorySettings.COMPETITION_ALTITUDE__LIMIT_ASL ? weaponManager.vessel.altitude < limit : weaponManager.vessel.radarAltitude < limit)
                     {
                         var killerName = Scores.ScoreData[weaponManager.vessel.vesselName].lastPersonWhoDamagedMe;
                         if (killerName == "")

--- a/BDArmory/Competition/BDATournament.cs
+++ b/BDArmory/Competition/BDATournament.cs
@@ -985,9 +985,9 @@ namespace BDArmory.Competition
         {
             if (TournamentCoordinator.Instance.IsRunning) TournamentCoordinator.Instance.Stop();
             var spawnConfig = tournamentState.rounds[roundIndex][heatIndex];
-            spawnConfig.worldIndex = 1;
-            spawnConfig.latitude = 27.97f;
-            spawnConfig.longitude = -39.35f;
+            spawnConfig.worldIndex = WaypointCourses.CourseLocations[BDArmorySettings.WAYPOINT_COURSE_INDEX].worldIndex;
+            spawnConfig.latitude = WaypointCourses.CourseLocations[BDArmorySettings.WAYPOINT_COURSE_INDEX].spawnPoint.x;
+            spawnConfig.longitude = WaypointCourses.CourseLocations[BDArmorySettings.WAYPOINT_COURSE_INDEX].spawnPoint.y;
 
             TournamentCoordinator.Instance.Configure(new SpawnConfigStrategy(spawnConfig),
                 new WaypointFollowingStrategy(WaypointCourses.CourseLocations[BDArmorySettings.WAYPOINT_COURSE_INDEX].waypoints),

--- a/BDArmory/Competition/OrchestrationStrategies/WaypointFollowingStrategy.cs
+++ b/BDArmory/Competition/OrchestrationStrategies/WaypointFollowingStrategy.cs
@@ -145,7 +145,7 @@ namespace BDArmory.Competition.OrchestrationStrategies
 
                     previousLocation = WorldCoords;
                     var location = string.Format("({0:##.###}, {1:##.###}, {2:####}", waypoints[i].location.x, waypoints[i].location.y, waypoints[i].location.z);
-                    Debug.Log("[BDArmory.Waypoints]: Creating waypoint marker at  " + " " + location + " scale: " + waypoints[i].scale);
+                    Debug.Log("[BDArmory.Waypoints]: Creating waypoint marker at  " + " " + location + " World: " + FlightGlobals.currentMainBody.flightGlobalsIndex + " scale: " + (BDArmorySettings.WAYPOINTS_SCALE > 0 ? BDArmorySettings.WAYPOINTS_SCALE : waypoints[i].scale));
                 }
             }
 

--- a/BDArmory/Competition/RemoteOrchestration/BDAScoreClient.cs
+++ b/BDArmory/Competition/RemoteOrchestration/BDAScoreClient.cs
@@ -483,9 +483,8 @@ namespace BDArmory.Competition.RemoteOrchestration
                 .Where(e => !e.Contains("VESSELNAMING"))
                 .ToArray();
             pattern = ".*version = (.+)";
-            modifiedLines = lines
+            modifiedLines = modifiedLines
                 .Select(e => Regex.Replace(e, pattern, "version = 1.12.2"))
-                .Where(e => !e.Contains("VESSELNAMING"))
                 .ToArray();
             File.WriteAllLines(filename, modifiedLines);
             Debug.Log(string.Format("[BDArmory.BDAScoreClient] Saved craft for player {0}", vesselName));
@@ -497,12 +496,18 @@ namespace BDArmory.Competition.RemoteOrchestration
 
         public void SwapCraftFiles()
         {
+
             DirectoryInfo info = new DirectoryInfo(vesselStagingPath);
             FileInfo[] craftFiles = info.GetFiles("*.craft");
-                //.Where(e => e.Extension == ".craft").ToArray();
+            //.Where(e => e.Extension == ".craft").ToArray();
+            if (!Directory.Exists(NPCPath))
+            {
+                Debug.Log("[BDArmory.BDAScoreClient] Creating staging directory " + NPCPath);
+                Directory.CreateDirectory(NPCPath);
+            }
             DirectoryInfo NPCinfo = new DirectoryInfo(NPCPath);
             FileInfo[] NPCFiles = NPCinfo.GetFiles("*.craft");
-               // .Where(e => e.Extension == ".craft").ToArray();
+
             foreach (FileInfo file in craftFiles)
             {
                 if (file.Name.Contains(BDArmorySettings.REMOTE_ORCHESTRATION_NPC_SWAPPER))

--- a/BDArmory/Competition/Scoring.cs
+++ b/BDArmory/Competition/Scoring.cs
@@ -894,6 +894,7 @@ namespace BDArmory.Competition
         public bool landedState; // Whether the vessel is landed or not.
         public double lastLandedTime; // Time that this vessel was landed last.
         public double landedKillTimer; // Counter tracking time this vessel is landed (for the kill timer).
+        public double AltitudeKillTimer; //counter tracing time this vessel is outside GM altitude restrictions (for kill timer).
         public double AverageSpeed; // Average speed of this vessel recently (for the killer GM).
         public double AverageAltitude; // Average altitude of this vessel recently (for the killer GM).
         public int averageCount; // Count for the averaging stats.

--- a/BDArmory/Control/BDGenericAIBase.cs
+++ b/BDArmory/Control/BDGenericAIBase.cs
@@ -577,7 +577,7 @@ namespace BDArmory.Control
             }
         }
         #endregion
-
+        /* Unnecessary. Use CheatOptions.infinitePropellant = bool instead.
         /// <summary>
         /// Prevent fuel drain (control function).
         /// </summary>
@@ -588,26 +588,27 @@ namespace BDArmory.Control
             if (active) maintainingFuelLevelsCoroutine = StartCoroutine(MaintainFuelLevelsCoroutine());
         }
 
-        /// <summary>
-        /// Prevent fuel drain (coroutine).
-        /// </summary>
-        /// <returns></returns>
-        IEnumerator MaintainFuelLevelsCoroutine()
-        {
-            if (vessel == null) yield break;
-            var wait = new WaitForFixedUpdate();
-            var fuelResourceParts = new Dictionary<string, HashSet<PartResource>>();
-            ResourceUtils.DeepFind(vessel.rootPart, ResourceUtils.FuelResources, fuelResourceParts, true);
-            var fuelResources = fuelResourceParts.ToDictionary(t => t.Key, t => t.Value.ToDictionary(p => p, p => p.amount));
-            while (vessel != null)
-            {
-                foreach (var fuelResource in fuelResources.Values)
-                {
-                    foreach (var partResource in fuelResource.Keys)
-                    { partResource.amount = fuelResource[partResource]; }
-                }
-                yield return wait;
-            }
-        }
+		/// <summary>
+		/// Prevent fuel drain (coroutine).
+		/// </summary>
+		/// <returns></returns>
+		IEnumerator MaintainFuelLevelsCoroutine()
+		{
+			if (vessel == null) yield break;
+			var wait = new WaitForFixedUpdate();
+			var fuelResourceParts = new Dictionary<string, HashSet<PartResource>>();
+			ResourceUtils.DeepFind(vessel.rootPart, ResourceUtils.FuelResources, fuelResourceParts, true);
+			var fuelResources = fuelResourceParts.ToDictionary(t => t.Key, t => t.Value.ToDictionary(p => p, p => p.amount));
+			while (vessel != null)
+			{
+				foreach (var fuelResource in fuelResources.Values)
+				{
+					foreach (var partResource in fuelResource.Keys)
+					{ partResource.amount = fuelResource[partResource]; }
+				}
+				yield return wait;
+			}
+		}
+        */
     }
 }

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -3637,7 +3637,7 @@ namespace BDArmory.Control
                 targetPosition += upDirection * Math.Min(distance, 1000) * vertFactor * Mathf.Clamp01(0.7f - Math.Abs(Vector3.Dot(projectedTargetDirection, projectedDirection)));
                 if (maxAltitudeEnabled)
                 {
-                    var targetRadarAlt = BodyUtils.GetRadarAltitudeAtPos(targetPosition);
+					var targetRadarAlt = BDArmorySettings.COMPETITION_ALTITUDE__LIMIT_ASL ? FlightGlobals.getAltitudeAtPos(targetPosition) : BodyUtils.GetRadarAltitudeAtPos(targetPosition);
                     if (targetRadarAlt > maxAltitude)
                     {
                         targetPosition -= (targetRadarAlt - maxAltitude) * upDirection;

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -1377,7 +1377,7 @@ namespace BDArmory.Control
 
             SetAutoTuneFields();
             //MaintainFuelLevels(autoTune); // Prevent fuel drain while auto-tuning.
-            CheatOptions.InfinitePropellant = autoTune;
+            CheatOptions.InfinitePropellant = !BDArmorySettings.INFINITE_FUEL ? autoTune : true;
             OtherUtils.SetTimeOverride(autoTune);
         }
         void SetAutoTuneFields()

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -1376,7 +1376,8 @@ namespace BDArmory.Control
             pidAutoTuning.ResetMeasurements();
 
             SetAutoTuneFields();
-            MaintainFuelLevels(autoTune); // Prevent fuel drain while auto-tuning.
+            //MaintainFuelLevels(autoTune); // Prevent fuel drain while auto-tuning.
+            CheatOptions.InfinitePropellant = autoTune;
             OtherUtils.SetTimeOverride(autoTune);
         }
         void SetAutoTuneFields()

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -989,6 +989,8 @@ namespace BDArmory.Control
                             var gun = weapon.Current.GetPart().FindModuleImplementing<ModuleWeapon>();
                             sw = weapon.Current; //check against salvofiring turrets - if all guns overheat at the same time, turrets get stuck in standby mode
                             if (gun.isReloading || gun.isOverheated || gun.pointingAtSelf || !(gun.ammoCount > 0 || BDArmorySettings.INFINITE_AMMO)) continue; //instead of returning the first weapon in a weapon group, return the first weapon in a group that actually can fire
+                            //no check for if all weapons in the group are reloading/overheated...
+                            //Doc also was floating the idea of a 'use this gun' button for aiming, though that would be more a PilotAi thing...
                         }
                         if (weapon.Current.GetWeaponClass() == WeaponClasses.Missile || weapon.Current.GetWeaponClass() == WeaponClasses.Bomb || weapon.Current.GetWeaponClass() == WeaponClasses.SLW)
                         {
@@ -5732,7 +5734,7 @@ namespace BDArmory.Control
                 float scanRadius = CurrentMissile.lockedSensorFOV * 0.5f;
                 float maxOffBoresight = CurrentMissile.maxOffBoresight * 0.85f;
 
-                if (vesselRadarData)
+                if (vesselRadarData) // && !CurrentMissile.IndependantSeeker) //missile with independantSeeker can't get targetdata from radar/IRST
                 {
                     if (vesselRadarData.irstCount > 0)
                     {
@@ -5748,7 +5750,7 @@ namespace BDArmory.Control
                     heatTarget.exists && Vector3.Angle(heatTarget.position - CurrentMissile.MissileReferenceTransform.position, CurrentMissile.GetForwardTransform()) < maxOffBoresight ?
                     heatTarget.predictedPosition - CurrentMissile.MissileReferenceTransform.position
                     : CurrentMissile.GetForwardTransform();
-
+                // remove AI target check/move to a missile .cfg option to allow older gen heaters?
                 heatTarget = BDATargetManager.GetHeatTarget(vessel, vessel, new Ray(CurrentMissile.MissileReferenceTransform.position + (50 * CurrentMissile.GetForwardTransform()), direction), TargetSignatureData.noTarget, scanRadius, CurrentMissile.heatThreshold, CurrentMissile.frontAspectHeatModifier, CurrentMissile.uncagedLock, CurrentMissile.lockedSensorFOVBias, CurrentMissile.lockedSensorVelocityBias, this, guardMode ? currentTarget : null);
             }
         }

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -5771,7 +5771,7 @@ namespace BDArmory.Control
             return matchFound;
         }
 
-        public void SendTargetDataToMissile(MissileBase ml)
+        public void SendTargetDataToMissile(MissileBase ml, bool clearHeat = true)
         { //TODO BDModularGuidance: implement all targetings on base
             if (ml.TargetingMode == MissileBase.TargetingModes.Laser && laserPointDetected)
             {
@@ -5807,7 +5807,7 @@ namespace BDArmory.Control
                 MissileLauncher mml = ml as MissileLauncher;
                 if (BDArmorySettings.DEBUG_MISSILES)
                     Debug.Log("[BDArmory.MissileData]: Missile multi-launcher or reloadable rail found...");
-                if (!mml.multiLauncher) heatTarget = TargetSignatureData.noTarget;
+                if (clearHeat) heatTarget = TargetSignatureData.noTarget;
                 if (BDArmorySettings.DEBUG_MISSILES)
                     Debug.Log("[BDArmory.MissileData]: Sending targetInfo to heat Missile...");
                 ml.targetVessel = ml.heatTarget.vessel.gameObject.GetComponent<TargetInfo>();

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -995,7 +995,8 @@ namespace BDArmory.Control
                         if (weapon.Current.GetWeaponClass() == WeaponClasses.Missile || weapon.Current.GetWeaponClass() == WeaponClasses.Bomb || weapon.Current.GetWeaponClass() == WeaponClasses.SLW)
                         {
                             var msl = weapon.Current.GetPart().FindModuleImplementing<MissileLauncher>();
-                            if (msl.launched || msl.HasFired) continue; //return first missile that is ready to fire
+                            if (msl != null)
+                                if (msl.launched || msl.HasFired) continue; //return first missile that is ready to fire
                         }
                         sw = weapon.Current;
                         break;
@@ -1459,7 +1460,6 @@ namespace BDArmory.Control
             engagedTargets = missilesAway.Count;
             //this.missilesAway = tempMissilesAway;
         }
-
         public override void OnFixedUpdate()
         {
             if (vessel == null) return;

--- a/BDArmory/CounterMeasure/CMFlare.cs
+++ b/BDArmory/CounterMeasure/CMFlare.cs
@@ -23,7 +23,8 @@ namespace BDArmory.CounterMeasure
 
         public Vector3 velocity;
 
-        public float thermal; //heat value
+        public Tuple<float, Part> thermalSig; //heat value
+        public float thermal;
         float minThermal;
         float startThermal;
 
@@ -53,14 +54,15 @@ namespace BDArmory.CounterMeasure
 
             // NEW (1.10 and later): generate flare within spectrum of emitting vessel's heat signature, but narrow range for low heats
 
-            thermal = BDATargetManager.GetVesselHeatSignature(sourceVessel, Vector3.zero); //if enabling heatSig occlusion in IR missiles the thermal value of flares will have to be adjusted to compensate.
+            thermalSig = BDATargetManager.GetVesselHeatSignature(sourceVessel, Vector3.zero); //if enabling heatSig occlusion in IR missiles the thermal value of flares will have to be adjusted to compensate.
+            thermal = thermalSig.Item1;
             //Then again, these are being ejected in a range of temps, which should cover potential differences in heatreturn from a target based on occlusion. Have vector3.Zero replaced with missile position to sim occlusion level missile owuld see and set flare temps accordingly?
             // float minMult = Mathf.Clamp(-0.265f * Mathf.Log(sourceHeat) + 2.3f, 0.65f, 0.8f);
             float thermalMinMult = Mathf.Clamp(((0.00093f * thermal * thermal - 1.4457f * thermal + 1141.95f) / 1000f), 0.65f, 0.8f); // Equivalent to above, but uses polynomial for speed
             thermal *= UnityEngine.Random.Range(thermalMinMult, Mathf.Max(BDArmorySettings.FLARE_FACTOR, 0f) - thermalMinMult + 0.8f);
 
             if (BDArmorySettings.DEBUG_OTHER)
-                Debug.Log("[BDArmory.CMFlare]: New flare generated from " + sourceVessel.GetDisplayName() + ":" + BDATargetManager.GetVesselHeatSignature(sourceVessel, Vector3.zero).ToString("0.0") + ", heat: " + thermal.ToString("0.0"));
+                Debug.Log("[BDArmory.CMFlare]: New flare generated from " + sourceVessel.GetDisplayName() + ":" + thermalSig.Item1.ToString("0.0") + ", heat: " + thermal.ToString("0.0"));
         }
 
         void OnEnable()

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -324,7 +324,7 @@ namespace BDArmory.Damage
             guiArmorTypeString = SelectedArmorType;
             guiHullTypeString = StringUtils.Localize(HullInfo.materials[HullInfo.materialNames[(int)HullTypeNum - 1]].localizedName);
             skinskinConduction = part.partInfo.partPrefab.skinSkinConductionMult;
-            skinInternalConduction = part.partInfo.partPrefab.skinSkinConductionMult;
+            skinInternalConduction = part.partInfo.partPrefab.skinInternalConductionMult;
             if (HighLogic.LoadedSceneIsFlight)
             {
                 if (BDArmorySettings.RESET_ARMOUR)
@@ -934,7 +934,7 @@ namespace BDArmory.Damage
                                     armorVolume = (float)Math.Round(hitpoints / hitpointMultiplier / 0.333 / 350, 1); //stock is 0.25 lift/m2, so...                                                                                                               //edges contribute to HP when they shouldn't; suggestion was to use tank volume instead (which would also allow thickness to play a role in HP), try ProceduralWing.aeroStatVolume * 700 
                                 }
                             }
-                            if (!BDArmorySettings.PWING_EDGE_LIFT || BDArmorySettings.RUNWAY_PROJECT || part.name.Contains("B9.Aero.Wing.Procedural.Panel")) //method to make pwings balanced with stock. 
+                            if (!BDArmorySettings.PWING_EDGE_LIFT || BDArmorySettings.PWING_THICKNESS_AFFECT_MASS_HP || BDArmorySettings.RUNWAY_PROJECT || part.name.Contains("B9.Aero.Wing.Procedural.Panel")) //method to make pwings balanced with stock. 
                             {
                                 hitpoints = -1;
                                 armorVolume = -1;

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -36,7 +36,7 @@ namespace BDArmory.Damage
 
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = false, guiName = "#LOC_BDArmory_ArmorRemaining"),//Armor intregity
         UI_ProgressBar(affectSymCounterparts = UI_Scene.None, controlEnabled = false, scene = UI_Scene.Flight, maxValue = 100, minValue = 0, requireFullControl = false)]
-        public float ArmorRemaining;
+        public float ArmorRemaining = 100;
 
         public float StartingArmor;
 
@@ -982,15 +982,16 @@ namespace BDArmory.Damage
                             hitpoints = Mathf.Min(hitpoints, (BDArmorySettings.HP_THRESHOLD >= 100 ? BDArmorySettings.HP_THRESHOLD : 2000f) * Mathf.Log(hitpoints / scale + 1)); //use default of 2K for RP if slider set to unclamped
                         }
                         hitpoints *= HullInfo.materials[hullType].healthMod;
-                        hitpoints = Mathf.Round(hitpoints / HpRounding) * HpRounding;
+                        //hitpoints = Mathf.Round(hitpoints / HpRounding) * HpRounding;
+                        hitpoints = Mathf.Round(hitpoints);
                         if (hitpoints < 100) hitpoints = 100;
                         if (BDArmorySettings.DEBUG_ARMOR && maxHitPoints <= 0 && Hitpoints != hitpoints) Debug.Log($"[BDArmory.HitpointTracker]: {part.name} updated HP: {Hitpoints}->{hitpoints} at time {Time.time}, partMass: {partMass}, density: {density}, structuralVolume: {structuralVolume}, structuralMass {structuralMass}");
                     }
                     else // Override based on part configuration for custom parts
                     {
                         hitpoints = maxHitPoints * HullInfo.materials[hullType].healthMod;
-                        hitpoints = Mathf.Round(hitpoints / HpRounding) * HpRounding;
-                        if (hitpoints < 100) hitpoints = 100;
+                        //hitpoints = Mathf.Round(hitpoints / HpRounding) * HpRounding; //don't round or cap MM patched HP values
+                        hitpoints = Mathf.Round(hitpoints);
                         if (BDArmorySettings.DEBUG_ARMOR && maxHitPoints <= 0 && Hitpoints != hitpoints) Debug.Log($"[BDArmory.HitpointTracker]: {part.name} updated HP: {Hitpoints}->{hitpoints} at time {Time.time}");
                     }
                 }
@@ -1000,7 +1001,6 @@ namespace BDArmory.Damage
                                                 //hitpoints = Mathf.Round(hitpoints / HpRounding) * HpRounding;
                                                 //armorpanel HP is panel integrity, as 'HP' is the slab of armor; having a secondary unused HP pool will only make armor massively more effective against explosions than it should due to how isInLineOfSight calculates intermediate parts
                 }
-                if (hitpoints < 100) hitpoints = 100;
             }
             else
             {

--- a/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Materials.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Materials.cfg
@@ -47,7 +47,7 @@ MATERIAL
 	costMod = 2
 	healthMod = 1.75
 	ignitionTemp = -1
-	maxTemp = 1500
+	maxTemp = 1694
 	ImpactMod = 2
 }
 MATERIAL

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,4 +1,11 @@
-﻿IMPROVEMENTS / FIXES
+﻿-Add whitelist option for guns/rockets/lasers to report hits in the competition marquee.
+-Fix heatseeker missiles fired from relaodable rails occasionally losing lock on firing
+
+
+
+
+
+IMPROVEMENTS / FIXES
 - General:
 	- Fix Firebottle mass not resetting if a part switched from fueltank to structural
 - UI:

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -9,6 +9,7 @@
 -Add Infinite Propellant Gamemode toggle to BDA settings menu.
 -Fix NRE spam when trying to fire Modular Missiles.
 -Fix NRE when firing Modular Missiles and Missile Icons are enabled.
+-Modular Missiles will use RCS when fired in space.
 -Heatseekers now target the hottest part on a craft, not the CoM
 
 

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -3,8 +3,13 @@
 -Add toggle for setting maxAltitude and GM Kill limits to ASl or AGL.
 -Fix issue causing Web API to not report scores.
 -HP no longer rounds MM patched values.
--Steel Hull MAterial melting point increased.
+-Steel Hull Material melting point increased.
 -Weapon burst length/fire angle overrides now respect symmetry.
+-Add Kill timer for GM Altitude to give violators a chance to get back to safe altitude instead of immediate kill.
+-Add Infinite Propellant Gamemode toggle to BDA settings menu.
+-Fix NRE spam when trying to fire Modular Missiles.
+-Fix NRE when firing Modular Missiles and Missile Icons are enabled.
+-Heatseekers now target the hottest part on a craft, not the CoM
 
 
 IMPROVEMENTS / FIXES

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,8 +1,10 @@
 ﻿-Add whitelist option for guns/rockets/lasers to report hits in the competition marquee.
--Fix heatseeker missiles fired from relaodable rails occasionally losing lock on firing
-
-
-
+-Fix heatseeker missiles fired from relaodable rails occasionally losing lock on firing.
+-Add toggle for setting maxAltitude and GM Kill limits to ASl or AGL.
+-Fix issue causing Web API to not report scores.
+-HP no longer rounds MM patched values.
+-Steel Hull MAterial melting point increased.
+-Weapon burst length/fire angle overrides now respect symmetry.
 
 
 IMPROVEMENTS / FIXES

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -390,24 +390,27 @@ namespace BDArmory.FX
             {
                 string message = "";
                 foreach (var vesselName in explosionEventsVesselsHit.Keys)
-                    message += (message == "" ? "" : " and ") + vesselName + " had " + explosionEventsVesselsHit[vesselName];
-                switch (ExplosionSource)
+                    //message += (message == "" ? "" : " and ") + vesselName + " had " + explosionEventsVesselsHit[vesselName];
+                    switch (ExplosionSource)
                     {
                         case ExplosionSourceType.Missile:
+                            message += (message == "" ? "" : " and ") + vesselName + " had " + explosionEventsVesselsHit[vesselName];
                             message += " parts damaged due to missile strike";
                             message += (SourceWeaponName != null ? $" ({SourceWeaponName})" : "") + (sourceVesselName != null ? $" from {sourceVesselName}" : "") + ".";
                             break;
-                        case ExplosionSourceType.Bullet: 
-                            message += " parts damaged from ";
+                        case ExplosionSourceType.Bullet:
+                            message += (message == "" ? "" : " and ") + vesselName + " had " + explosionEventsVesselsHit[vesselName] + " parts damaged from";
                             message += (sourceVesselName != null ? $" from {sourceVesselName}'s" : "") + (SourceWeaponName != null ? $" ({SourceWeaponName})" : "shell hit") + ($" at {travelDistance:F3}m") + ".";
                             break;
                         case ExplosionSourceType.Rocket:
-                        {
-                            if (travelDistance < 0) break;
-                            message += " parts damaged from";
-                            message += (sourceVesselName != null ? $" from {sourceVesselName}'s" : "") + (SourceWeaponName != null ? $" ({SourceWeaponName})" : "rocket hit") + ($" at {travelDistance:F3}m") + ".";
-                            break;
-                        }
+                            {
+                                if (travelDistance > 0)
+                                {
+                                    message += (message == "" ? "" : " and ") + vesselName + " had " + explosionEventsVesselsHit[vesselName] + " parts damaged from";
+                                    message += (sourceVesselName != null ? $" from {sourceVesselName}'s" : "") + (SourceWeaponName != null ? $" ({SourceWeaponName})" : "rocket hit") + ($" at {travelDistance:F3}m") + ".";
+                                }
+                                break;
+                            }
                     }
                 BDACompetitionMode.Instance.competitionStatus.Add(message);
                 // Note: damage hasn't actually been applied to the parts yet, just assigned as events, so we can't know if they survived.

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -412,7 +412,7 @@ namespace BDArmory.FX
                                 break;
                             }
                     }
-                BDACompetitionMode.Instance.competitionStatus.Add(message);
+                if (!String.IsNullOrEmpty(message)) BDACompetitionMode.Instance.competitionStatus.Add(message);
                 // Note: damage hasn't actually been applied to the parts yet, just assigned as events, so we can't know if they survived.
                 foreach (var vesselName in explosionEventsVesselsHit.Keys) // Note: sourceVesselName is already checked for being in the competition before damagedVesselName is added to explosionEventsVesselsHitByMissiles, so we don't need to check it here.
                 {

--- a/BDArmory/Properties/AssemblyInfo.cs
+++ b/BDArmory/Properties/AssemblyInfo.cs
@@ -17,8 +17,8 @@ using System.Runtime.InteropServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("1.5.7.0")]
-[assembly: AssemblyFileVersion("1.5.7.0")]
+[assembly: AssemblyVersion("1.5.8.0")]
+[assembly: AssemblyFileVersion("1.5.8.0")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -104,6 +104,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static float COMPETITION_KILLER_GM_GRACE_PERIOD = 150;     // Competition killer GM grace period in seconds.
         [BDAPersistentSettingsField] public static float COMPETITION_ALTITUDE_LIMIT_HIGH = 46;         // Altitude (high) in km at which to kill off craft.
         [BDAPersistentSettingsField] public static float COMPETITION_ALTITUDE_LIMIT_LOW = -1;          // Altitude (low) in km at which to kill off craft.
+        [BDAPersistentSettingsField] public static bool COMPETITION_ALTITUDE__LIMIT_ASL = false;       // Does Killer GM use ASL or AGL for latitide ceiling/floor?
         [BDAPersistentSettingsField] public static float COMPETITION_NONCOMPETITOR_REMOVAL_DELAY = 30; // Competition non-competitor removal delay in seconds.
         [BDAPersistentSettingsField] public static float COMPETITION_DISTANCE = 1000;                  // Competition distance.
         [BDAPersistentSettingsField] public static int COMPETITION_START_NOW_AFTER = 11;               // Competition auto-start now.

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -40,6 +40,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static bool AI_TOOLBAR_BUTTON = true;                 // Show or hide the BDA AI toolbar button.
         [BDAPersistentSettingsField] public static bool INFINITE_AMMO = false;              //infinite Bullets/rockets/laserpower
         [BDAPersistentSettingsField] public static bool INFINITE_ORDINANCE = false;         //infinite missiles/bombs (on ordinance w/ Reload Module)
+        [BDAPersistentSettingsField] public static bool INFINITE_FUEL = false;              //Infinite propellant
         [BDAPersistentSettingsField] public static bool BULLET_HITS = true;
         [BDAPersistentSettingsField] public static bool EJECT_SHELLS = true;
         [BDAPersistentSettingsField] public static bool VESSEL_RELATIVE_BULLET_CHECKS = false;

--- a/BDArmory/Targeting/TargetSignatureData.cs
+++ b/BDArmory/Targeting/TargetSignatureData.cs
@@ -56,7 +56,7 @@ namespace BDArmory.Targeting
             // vessel never been picked up on radar before: create new targetinfo record
             if (targetInfo == null)
             {
-                if (VesselModuleRegistry.GetMissileFire(v));
+                if (VesselModuleRegistry.GetMissileFire(v))
                 targetInfo = v.gameObject.AddComponent<TargetInfo>();
             }
 

--- a/BDArmory/Targeting/TargetSignatureData.cs
+++ b/BDArmory/Targeting/TargetSignatureData.cs
@@ -24,6 +24,7 @@ namespace BDArmory.Targeting
         public VesselECMJInfo vesselJammer;
         public ModuleRadar lockedByRadar;
         public Vessel vessel;
+        public Part IRSource;
         bool orbital;
         Orbit orbit;
 
@@ -35,7 +36,7 @@ namespace BDArmory.Targeting
                 timeAcquired == other.timeAcquired;
         }
 
-        public TargetSignatureData(Vessel v, float _signalStrength)
+        public TargetSignatureData(Vessel v, float _signalStrength, Part heatpart = null)
         {
             orbital = v.InOrbit();
             orbit = v.orbit;
@@ -43,8 +44,8 @@ namespace BDArmory.Targeting
             timeAcquired = Time.time;
             vessel = v;
             velocity = v.Velocity();
-
-            geoPos = VectorUtils.WorldPositionToGeoCoords(v.CoM, v.mainBody);
+            IRSource = heatpart;
+            geoPos = VectorUtils.WorldPositionToGeoCoords(IRSource != null? IRSource.transform.position : v.CoM, v.mainBody);
             acceleration = v.acceleration_immediate;
             exists = true;
 
@@ -55,12 +56,13 @@ namespace BDArmory.Targeting
             // vessel never been picked up on radar before: create new targetinfo record
             if (targetInfo == null)
             {
+                if (VesselModuleRegistry.GetMissileFire(v));
                 targetInfo = v.gameObject.AddComponent<TargetInfo>();
             }
 
             Team = null;
 
-            if (targetInfo)  // Always true, as we just set it?
+            if (targetInfo) 
             {
                 Team = targetInfo.Team;
             }
@@ -92,6 +94,7 @@ namespace BDArmory.Targeting
             orbit = null;
             lockedByRadar = null;
             vessel = null;
+            IRSource = null;
         }
 
         public TargetSignatureData(Vector3 _velocity, Vector3 _position, Vector3 _acceleration, bool _exists, float _signalStrength)
@@ -110,6 +113,7 @@ namespace BDArmory.Targeting
             orbit = null;
             lockedByRadar = null;
             vessel = null;
+            IRSource = null;
         }
 
         public Vector3 position

--- a/BDArmory/UI/BDATeamIcons.cs
+++ b/BDArmory/UI/BDATeamIcons.cs
@@ -207,7 +207,12 @@ namespace BDArmory.UI
                                     if (ml.Current == null) continue;
                                     MissileLauncher launcher = ml.Current as MissileLauncher;
                                     //if (ml.Current.MissileState != MissileBase.MissileStates.Idle && ml.Current.MissileState != MissileBase.MissileStates.Drop)
-                                    if ((ml.Current.HasFired && (!launcher.multiLauncher || launcher.multiLauncher && launcher.multiLauncher.isClusterMissile)) && !ml.Current.HasMissed && !ml.Current.HasExploded) //culling post-thrust missiles makes AGMs get cleared almost immediately after launch
+                                    bool multilauncher = false;
+                                    if (launcher != null)
+                                    {
+                                        if (launcher.multiLauncher && !launcher.multiLauncher.isClusterMissile) multilauncher = true;
+                                    }
+                                    if ((ml.Current.HasFired && !multilauncher) && !ml.Current.HasMissed && !ml.Current.HasExploded) //culling post-thrust missiles makes AGMs get cleared almost immediately after launch
                                     {
                                         Vector3 sPos = FlightGlobals.ActiveVessel.vesselTransform.position;
                                         Vector3 tPos = v.Current.vesselTransform.position;

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -950,7 +950,7 @@ namespace BDArmory.UI
             GUI.Label(new Rect(_windowMargin + _buttonSize, _windowMargin, columnWidth - 2 * _windowMargin - numberOfButtons * _buttonSize, _windowMargin + _buttonSize), StringUtils.Localize("#LOC_BDArmory_WMWindow_title") + "          ", kspTitleLabel);
 
             // Version.
-            GUI.Label(new Rect(columnWidth - _windowMargin - (numberOfButtons - 1) * _buttonSize - 100, 23, 57, 10), Version, waterMarkStyle);
+            GUI.Label(new Rect(columnWidth - _windowMargin - (numberOfButtons - 1) * _buttonSize - 100, 23, 57, 10), Version + " SI", waterMarkStyle);
             //SETTINGS BUTTON
             if (!BDKeyBinder.current &&
                 GUI.Button(new Rect(columnWidth - _windowMargin - ++buttonNumber * _buttonSize, _windowMargin, _buttonSize, _buttonSize), settingsIconTexture, BDGuiSkin.button))
@@ -3699,6 +3699,7 @@ namespace BDArmory.UI
                         GUI.Label(SLeftSliderRect(++line), $"{StringUtils.Localize("#LOC_BDArmory_Settings_CompetitionAltitudeLimitLow")}: ({killerGMMinAltitudeText})", leftLabel);
                         BDArmorySettings.COMPETITION_ALTITUDE_LIMIT_LOW = Mathf.Round(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.COMPETITION_ALTITUDE_LIMIT_LOW, -39f, 44f));
                     }
+                    BDArmorySettings.COMPETITION_ALTITUDE__LIMIT_ASL = GUI.Toggle(SLineRect(++line), BDArmorySettings.COMPETITION_ALTITUDE__LIMIT_ASL, "Use Absolute Altitude?"); // StringUtils.Localize("#LLOC_BDArmory_Settings_CompetitionAltitudeLimitASL"));                    
                     if (BDArmorySettings.RUNWAY_PROJECT)
                     {
                         GUI.Label(SLeftSliderRect(++line), $"{StringUtils.Localize("#LOC_BDArmory_Settings_CompetitionKillerGMGracePeriod")}: ({BDArmorySettings.COMPETITION_KILLER_GM_GRACE_PERIOD}s)", leftLabel);

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -3190,12 +3190,12 @@ namespace BDArmory.UI
                         BDArmorySettings.MUTATOR_ICONS = GUI.Toggle(SLeftRect(++line, 1f), BDArmorySettings.MUTATOR_ICONS, StringUtils.Localize("#LOC_BDArmory_Settings_MutatorIcons"));
                     }
                 }
-                if (BDArmorySettings.INFINITE_FUEL != (BDArmorySettings.INFINITE_FUEL = GUI.Toggle(SRightRect(line), BDArmorySettings.INFINITE_FUEL, StringUtils.Localize("#autoLOC_900349"))))//"Infinite Propellant"
+                if (BDArmorySettings.INFINITE_FUEL != (BDArmorySettings.INFINITE_FUEL = GUI.Toggle(SRightRect(++line), BDArmorySettings.INFINITE_FUEL, StringUtils.Localize("#autoLOC_900349"))))//"Infinite Propellant"
                 {
                     CheatOptions.InfinitePropellant = BDArmorySettings.INFINITE_FUEL;
                 }
                 // Heartbleed
-                BDArmorySettings.HEART_BLEED_ENABLED = GUI.Toggle(SLeftRect(++line), BDArmorySettings.HEART_BLEED_ENABLED, StringUtils.Localize("#LOC_BDArmory_Settings_HeartBleed"));//"Heart Bleed"
+                BDArmorySettings.HEART_BLEED_ENABLED = GUI.Toggle(SLeftRect(line), BDArmorySettings.HEART_BLEED_ENABLED, StringUtils.Localize("#LOC_BDArmory_Settings_HeartBleed"));//"Heart Bleed"
                 if (BDArmorySettings.HEART_BLEED_ENABLED)
                 {
                     GUI.Label(SLeftSliderRect(++line), $"{StringUtils.Localize("#LOC_BDArmory_Settings_HeartBleedRate")}:  ({BDArmorySettings.HEART_BLEED_RATE})", leftLabel);//Heart Bleed Rate

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -421,7 +421,7 @@ namespace BDArmory.UI
             if (HighLogic.LoadedSceneIsFlight)
             {
                 saveWindowPosition = true;     //otherwise later we should NOT save the current window positions!
-                CheatOptions.InfinitePropellant = BDArmorySettings.PEACE_MODE;
+                CheatOptions.InfinitePropellant = BDArmorySettings.INFINITE_FUEL;
             }
             // // Create settings file if not present.
             // if (ConfigNode.Load(BDArmorySettings.settingsConfigURL) == null)
@@ -3192,7 +3192,7 @@ namespace BDArmory.UI
                 }
                 if (BDArmorySettings.INFINITE_FUEL != (BDArmorySettings.INFINITE_FUEL = GUI.Toggle(SRightRect(line), BDArmorySettings.INFINITE_FUEL, StringUtils.Localize("#autoLOC_900349"))))//"Infinite Propellant"
                 {
-                    CheatOptions.InfinitePropellant = BDArmorySettings.PEACE_MODE;
+                    CheatOptions.InfinitePropellant = BDArmorySettings.INFINITE_FUEL;
                 }
                 // Heartbleed
                 BDArmorySettings.HEART_BLEED_ENABLED = GUI.Toggle(SLeftRect(++line), BDArmorySettings.HEART_BLEED_ENABLED, StringUtils.Localize("#LOC_BDArmory_Settings_HeartBleed"));//"Heart Bleed"

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -579,6 +579,7 @@ namespace BDArmory.UI
             MutatorInfo.Load();
             HullInfo.Load();
             ProjectileUtils.SetUpPartsHashSets();
+            ProjectileUtils.SetUpWeaponReporting();
 
             compDistGui = BDArmorySettings.COMPETITION_DISTANCE.ToString();
             HoSTag = BDArmorySettings.HOS_BADGE;

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -950,7 +950,7 @@ namespace BDArmory.UI
             GUI.Label(new Rect(_windowMargin + _buttonSize, _windowMargin, columnWidth - 2 * _windowMargin - numberOfButtons * _buttonSize, _windowMargin + _buttonSize), StringUtils.Localize("#LOC_BDArmory_WMWindow_title") + "          ", kspTitleLabel);
 
             // Version.
-            GUI.Label(new Rect(columnWidth - _windowMargin - (numberOfButtons - 1) * _buttonSize - 100, 23, 57, 10), Version + " SI", waterMarkStyle);
+            GUI.Label(new Rect(columnWidth - _windowMargin - (numberOfButtons - 1) * _buttonSize - 1200, 23, 90, 10), Version, waterMarkStyle);
             //SETTINGS BUTTON
             if (!BDKeyBinder.current &&
                 GUI.Button(new Rect(columnWidth - _windowMargin - ++buttonNumber * _buttonSize, _windowMargin, _buttonSize, _buttonSize), settingsIconTexture, BDGuiSkin.button))
@@ -3077,6 +3077,7 @@ namespace BDArmory.UI
                     {
                         OnPeaceEnabled();
                     }
+                    CheatOptions.InfinitePropellant = BDArmorySettings.PEACE_MODE;
                 }
                 //Mutators
                 var oldMutators = BDArmorySettings.MUTATOR_MODE;
@@ -3186,6 +3187,10 @@ namespace BDArmory.UI
                         }
                         BDArmorySettings.MUTATOR_ICONS = GUI.Toggle(SLeftRect(++line, 1f), BDArmorySettings.MUTATOR_ICONS, StringUtils.Localize("#LOC_BDArmory_Settings_MutatorIcons"));
                     }
+                }
+                if (BDArmorySettings.INFINITE_FUEL != (BDArmorySettings.INFINITE_FUEL = GUI.Toggle(SRightRect(++line), BDArmorySettings.INFINITE_FUEL, StringUtils.Localize("#autoLOC_900349 "))))//"Infinite Propellant"
+                {
+                    CheatOptions.InfinitePropellant = BDArmorySettings.PEACE_MODE;
                 }
                 // Heartbleed
                 BDArmorySettings.HEART_BLEED_ENABLED = GUI.Toggle(SLeftRect(++line), BDArmorySettings.HEART_BLEED_ENABLED, StringUtils.Localize("#LOC_BDArmory_Settings_HeartBleed"));//"Heart Bleed"

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -419,8 +419,10 @@ namespace BDArmory.UI
         {
             //wmgr toolbar
             if (HighLogic.LoadedSceneIsFlight)
+            {
                 saveWindowPosition = true;     //otherwise later we should NOT save the current window positions!
-
+                CheatOptions.InfinitePropellant = BDArmorySettings.PEACE_MODE;
+            }
             // // Create settings file if not present.
             // if (ConfigNode.Load(BDArmorySettings.settingsConfigURL) == null)
             // {
@@ -950,7 +952,7 @@ namespace BDArmory.UI
             GUI.Label(new Rect(_windowMargin + _buttonSize, _windowMargin, columnWidth - 2 * _windowMargin - numberOfButtons * _buttonSize, _windowMargin + _buttonSize), StringUtils.Localize("#LOC_BDArmory_WMWindow_title") + "          ", kspTitleLabel);
 
             // Version.
-            GUI.Label(new Rect(columnWidth - _windowMargin - (numberOfButtons - 1) * _buttonSize - 1200, 23, 90, 10), Version, waterMarkStyle);
+            GUI.Label(new Rect(columnWidth - _windowMargin - (numberOfButtons - 1) * _buttonSize - 1200, 23, 90, 10), Version + " SI", waterMarkStyle);
             //SETTINGS BUTTON
             if (!BDKeyBinder.current &&
                 GUI.Button(new Rect(columnWidth - _windowMargin - ++buttonNumber * _buttonSize, _windowMargin, _buttonSize, _buttonSize), settingsIconTexture, BDGuiSkin.button))
@@ -3188,7 +3190,7 @@ namespace BDArmory.UI
                         BDArmorySettings.MUTATOR_ICONS = GUI.Toggle(SLeftRect(++line, 1f), BDArmorySettings.MUTATOR_ICONS, StringUtils.Localize("#LOC_BDArmory_Settings_MutatorIcons"));
                     }
                 }
-                if (BDArmorySettings.INFINITE_FUEL != (BDArmorySettings.INFINITE_FUEL = GUI.Toggle(SRightRect(++line), BDArmorySettings.INFINITE_FUEL, StringUtils.Localize("#autoLOC_900349 "))))//"Infinite Propellant"
+                if (BDArmorySettings.INFINITE_FUEL != (BDArmorySettings.INFINITE_FUEL = GUI.Toggle(SRightRect(line), BDArmorySettings.INFINITE_FUEL, StringUtils.Localize("#autoLOC_900349"))))//"Infinite Propellant"
                 {
                     CheatOptions.InfinitePropellant = BDArmorySettings.PEACE_MODE;
                 }

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -986,7 +986,7 @@ namespace BDArmory.UI
             GUI.Label(new Rect(_windowMargin + _buttonSize, _windowMargin, columnWidth - 2 * _windowMargin - numberOfButtons * _buttonSize, _windowMargin + _buttonSize), StringUtils.Localize("#LOC_BDArmory_WMWindow_title") + "          ", kspTitleLabel);
 
             // Version.
-            GUI.Label(new Rect(columnWidth - _windowMargin - (numberOfButtons - 1) * _buttonSize - 1200, 23, 90, 10), Version + " SI", waterMarkStyle);
+            GUI.Label(new Rect(columnWidth - _windowMargin - (numberOfButtons - 1) * _buttonSize - 1200, 23, 90, 10), Version, waterMarkStyle);
             //SETTINGS BUTTON
             if (!BDKeyBinder.current &&
                 GUI.Button(new Rect(columnWidth - _windowMargin - ++buttonNumber * _buttonSize, _windowMargin, _buttonSize, _buttonSize), settingsIconTexture, BDGuiSkin.button))

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -2944,7 +2944,7 @@ namespace BDArmory.UI
                     {
                         OnPeaceEnabled();
                     }
-                    CheatOptions.InfinitePropellant = BDArmorySettings.PEACE_MODE;
+                    CheatOptions.InfinitePropellant = !BDArmorySettings.INFINITE_FUEL ? BDArmorySettings.PEACE_MODE : true;
                 }
                 //Mutators
                 var oldMutators = BDArmorySettings.MUTATOR_MODE;

--- a/BDArmory/Utils/FARUtils.cs
+++ b/BDArmory/Utils/FARUtils.cs
@@ -191,7 +191,8 @@ namespace BDArmory.Utils
                         float thickness = 0.36f;
                         float adjustedThickness = 0.36f;
                         if (BDArmorySettings.RUNWAY_PROJECT || BDArmorySettings.PWING_THICKNESS_AFFECT_MASS_HP)
-                        {
+                        //if (BDArmorySettings.PWING_THICKNESS_AFFECT_MASS_HP)
+                            {
                             thickness = Mathf.Max(((float)PWType.GetField("sharedBaseThicknessRoot", BindingFlags.Public | BindingFlags.Instance).GetValue(module) + (float)PWType.GetField("sharedBaseThicknessTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module)), 0.2f);
                             if (thickness >= 0.36f) //0.18 * 2
                                 adjustedThickness = (Mathf.Max(0.36f, (Mathf.Log(1.55f + (thickness * 0.5f)) * 0.66f)));
@@ -206,17 +207,19 @@ namespace BDArmory.Utils
                         //float thickness = 0.36f;
                         float aeroVolume = (0.786f * length * width * adjustedThickness) / 4f; //original .7 was based on errorneous 2x4 wingboard dimensions; stock reference wing area is 1.875x3.75m
                         if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.FARUtils]: Found volume of {aeroVolume} for {part.name}.");
+                        float liftCoeff = (float)PWType.GetField("stockLiftCoefficient", BindingFlags.Public | BindingFlags.Instance).GetValue(module);
                         if ((BDArmorySettings.RUNWAY_PROJECT || !BDArmorySettings.PWING_EDGE_LIFT) && !ctrlSrf) //if RunwayProject and part !controlsurface, remove lift/mass from edges to bring inline with stock boards
                         {
                             bool isLiftingSurface = (float)PWType.GetField("stockLiftCoefficient", BindingFlags.Public | BindingFlags.Instance).GetValue(module) > 0f;
-                            float liftCoeff = (length * (width / 2f)) / 3.52f;
+                            liftCoeff = (length * (width / 2f)) / 3.52f;
                             PWType.GetField("stockLiftCoefficient", BindingFlags.Public | BindingFlags.Instance).SetValue(module, isLiftingSurface ? liftCoeff : 0f); //adjust PWing GUI lift readout
                             part.Modules.GetModule<ModuleLiftingSurface>().deflectionLiftCoeff = (length * (width / 2f) / 3.52f); //adjust lift to be inline with stock wings
-                            if (!WingctrlSrf)
-                                PWType.GetField("aeroUIMass", BindingFlags.Public | BindingFlags.Instance).SetValue(module, (liftCoeff / 10f) * (thickness * 3)); //Adjust PWing GUI mass readout
-                            else
-                                PWType.GetField("aeroUIMass", BindingFlags.Public | BindingFlags.Instance).SetValue(module, (liftCoeff / 5f) * (thickness * 3)); //this modifies the IPartMassModifier, so the mass will also change along with the GUI
                         }
+                        if (!WingctrlSrf)
+                            PWType.GetField("aeroUIMass", BindingFlags.Public | BindingFlags.Instance).SetValue(module, (liftCoeff / 10f) * (thickness * 3)); //Adjust PWing GUI mass readout
+                        else
+                            PWType.GetField("aeroUIMass", BindingFlags.Public | BindingFlags.Instance).SetValue(module, (liftCoeff / 5f) * (thickness * 3)); //this modifies the IPartMassModifier, so the mass will also change along with the GUI
+
                         if (part.name.Contains("B9.Aero.Wing.Procedural.Panel")) //if Josue's noLift PWings PR never gets folded in, here's an alternative using an MM'ed PWing structural panel part
                         {
                             PWType.GetField("stockLiftCoefficient", BindingFlags.Public | BindingFlags.Instance).SetValue(module, 0f); //adjust PWing GUI lift readout

--- a/BDArmory/Utils/VesselUtils.cs
+++ b/BDArmory/Utils/VesselUtils.cs
@@ -30,6 +30,12 @@ namespace BDArmory.Utils
                 {
                     UI.BDATargetManager.RemoveTarget(tInfo); //prevent other craft from chasing GM killed craft (in case of maxAltitude or similar
                 }
+                if (v != null)
+                {
+                    UI.BDATargetManager.LoadedVessels.Remove(v);
+                }
+                UI.BDATargetManager.LoadedVessels.RemoveAll(ves => ves == null);
+                UI.BDATargetManager.LoadedVessels.RemoveAll(ves => ves.loaded == false);
             }
         }
 

--- a/BDArmory/Weapons/Missiles/BDModularGuidance.cs
+++ b/BDArmory/Weapons/Missiles/BDModularGuidance.cs
@@ -1024,6 +1024,10 @@ namespace BDArmory.Weapons.Missiles
 
                 HasFired = true;
                 DetonationDistanceState = DetonationDistanceStates.NotSafe;
+                if (vessel.atmDensity < 0.05)
+                {
+                    vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, true);
+                }
             }
             if (BDArmorySetup.Instance.ActiveWeaponManager != null)
             {

--- a/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
@@ -339,7 +339,7 @@ namespace BDArmory.Weapons.Missiles
                             {
                                 var ml = pSym.Current.FindModuleImplementing<MissileBase>();
                                 if (ml == null) continue;
-                                if (wpm != null) wpm.SendTargetDataToMissile(ml);
+                                if (wpm != null) wpm.SendTargetDataToMissile(ml, false);
                                 MissileLauncher launcher = ml as MissileLauncher;
                                 if (launcher != null)
                                 {
@@ -561,7 +561,7 @@ namespace BDArmory.Weapons.Missiles
                     }
                     else
                     {
-                        if (wpm != null) wpm.SendTargetDataToMissile(ml);
+                        if (wpm != null) wpm.SendTargetDataToMissile(ml, false);
                     }
                 }
                 else

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -402,7 +402,7 @@ namespace BDArmory.Weapons
         public bool BurstOverride = false;
 
         [KSPField(advancedTweakable = true, isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_FiringBurstCount"),//Burst Firing Count
-            UI_FloatRange(minValue = 1f, maxValue = 100f, stepIncrement = 1, scene = UI_Scene.All)]
+            UI_FloatRange(minValue = 1f, maxValue = 100f, stepIncrement = 1, scene = UI_Scene.All, affectSymCounterparts = UI_Scene.All)]
         public float fireBurstLength = 1;
 
         [KSPField(isPersistant = true)]
@@ -1583,41 +1583,62 @@ namespace BDArmory.Weapons
         [KSPEvent(advancedTweakable = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_FireAngleOverride_Enable", active = true)]//Disable fire angle override
         public void ToggleOverrideAngle()
         {
-            FireAngleOverride = !FireAngleOverride;
+            using (List<Part>.Enumerator craftPart = EditorLogic.fetch.ship.parts.GetEnumerator())
+                while (craftPart.MoveNext())
+                {
+                    if (craftPart.Current == null) continue;
+                    if (craftPart.Current.name != part.name) continue;
+                    using (List<ModuleWeapon>.Enumerator weapon = craftPart.Current.FindModulesImplementing<ModuleWeapon>().GetEnumerator())
+                        while (weapon.MoveNext())
+                        {
+                            if (weapon.Current == null) continue;
+                            weapon.Current.FireAngleOverride = !weapon.Current.FireAngleOverride;
+                            if (weapon.Current.FireAngleOverride == false)
+                            {
+                                weapon.Current.Events["ToggleOverrideAngle"].guiName = StringUtils.Localize("#LOC_BDArmory_FireAngleOverride_Enable");// Enable Firing Angle Override
+                            }
+                            else
+                            {
+                                weapon.Current.Events["ToggleOverrideAngle"].guiName = StringUtils.Localize("#LOC_BDArmory_FireAngleOverride_Disable");// Disable Firing Angle Override
+                            }
 
-            if (FireAngleOverride == false)
-            {
-                Events["ToggleOverrideAngle"].guiName = StringUtils.Localize("#LOC_BDArmory_FireAngleOverride_Enable");// Enable Firing Angle Override
-            }
-            else
-            {
-                Events["ToggleOverrideAngle"].guiName = StringUtils.Localize("#LOC_BDArmory_FireAngleOverride_Disable");// Disable Firing Angle Override
-            }
+                            weapon.Current.Fields["FiringTolerance"].guiActive = weapon.Current.FireAngleOverride;
+                            weapon.Current.Fields["FiringTolerance"].guiActiveEditor = weapon.Current.FireAngleOverride;
 
-            Fields["FiringTolerance"].guiActive = FireAngleOverride;
-            Fields["FiringTolerance"].guiActiveEditor = FireAngleOverride;
-
-            GUIUtils.RefreshAssociatedWindows(part);
+                            GUIUtils.RefreshAssociatedWindows(weapon.Current.part);
+                        }
+                }        
         }
         [KSPEvent(advancedTweakable = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_BurstLengthOverride_Enable", active = true)]//Burst length override
         public void ToggleBurstLengthOverride()
         {
-            BurstOverride = !BurstOverride;
+            using (List<Part>.Enumerator craftPart = EditorLogic.fetch.ship.parts.GetEnumerator())
+                while (craftPart.MoveNext())
+                {
+                    if (craftPart.Current == null) continue;
+                    if (craftPart.Current.name != part.name) continue;
+                    using (List<ModuleWeapon>.Enumerator weapon = craftPart.Current.FindModulesImplementing<ModuleWeapon>().GetEnumerator())
+                        while (weapon.MoveNext())
+                        {
+                            if (weapon.Current == null) continue;
+                            weapon.Current.BurstOverride = !weapon.Current.BurstOverride;
+                            if (weapon.Current.BurstOverride == false)
+                            {
+                                weapon.Current.Events["ToggleBurstLengthOverride"].guiName = StringUtils.Localize("#LOC_BDArmory_BurstLengthOverride_Enable");// Enable Firing Angle Override
+                            }
+                            else
+                            {
+                                weapon.Current.Events["ToggleBurstLengthOverride"].guiName = StringUtils.Localize("#LOC_BDArmory_BurstLengthOverride_Disable");// Disable Firing Angle Override
+                            }
 
-            if (BurstOverride == false)
-            {
-                Events["ToggleBurstLengthOverride"].guiName = StringUtils.Localize("#LOC_BDArmory_BurstLengthOverride_Enable");// Enable Burst Fire length Override
-            }
-            else
-            {
-                Events["ToggleBurstLengthOverride"].guiName = StringUtils.Localize("#LOC_BDArmory_BurstLengthOverride_Disable");// Disable Burst Fire length Override
-            }
+                            weapon.Current.Fields["fireBurstLength"].guiActive = weapon.Current.BurstOverride;
+                            weapon.Current.Fields["fireBurstLength"].guiActiveEditor = weapon.Current.BurstOverride;
 
-            Fields["fireBurstLength"].guiActive = BurstOverride;
-            Fields["fireBurstLength"].guiActiveEditor = BurstOverride;
-
-            GUIUtils.RefreshAssociatedWindows(part);
+                            GUIUtils.RefreshAssociatedWindows(weapon.Current.part);
+                        }
+                }
         }
+
         void FAOCos(BaseField field, object obj)
         {
             maxAutoFireCosAngle = Mathf.Cos((FiringTolerance * Mathf.Deg2Rad));

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -2444,7 +2444,7 @@ namespace BDArmory.Weapons
                                         if (HEpulses)
                                         {
                                             ExplosionFx.CreateExplosion(hit.point,
-                                                           (laserDamage / 30000),
+                                                           (laserDamage / 10000),
                                                            explModelPath, explSoundPath, ExplosionSourceType.Bullet, 1, null, vessel.vesselName, null);
                                         }
                                         if (Impulse != 0)
@@ -2501,6 +2501,11 @@ namespace BDArmory.Weapons
                                         BDACompetitionMode.Instance.Scores.RegisterBulletHit(aName, tName, WeaponName, distance);
                                         if (!pulseLaser && laserDamage > 0) BattleDamageHandler.CheckDamageFX(p, caliber, 1 + (damage / initialDamage), HEpulses, false, part.vessel.GetName(), hit, false, false);
                                         //pulse lasers check battle damage earlier in the code
+                                        if (ProjectileUtils.isReportingWeapon(part) && BDACompetitionMode.Instance.competitionIsActive)
+                                        {
+                                            string message = $"{tName} hit by {aName}'s {OriginalShortName} at {distance:F3}m!";
+                                            BDACompetitionMode.Instance.competitionStatus.Add(message);
+                                        }
                                     }
                                     else
                                     {


### PR DESCRIPTION
-Fix activation conditionals for Pwing thickness/HP/Mass tweak
﻿-Add whitelist option for guns/rockets/lasers to report hits in the competition marquee.
-Fix heatseeker missiles fired from reloadable rails occasionally losing lock on firing
-add toggle for setting maxAltitude and GM Kill limits to ASl or AGL.
-Fix issue causing Web API to not report scores.
-HP no longer rounds MM patched values.
-Steel Hull Material melting point increased.
-Weapon burst length/fire angle overrides now respect symmetry.
-Add Kill timer for GM Altitude to give violators a chance to get back to safe altitude instead of immediate kill.
-Add Infinite Propellant Gamemode toggle to BDA settings menu.
-Fix NRE spam when trying to fire Modular Missiles.
-Fix NRE when firing Modular Missiles and Missile Icons are enabled.
-Heatseekers now target the hottest part on a craft, not the CoM
-'Run Tournament' when using WayPoint Mode now properly spawns you at the start of the selected WP course