### PR TITLE
Single target Radar fix

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,7 +1,7 @@
 ﻿IMPROVEMENTS / FIXES
 - Weapons:
 	- Missiles:
-		- New 'canRelock' Field (Default: true) that sets if the Radar Missile on SARH guidance can acquire a new lock different the original target it was launched
+		- New 'canRelock' Field (Default: true), sets if SARH Radar-guided Missiles will re-lock onto the active radar target if the original radar lock is lost.
 
 v1.6.2.0
 IMPROVEMENTS / FIXES

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,4 +1,9 @@
-﻿v1.6.2.0
+﻿IMPROVEMENTS / FIXES
+- Weapons:
+	- Missiles:
+		- New 'canRelock' Field (Default: true) that sets if the Radar Missile on SARH guidance can acquire a new lock different the original target it was launched
+
+v1.6.2.0
 IMPROVEMENTS / FIXES
 - General:
 	- Fix TweakScale config for Typhoon engine (again).


### PR DESCRIPTION
A fix for the single target SARH guidance, so you can launch multiple missiles at multiple targets again, but also maintaining the ability to lock a new target, by unlocking the old one and locking the new one