### PR TITLE
S5R5 rule updates

### DIFF
--- a/BDArmory/Competition/OrchestrationStrategies/WaypointFollowingStrategy.cs
+++ b/BDArmory/Competition/OrchestrationStrategies/WaypointFollowingStrategy.cs
@@ -81,7 +81,11 @@ namespace BDArmory.Competition.OrchestrationStrategies
             if (BDArmorySettings.DEBUG_OTHER) Debug.Log(string.Format("[BDArmory.WaypointFollowingStrategy]: Setting {0} waypoints", mappedWaypoints.Count));
 
             foreach (var pilot in pilots)
-            { pilot.SetWaypoints(mappedWaypoints); }
+            {
+                pilot.SetWaypoints(mappedWaypoints);
+                var Kerb = VesselModuleRegistry.GetModule<KerbalEVA>(pilot.vessel);
+                Kerb.part.ShieldedFromAirstream = true;
+            }
 
             if (BDArmorySettings.WAYPOINTS_INFINITE_FUEL_AT_START)
             { foreach (var pilot in pilots) pilot.MaintainFuelLevelsUntilWaypoint(); }

--- a/BDArmory/Competition/OrchestrationStrategies/WaypointFollowingStrategy.cs
+++ b/BDArmory/Competition/OrchestrationStrategies/WaypointFollowingStrategy.cs
@@ -84,7 +84,7 @@ namespace BDArmory.Competition.OrchestrationStrategies
             {
                 pilot.SetWaypoints(mappedWaypoints);
                 var Kerb = VesselModuleRegistry.GetModule<KerbalEVA>(pilot.vessel);
-                Kerb.part.ShieldedFromAirstream = true;
+                if (Kerb != null) Kerb.part.ShieldedFromAirstream = true;
             }
 
             if (BDArmorySettings.WAYPOINTS_INFINITE_FUEL_AT_START)

