### PR TITLE
Missile proximity tweak

### DIFF
--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -1225,7 +1225,7 @@ namespace BDArmory.Weapons.Missiles
                         else
                         {
                             float optimalDistance = (float)(Math.Max(DetonationDistance, relativeSpeed));
-                            var hitCount = Physics.OverlapSphereNonAlloc(vessel.CoM, optimalDistance, proximityHitColliders, layerMask);
+                            var hitCount = Physics.OverlapSphereNonAlloc(warheadType == WarheadTypes.ContinuousRod? vessel.CoM -= VectorUtils.GetUpDirection(TargetPosition) * (GetBlastRadius() > 0 ? (DetonationDistance / 3) : 5) : vessel.CoM, optimalDistance, proximityHitColliders, layerMask);
                             if (hitCount == proximityHitColliders.Length)
                             {
                                 proximityHitColliders = Physics.OverlapSphere(vessel.CoM, optimalDistance, layerMask);

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -2070,7 +2070,7 @@ namespace BDArmory.Weapons.Missiles
             {
                 if (warheadType == WarheadTypes.ContinuousRod) //Have CR missiles target slightly above target to ensure craft caught in planar blast AOE
                 {
-                    TargetPosition += VectorUtils.GetUpDirection(TargetPosition) * (blastRadius > 0 ? (blastRadius / 3) : 5);
+                    TargetPosition += VectorUtils.GetUpDirection(TargetPosition) * (blastRadius > 0 ? (DetonationDistance / 3) : 5);
                     //TargetPosition += VectorUtils.GetUpDirection(TargetPosition) * (blastRadius < 10? (blastRadius / 2) : 10);
                 }
                 DrawDebugLine(transform.position + (part.rb.velocity * Time.fixedDeltaTime), TargetPosition);


### PR DESCRIPTION
Have the checkProximity collision sphere subtract the offset added in AAMGuidance(), decrease offset slightly.
This might alleviate rakete's issue, it might not; without further info I'm debugging blind.
I found no issues with the IRST; sidewinders were properly locking in both AI and manual use cases, with and without the IRST. If we get more info, I can poke at this some more and we can get a fix out (if such is actually needed) in a later update.