--- a/BDArmory/Competition/VesselSpawning/SpawnUtils.cs
+++ b/BDArmory/Competition/VesselSpawning/SpawnUtils.cs
@@ -115,6 +115,7 @@ namespace BDArmory.Competition.VesselSpawning
             foreach (var engine in VesselModuleRegistry.GetModules<ModuleEngines>(vessel))
             {
                 if (ignoreModularMissileEngines && IsModularMissileEngine(engine)) continue; // Ignore modular missile engines.
+                if (BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.RUNWAY_PROJECT_ROUND == 55) engine.independentThrottle = false;
                 var mme = engine.part.FindModuleImplementing<MultiModeEngine>();
                 if (mme == null)
                 {

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -1494,6 +1494,7 @@ namespace BDArmory.Control
             {
                 maxBank = 40;
                 postStallAoA = 0.0f;
+                maxSpeed = 600;
                 if (HighLogic.LoadedSceneIsFlight)
                 {
                     UI_FloatRange bank = (UI_FloatRange)Fields["maxBank"].uiControlFlight;
@@ -1506,6 +1507,8 @@ namespace BDArmory.Control
                 }
                 Fields["postStallAoA"].guiActiveEditor = false;
                 Fields["postStallAoA"].guiActive = false;
+                Fields["maxSpeed"].guiActiveEditor = false;
+                Fields["maxSpeed"].guiActive = false;
             }
             SetupSliderResolution();
             SetSliderPairClamps("turnRadiusTwiddleFactorMin", "turnRadiusTwiddleFactorMax");

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -599,7 +599,7 @@ namespace BDArmory.Control
             { nameof(steerKiAdjust), 20f },
             { nameof(steerDamping), 100f },
             { nameof(maxSteer), 1f},
-            { nameof(maxSpeed), 3000f },
+            { nameof(maxSpeed), (BDArmorySettings.RUNWAY_PROJECT_ROUND == 55) ? 600 : 3000f },
             { nameof(takeOffSpeed), 2000f },
             { nameof(minSpeed), 2000f },
             { nameof(strafingSpeed), 2000f },
@@ -1499,16 +1499,18 @@ namespace BDArmory.Control
                 {
                     UI_FloatRange bank = (UI_FloatRange)Fields["maxBank"].uiControlFlight;
                     bank.maxValue = 40;
+                    UI_FloatRange spd = (UI_FloatRange)Fields["maxSpeed"].uiControlFlight;
+                    spd.maxValue = 600;
                 }
                 else
                 {
                     UI_FloatRange bank = (UI_FloatRange)Fields["maxBank"].uiControlEditor;
                     bank.maxValue = 40;
+                    UI_FloatRange spd = (UI_FloatRange)Fields["maxSpeed"].uiControlEditor;
+                    spd.maxValue = 600;
                 }
                 Fields["postStallAoA"].guiActiveEditor = false;
                 Fields["postStallAoA"].guiActive = false;
-                Fields["maxSpeed"].guiActiveEditor = false;
-                Fields["maxSpeed"].guiActive = false;
             }
             SetupSliderResolution();
             SetSliderPairClamps("turnRadiusTwiddleFactorMin", "turnRadiusTwiddleFactorMax");

--- a/BDArmory/UI/BDArmoryAIGUI.cs
+++ b/BDArmory/UI/BDArmoryAIGUI.cs
@@ -437,7 +437,7 @@ namespace BDArmory.UI
                     inputFields["minAltitude"].maxValue = ActivePilot.UpToEleven ? 60000 : 6000;
                     inputFields["maxAltitude"].maxValue = ActivePilot.UpToEleven ? 100000 : 15000;
 
-                    if (BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.RUNWAY_PROJECT_ROUND == 55) inputFields["maxSpeed"].maxValue = ActivePilot.UpToEleven ? 600 : 600;
+                    if (BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.RUNWAY_PROJECT_ROUND == 55) inputFields["maxSpeed"].maxValue = 600;
                     else inputFields["maxSpeed"].maxValue = ActivePilot.UpToEleven ? 3000 : 800;
                     inputFields["takeOffSpeed"].maxValue = ActivePilot.UpToEleven ? 2000 : 200;
                     inputFields["minSpeed"].maxValue = ActivePilot.UpToEleven ? 2000 : 200;

--- a/BDArmory/UI/BDArmoryAIGUI.cs
+++ b/BDArmory/UI/BDArmoryAIGUI.cs
@@ -346,7 +346,7 @@ namespace BDArmory.UI
                         { "minAltitude", gameObject.AddComponent<NumericInputField>().Initialise(0, ActivePilot.minAltitude, 25, 6000) },
                         { "maxAltitude", gameObject.AddComponent<NumericInputField>().Initialise(0, ActivePilot.maxAltitude, 100, 15000) },
 
-                        { "maxSpeed", gameObject.AddComponent<NumericInputField>().Initialise(0, ActivePilot.maxSpeed, 20, 800) },
+                        { "maxSpeed", gameObject.AddComponent<NumericInputField>().Initialise(0, ActivePilot.maxSpeed, 20, (BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.RUNWAY_PROJECT_ROUND == 55)? 600 :800) },
                         { "takeOffSpeed", gameObject.AddComponent<NumericInputField>().Initialise(0, ActivePilot.takeOffSpeed, 10, 200) },
                         { "minSpeed", gameObject.AddComponent<NumericInputField>().Initialise(0, ActivePilot.minSpeed, 10, 200) },
                         { "strafingSpeed", gameObject.AddComponent<NumericInputField>().Initialise(0, ActivePilot.strafingSpeed, 10, 200) },
@@ -437,7 +437,8 @@ namespace BDArmory.UI
                     inputFields["minAltitude"].maxValue = ActivePilot.UpToEleven ? 60000 : 6000;
                     inputFields["maxAltitude"].maxValue = ActivePilot.UpToEleven ? 100000 : 15000;
 
-                    inputFields["maxSpeed"].maxValue = ActivePilot.UpToEleven ? 3000 : 800;
+                    if (BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.RUNWAY_PROJECT_ROUND == 55) inputFields["maxSpeed"].maxValue = ActivePilot.UpToEleven ? 600 : 600;
+                    else inputFields["maxSpeed"].maxValue = ActivePilot.UpToEleven ? 3000 : 800;
                     inputFields["takeOffSpeed"].maxValue = ActivePilot.UpToEleven ? 2000 : 200;
                     inputFields["minSpeed"].maxValue = ActivePilot.UpToEleven ? 2000 : 200;
                     inputFields["idleSpeed"].maxValue = ActivePilot.UpToEleven ? 3000 : 200;
@@ -1454,22 +1455,20 @@ namespace BDArmory.UI
                                 GUIContent.none, BDArmorySetup.BDGuiSkin.box);
                             spdLines += 0.25f;
 
-                            if (!(BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.RUNWAY_PROJECT_ROUND == 55))
+                            GUI.Label(SettinglabelRect(leftIndent, spdLines), StringUtils.Localize("#LOC_BDArmory_PilotAI_Speeds"), BoldLabel);//"Speed"
+                            if (!NumFieldsEnabled)
                             {
-                                GUI.Label(SettinglabelRect(leftIndent, spdLines), StringUtils.Localize("#LOC_BDArmory_PilotAI_Speeds"), BoldLabel);//"Speed"
-                                if (!NumFieldsEnabled)
-                                {
-                                    ActivePilot.maxSpeed = GUI.HorizontalSlider(SettingSliderRect(leftIndent, ++spdLines, contentWidth), ActivePilot.maxSpeed, 20, ActivePilot.UpToEleven ? 3000 : 800);
-                                    ActivePilot.maxSpeed = Mathf.Round(ActivePilot.maxSpeed / 5) * 5;
-                                }
-                                else
-                                {
-                                    inputFields["maxSpeed"].tryParseValue(GUI.TextField(SettingTextRect(leftIndent, ++spdLines, contentWidth), inputFields["maxSpeed"].possibleValue, 6, inputFieldStyle));
-                                    ActivePilot.maxSpeed = (float)inputFields["maxSpeed"].currentValue;
-                                }
-                                GUI.Label(SettinglabelRect(leftIndent, spdLines), StringUtils.Localize("#LOC_BDArmory_MaxSpeed") + ": " + ActivePilot.maxSpeed.ToString("0"), Label);//"max speed"
-                                if (contextTipsEnabled) GUI.Label(ContextLabelRect(leftIndent, ++spdLines), StringUtils.Localize("#LOC_BDArmory_AIWindow_maxSpeed"), contextLabel);//"max speed"
+                                ActivePilot.maxSpeed = GUI.HorizontalSlider(SettingSliderRect(leftIndent, ++spdLines, contentWidth), ActivePilot.maxSpeed, 20, ActivePilot.UpToEleven ? 3000 : 800);
+                                ActivePilot.maxSpeed = Mathf.Round(ActivePilot.maxSpeed / 5) * 5;
                             }
+                            else
+                            {
+                                inputFields["maxSpeed"].tryParseValue(GUI.TextField(SettingTextRect(leftIndent, ++spdLines, contentWidth), inputFields["maxSpeed"].possibleValue, 6, inputFieldStyle));
+                                ActivePilot.maxSpeed = (float)inputFields["maxSpeed"].currentValue;
+                            }
+                            GUI.Label(SettinglabelRect(leftIndent, spdLines), StringUtils.Localize("#LOC_BDArmory_MaxSpeed") + ": " + ActivePilot.maxSpeed.ToString("0"), Label);//"max speed"
+                            if (contextTipsEnabled) GUI.Label(ContextLabelRect(leftIndent, ++spdLines), StringUtils.Localize("#LOC_BDArmory_AIWindow_maxSpeed"), contextLabel);//"max speed"
+
                             if (!NumFieldsEnabled)
                             {
                                 ActivePilot.takeOffSpeed = GUI.HorizontalSlider(SettingSliderRect(leftIndent, ++spdLines, contentWidth), ActivePilot.takeOffSpeed, 10f, ActivePilot.UpToEleven ? 2000 : 200);

--- a/BDArmory/UI/BDArmoryAIGUI.cs
+++ b/BDArmory/UI/BDArmoryAIGUI.cs
@@ -1454,20 +1454,22 @@ namespace BDArmory.UI
                                 GUIContent.none, BDArmorySetup.BDGuiSkin.box);
                             spdLines += 0.25f;
 
-                            GUI.Label(SettinglabelRect(leftIndent, spdLines), StringUtils.Localize("#LOC_BDArmory_PilotAI_Speeds"), BoldLabel);//"Speed"
-                            if (!NumFieldsEnabled)
+                            if (!(BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.RUNWAY_PROJECT_ROUND == 55))
                             {
-                                ActivePilot.maxSpeed = GUI.HorizontalSlider(SettingSliderRect(leftIndent, ++spdLines, contentWidth), ActivePilot.maxSpeed, 20, ActivePilot.UpToEleven ? 3000 : 800);
-                                ActivePilot.maxSpeed = Mathf.Round(ActivePilot.maxSpeed / 5) * 5;
+                                GUI.Label(SettinglabelRect(leftIndent, spdLines), StringUtils.Localize("#LOC_BDArmory_PilotAI_Speeds"), BoldLabel);//"Speed"
+                                if (!NumFieldsEnabled)
+                                {
+                                    ActivePilot.maxSpeed = GUI.HorizontalSlider(SettingSliderRect(leftIndent, ++spdLines, contentWidth), ActivePilot.maxSpeed, 20, ActivePilot.UpToEleven ? 3000 : 800);
+                                    ActivePilot.maxSpeed = Mathf.Round(ActivePilot.maxSpeed / 5) * 5;
+                                }
+                                else
+                                {
+                                    inputFields["maxSpeed"].tryParseValue(GUI.TextField(SettingTextRect(leftIndent, ++spdLines, contentWidth), inputFields["maxSpeed"].possibleValue, 6, inputFieldStyle));
+                                    ActivePilot.maxSpeed = (float)inputFields["maxSpeed"].currentValue;
+                                }
+                                GUI.Label(SettinglabelRect(leftIndent, spdLines), StringUtils.Localize("#LOC_BDArmory_MaxSpeed") + ": " + ActivePilot.maxSpeed.ToString("0"), Label);//"max speed"
+                                if (contextTipsEnabled) GUI.Label(ContextLabelRect(leftIndent, ++spdLines), StringUtils.Localize("#LOC_BDArmory_AIWindow_maxSpeed"), contextLabel);//"max speed"
                             }
-                            else
-                            {
-                                inputFields["maxSpeed"].tryParseValue(GUI.TextField(SettingTextRect(leftIndent, ++spdLines, contentWidth), inputFields["maxSpeed"].possibleValue, 6, inputFieldStyle));
-                                ActivePilot.maxSpeed = (float)inputFields["maxSpeed"].currentValue;
-                            }
-                            GUI.Label(SettinglabelRect(leftIndent, spdLines), StringUtils.Localize("#LOC_BDArmory_MaxSpeed") + ": " + ActivePilot.maxSpeed.ToString("0"), Label);//"max speed"
-                            if (contextTipsEnabled) GUI.Label(ContextLabelRect(leftIndent, ++spdLines), StringUtils.Localize("#LOC_BDArmory_AIWindow_maxSpeed"), contextLabel);//"max speed"
-
                             if (!NumFieldsEnabled)
                             {
                                 ActivePilot.takeOffSpeed = GUI.HorizontalSlider(SettingSliderRect(leftIndent, ++spdLines, contentWidth), ActivePilot.takeOffSpeed, 10f, ActivePilot.UpToEleven ? 2000 : 200);

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -3277,6 +3277,10 @@ namespace BDArmory.UI
                             GUI.Label(SLeftSliderRect(++line, 1f), $"{StringUtils.Localize("#LOC_BDArmory_settings_FireRateHitMultiplier")}:  ({BDArmorySettings.FIRE_RATE_OVERRIDE_HIT_MULTIPLIER})", leftLabel);//Fire Rate Hit Multiplier
                             BDArmorySettings.FIRE_RATE_OVERRIDE_HIT_MULTIPLIER = Mathf.Round(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.FIRE_RATE_OVERRIDE_HIT_MULTIPLIER, 1f, 4f) * 10f) / 10f;
                         }
+                        if (BDArmorySettings.RUNWAY_PROJECT_ROUND == 55 && !BDArmorySettings.WAYPOINTS_MODE)
+                        {
+                            BDArmorySettings.WAYPOINTS_MODE = true;
+                        }
                         // if (BDArmorySettings.RUNWAY_PROJECT_ROUND == 46) BDArmorySettings.NO_ENGINES = true;
                         if (CheatCodeGUI != (CheatCodeGUI = GUI.TextField(SLeftRect(++line, 1, true), CheatCodeGUI, inputFieldStyle))) //if we need super-secret stuff
                         {

--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -1099,8 +1099,7 @@ namespace BDArmory.Weapons.Missiles
         public void CheckDetonationState()
         {
             //Guard clauses
-            if (!TargetAcquired) return;
-
+            //if (!TargetAcquired) return;
             var targetDistancePerFrame = TargetVelocity * Time.fixedDeltaTime;
             var missileDistancePerFrame = vessel.Velocity() * Time.fixedDeltaTime;
 
@@ -1148,11 +1147,13 @@ namespace BDArmory.Weapons.Missiles
 
                         //We are safe and we can continue with the cruising phase
                         DetonationDistanceState = DetonationDistanceStates.Cruising;
+                        SetupExplosive(this.part); //moving arming of warhead to here from launch to prevent Laser anti-missile systems zapping a missile immediately after launch and fragging the launching plane as the missile detonates
                         break;
                     }
 
                 case DetonationDistanceStates.Cruising:
                     {
+                        if (!TargetAcquired) return;
                         //if (Vector3.Distance(futureMissilePosition, futureTargetPosition) < GetBlastRadius() * 10)
                         // Replaced old proximity check with proximity check based on either detonation distance or distance traveled per frame
                         if ((futureMissilePosition - futureTargetPosition).sqrMagnitude < 100 * (relativeSpeed > DetonationDistance ? relativeSpeed*relativeSpeed : DetonationDistance*DetonationDistance))
@@ -1176,6 +1177,7 @@ namespace BDArmory.Weapons.Missiles
 
                 case DetonationDistanceStates.CheckingProximity:
                     {
+                        if (!TargetAcquired) return;
                         if (DetonationDistance == 0)
                         {
                             if (weaponClass == WeaponClasses.Bomb) return;

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -1051,7 +1051,7 @@ namespace BDArmory.Weapons.Missiles
             HasFired = true;
             try // FIXME Remove this once the fix is sufficiently tested.
             {
-                SetupExplosive(this.part);
+                //SetupExplosive(this.part);
                 GameEvents.onPartDie.Add(PartDie);
 
                 if (GetComponentInChildren<KSPParticleEmitter>())


### PR DESCRIPTION
-Set seated Kerbs to dragless in Waypoint races
-Set AI maxSpeed to 600 if RUNWAY_PROJECT_ROUND = 55
-Sets independantThrottle engines to normal on spawn if RPR == 55
-Missiles/Bombs now arm their warheads when they reach a safe distance from their launching craft, to prevent anti-missile systems fragging craft by detonating ordinance immediately after launch

doing kerbs drag via code, as a cursory search on trying to use cargobays suggests that the bays need colliders to determine bay dimensions for if something is shielded or not, which would need new models for the EAS-2 and podracer seat