### PR TITLE
Dynamic RCS

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -28,7 +28,7 @@
 	- Fix a minor bug in the tournament log parsing script where wins weren't always being counted for the score.
 	- Make the saving of backup tournaments optional (hidden setting in settings.cfg).
 - Detectors
-	- Add settings toggle ASPECTED_RCS that enables real-time RCS evaluation based on the target aircraft's azimuth and elevation relative to the radar evaluating it. Enable from the BDA settings menu under Missile & CM settings: "Real-Time Aspected RCS." The real-time aspected RCS is dependent on a weighted averaged against overall craft RCS, so lower overall craft RCS will lead to better aspected RCS. Overall craft RCS weighting in this average is dependent on ASPECTED_RCS_OVERALL_RCS_WEIGHT = 0.25 in the settings.cfg file.
+	- Add settings toggle ASPECTED_RCS that enables real-time RCS evaluation based on the target aircraft's azimuth and elevation relative to the radar evaluating it. Enable from the BDA settings menu under Missile & CM settings: "Real-Time Aspected RCS." The real-time aspected RCS is dependent on a weighted average against overall craft RCS, so lower overall craft RCS will lead to better aspected RCS. Overall craft RCS weighting in this average is dependent on ASPECTED_RCS_OVERALL_RCS_WEIGHT = 0.25 in the settings.cfg file. Final aspected RCS will be = (1-ASPECTED_RCS_OVERALL_RCS_WEIGHT) * [Aspected RCS] + ASPECTED_RCS_OVERALL_RCS_WEIGHT * [Overall RCS].
 - RWP:
 	- S5R10 special settings.
 

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -28,7 +28,7 @@
 	- Fix a minor bug in the tournament log parsing script where wins weren't always being counted for the score.
 	- Make the saving of backup tournaments optional (hidden setting in settings.cfg).
 - Detectors
-	- Add settings toggle ASPECTED_RCS that enables real-time RCS evaluation based on the target aircraft's azimuth and elevation relative to the radar evaluating it. Enable from the BDA settings menu under Missile & CM settings: "Real-Time Aspected RCS." The real-time aspected RCS is dependent on a weighted averaged against overall craft RCS, so lower overall craft RCS will lead to better aspected RCS. Overall craft RCS weighting in this average is dependent on ASPECTED_RCS_OVERALL_RCS_FACTOR = 0.25 in the settings.cfg file.
+	- Add settings toggle ASPECTED_RCS that enables real-time RCS evaluation based on the target aircraft's azimuth and elevation relative to the radar evaluating it. Enable from the BDA settings menu under Missile & CM settings: "Real-Time Aspected RCS." The real-time aspected RCS is dependent on a weighted averaged against overall craft RCS, so lower overall craft RCS will lead to better aspected RCS. Overall craft RCS weighting in this average is dependent on ASPECTED_RCS_OVERALL_RCS_WEIGHT = 0.25 in the settings.cfg file.
 - RWP:
 	- S5R10 special settings.
 

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -28,7 +28,7 @@
 	- Fix a minor bug in the tournament log parsing script where wins weren't always being counted for the score.
 	- Make the saving of backup tournaments optional (hidden setting in settings.cfg).
 - Detectors
-	- Add settings toggle ASPECTED_RCS that enables real-time RCS evaluation based on the target aircraft's azimuth and elevation relative to the radar evaluating it. Enable from the BDA settings menu under Missile & CM settings: "Real-Time Aspected RCS."
+	- Add settings toggle ASPECTED_RCS that enables real-time RCS evaluation based on the target aircraft's azimuth and elevation relative to the radar evaluating it. Enable from the BDA settings menu under Missile & CM settings: "Real-Time Aspected RCS." The real-time aspected RCS is dependent on a weighted averaged against overall craft RCS, so lower overall craft RCS will lead to better aspected RCS. Overall craft RCS weighting in this average is dependent on ASPECTED_RCS_OVERALL_RCS_FACTOR = 0.25 in the settings.cfg file.
 - RWP:
 	- S5R10 special settings.
 

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -24,6 +24,8 @@
 		- A script (parse_tournament_state.py) can convert the tournament.state file to proper JSON (tournament.json), but can not convert it back yet.
 	- Fix a minor bug in the tournament log parsing script where wins weren't always being counted for the score.
 	- Make the saving of backup tournaments optional (hidden setting in settings.cfg).
+- Detectors
+	- Add settings toggle ASPECTED_RCS that enables real-time RCS evaluation based on the target aircraft's azimuth and elevation relative to the radar evaluating it. Enable from the BDA settings menu under Missile & CM settings: "Real-Time Aspected RCS."
 - RWP:
 	- S5R10 special settings.
 

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -1169,6 +1169,7 @@ Localization
 
         //Missile & CM Settings
         #LOC_BDArmory_Settings_MissileCMToggle = Show Missile & Countermeasure Settings
+        #LOC_BDArmory_Settings_AspectedRCS = Real-Time Aspected RCS
         #LOC_BDArmory_Settings_AspectedIRSeekers = IR Occlusion Affects Missiles
         #LOC_BDArmory_Settings_FlareFactor = Max Flare Start Heat Mult.
         #LOC_BDArmory_Settings_ChaffFactor = Chaff Pos. Distortion Mult.

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -73,7 +73,7 @@ namespace BDArmory.Radar
         internal const float MISSILE_DEFAULT_LOCKABLE_RCS = 5f;
 
         // RCS Aspects
-        private static float[,] rcsAspects = new float[45, 2] {
+        private static float[,] rcsAspectsConstant = new float[45, 2] {
             { 2.000f, -6.133f},
             { 6.000f, 6.133f},
             { 10.000f, -14.311f},
@@ -120,8 +120,116 @@ namespace BDArmory.Radar
             { 174.000f, -17.378f},
             { 178.000f, 3.067f}
         };
-        private static int numAspects = rcsAspects.GetLength(0); // Number of aspects
-        public static float[,] worstRCSAspects = new float[3, 3]; // Worst three aspects
+        private static float[,] rcsAspectsRealTime = new float[107, 2] {
+            { 0f, 0f},
+            { 90f, 0f},
+            { 180f, 0f},
+            { 11.25f, 0f},
+            { 22.5f, 0f},
+            { 33.75f, 0f},
+            { 45f, 0f},
+            { 56.25f, 0f},
+            { 67.5f, 0f},
+            { 78.75f, 0f},
+            { 101.25f, 0f},
+            { 112.5f, 0f},
+            { 123.75f, 0f},
+            { 135f, 0f},
+            { 146.25f, 0f},
+            { 157.5f, 0f},
+            { 168.75f, 0f},
+            { 5.625f, 8.42105f},
+            { 16.875f, 8.42105f},
+            { 28.125f, 8.42105f},
+            { 39.375f, 8.42105f},
+            { 50.625f, 8.42105f},
+            { 61.875f, 8.42105f},
+            { 73.125f, 8.42105f},
+            { 84.375f, 8.42105f},
+            { 95.625f, 8.42105f},
+            { 106.875f, 8.42105f},
+            { 118.125f, 8.42105f},
+            { 129.375f, 8.42105f},
+            { 140.625f, 8.42105f},
+            { 151.875f, 8.42105f},
+            { 163.125f, 8.42105f},
+            { 174.375f, 8.42105f},
+            { 0f, 18.94737f},
+            { 22.5f, 18.94737f},
+            { 45f, 18.94737f},
+            { 67.5f, 18.94737f},
+            { 90f, 18.94737f},
+            { 112.5f, 18.94737f},
+            { 135f, 18.94737f},
+            { 157.5f, 18.94737f},
+            { 180f, 18.94737f},
+            { 11.25f, 31.57895f},
+            { 33.75f, 31.57895f},
+            { 56.25f, 31.57895f},
+            { 78.75f, 31.57895f},
+            { 101.25f, 31.57895f},
+            { 123.75f, 31.57895f},
+            { 146.25f, 31.57895f},
+            { 168.75f, 31.57895f},
+            { 0f, 47.36842f},
+            { 45f, 47.36842f},
+            { 90f, 47.36842f},
+            { 135f, 47.36842f},
+            { 180f, 47.36842f},
+            { 22.5f, 66.31579f},
+            { 67.5f, 66.31579f},
+            { 112.5f, 66.31579f},
+            { 157.5f, 66.31579f},
+            { 0f, 90f},
+            { 90f, 90f},
+            { 180f, 90f},
+            { 5.625f, -8.42105f},
+            { 16.875f, -8.42105f},
+            { 28.125f, -8.42105f},
+            { 39.375f, -8.42105f},
+            { 50.625f, -8.42105f},
+            { 61.875f, -8.42105f},
+            { 73.125f, -8.42105f},
+            { 84.375f, -8.42105f},
+            { 95.625f, -8.42105f},
+            { 106.875f, -8.42105f},
+            { 118.125f, -8.42105f},
+            { 129.375f, -8.42105f},
+            { 140.625f, -8.42105f},
+            { 151.875f, -8.42105f},
+            { 163.125f, -8.42105f},
+            { 174.375f, -8.42105f},
+            { 0f, -18.94737f},
+            { 22.5f, -18.94737f},
+            { 45f, -18.94737f},
+            { 67.5f, -18.94737f},
+            { 90f, -18.94737f},
+            { 112.5f, -18.94737f},
+            { 135f, -18.94737f},
+            { 157.5f, -18.94737f},
+            { 180f, -18.94737f},
+            { 11.25f, -31.57895f},
+            { 33.75f, -31.57895f},
+            { 56.25f, -31.57895f},
+            { 78.75f, -31.57895f},
+            { 101.25f, -31.57895f},
+            { 123.75f, -31.57895f},
+            { 146.25f, -31.57895f},
+            { 168.75f, -31.57895f},
+            { 0f, -47.36842f},
+            { 45f, -47.36842f},
+            { 90f, -47.36842f},
+            { 135f, -47.36842f},
+            { 180f, -47.36842f},
+            { 22.5f, -66.31579f},
+            { 67.5f, -66.31579f},
+            { 112.5f, -66.31579f},
+            { 157.5f, -66.31579f},
+            { 0f, -90f},
+            { 90f, -90f},
+            { 180f, -90f},
+        };
+        public static float[,] editorRCSAspects = new float[3, 3]; // Worst three aspects
         static double[] rcsValues;
         static Color32[] pixels;
 
@@ -155,6 +263,114 @@ namespace BDArmory.Radar
             return ti;
         }
 
+        public static float GetVesselRadarSignatureAtAspect(TargetInfo ti, Vector3 radarPosition)
+        {
+            if (ti.radarSignatureMatrix is null)
+                return ti.radarBaseSignature;
+            
+            float signatureAtAspect;
+            float[,] rcsMatrix = ti.radarSignatureMatrix;
+
+            Vector3 directionOfRadar = radarPosition - ti.Vessel.ReferenceTransform.position;
+            Vector3 azComponent = Vector3.ProjectOnPlane(directionOfRadar, ti.Vessel.ReferenceTransform.forward);
+            Vector3 elComponent = Vector3.ProjectOnPlane(directionOfRadar, ti.Vessel.ReferenceTransform.right);
+
+            float azAngle = Mathf.Abs(Vector3.SignedAngle(ti.Vessel.ReferenceTransform.up, azComponent, ti.Vessel.ReferenceTransform.forward));
+            float elAngle = Vector3.SignedAngle(ti.Vessel.ReferenceTransform.up, elComponent, -ti.Vessel.ReferenceTransform.right);
+
+            if (elAngle > 90f)
+                elAngle = 180f - elAngle;
+            else if (elAngle < -90f)
+                elAngle = -180f - elAngle;
+
+            // Find the three closest evaluated az/el RCS pairs and convert to barycentric coordinates for triangular interpolation
+            // Using triangular interpolation so we don't need a perfect grid of az/el RCS pairs, which would drive up the time for RCS snapshots
+            // The below code could probably be re-written in a cleaner way
+            // --------------------------------------------------------------------------------
+            float x1 = 0f;
+            float y1 = 0f;
+            float d1 = float.MaxValue;
+            float w1 = 0f;
+            float x2 = 0f;
+            float y2 = 0f;
+            float d2 = float.MaxValue;
+            float w2 = 0f;
+            float x3 = 0f;
+            float y3 = 0f;
+            float d3 = float.MaxValue;
+            float w3 = 0f;
+            float rcs1 = 0f;
+            float rcs2 = 0f;
+            float rcs3 = 0f;
+
+            for (int i = 0; i < rcsMatrix.GetLength(0) ; i++)
+            {
+                float sqrDist = (rcsMatrix[i, 0] - azAngle) * (rcsMatrix[i, 0] - azAngle) + (rcsMatrix[i, 1] - elAngle) * (rcsMatrix[i, 1] - elAngle);
+
+                if (sqrDist < d3)
+                {
+                    if (sqrDist < d2)
+                    {
+                        if (sqrDist < d1)
+                        {
+                            d3 = d2;
+                            x3 = x2;
+                            y3 = y2;
+                            rcs3 = rcs2;
+
+                            d2 = d1;
+                            x2 = x1;
+                            y2 = y1;
+                            rcs2 = rcs1;
+
+                            d1 = sqrDist;
+                            x1 = rcsMatrix[i, 0];
+                            y1 = rcsMatrix[i, 1];
+                            rcs1 = rcsMatrix[i, 2];
+                        }
+                        else
+                        {
+                            d3 = d2;
+                            x3 = x2;
+                            y3 = y2;
+                            rcs3 = rcs2;
+
+                            d2 = sqrDist;
+                            x2 = rcsMatrix[i, 0];
+                            y2 = rcsMatrix[i, 1];
+                            rcs2 = rcsMatrix[i, 2];
+                        }
+                    }
+                    else
+                    {
+                        d3 = sqrDist;
+                        x3 = rcsMatrix[i, 0];
+                        y3 = rcsMatrix[i, 1];
+                        rcs3 = rcsMatrix[i, 2];
+                    }
+                }
+            }
+            // --------------------------------------------------------------------------------
+
+            // Compute interpolation weights using barycentric coordinates
+            w1 = ((y2 - y3) * (azAngle - x3) + (x3 - x2) * (elAngle - y3)) / ((y2 - y3) * (x1 - x3) + (x3 - x2) * (y1 - y3));
+            w2 = ((y3 - y1) * (azAngle - x3) + (x1 - x3) * (elAngle - y3)) / ((y2 - y3) * (x1 - x3) + (x3 - x2) * (y1 - y3));
+            w3 = 1 - w1 - w2;
+
+            if ((w1 > 0) && (w2 > 0) && (w3 > 0)) // If point is inside triangle, weights will all be positive, if not inside triangle use nearest neighbor
+                signatureAtAspect = w1 * rcs1 + w2 * rcs2 + w3 * rcs3;
+            else
+                signatureAtAspect = rcs1;
+
+            // Incorporate any signature modification
+            signatureAtAspect *= ti.radarModifiedSignature / ti.radarBaseSignature;
+
+            if (BDArmorySettings.DEBUG_RADAR)
+                Debug.Log("[BDArmory.RadarUtils]: " + ti.Vessel.vesselName + " signature of " + signatureAtAspect.ToString("0.00") + "m^2 at az/el " + azAngle.ToString("0.0") + "/" + elAngle.ToString("0.0") + " deg.");
+
+            return signatureAtAspect;
+        }
+
         /// <summary>
         /// Internal method: get a vessel base radar signature
         /// </summary>
@@ -181,11 +397,12 @@ namespace BDArmory.Radar
                         ti.radarBaseSignature = missile.missileRadarCrossSection;
 
                     ti.radarBaseSignatureNeedsUpdate = false;
+                    ti.radarSignatureMatrixNeedsUpdate = false;
                 }
             }
 
             // Run intensive RCS rendering if 1. It has not been done yet, 2. If the competition just started (capture vessel changes such as gear-raise or robotics)
-            if (force || ti.radarBaseSignature == -1 || ti.radarBaseSignatureNeedsUpdate)
+            if (force || ti.radarBaseSignature == -1 || ti.radarBaseSignatureNeedsUpdate || (BDArmorySettings.ASPECTED_RCS && ti.radarSignatureMatrixNeedsUpdate))
             {
                 // is it just some debris? then dont bother doing a real rcs rendering and just fake it with the parts mass
                 if (VesselModuleRegistry.ignoredVesselTypes.Contains(v.vesselType) || !v.IsControllable)
@@ -195,9 +412,10 @@ namespace BDArmory.Radar
                 else
                 {
                     // perform radar rendering to obtain base cross section
-                    ti.radarBaseSignature = RenderVesselRadarSnapshot(v, v.transform);
+                    ti = RenderVesselRadarSnapshot(v, v.transform, ti);
                 }
 
+                ti.radarSignatureMatrixNeedsUpdate = BDArmorySettings.ASPECTED_RCS ? false : ti.radarSignatureMatrixNeedsUpdate;
                 ti.radarBaseSignatureNeedsUpdate = false;
                 ti.alreadyScheduledRCSUpdate = false;
                 ti.radarMassAtUpdate = v.GetTotalMass();
@@ -254,12 +472,17 @@ namespace BDArmory.Radar
         ///         and there we dont have a VESSEL, only a SHIPCONSTRUCT, so the EditorRcSWindow passes the transform separately.
         /// </summary>
         /// <param name="inEditorZoom">when true, we try to make the rendered vessel fill the rendertexture completely, for a better detailed view. This does skew the computed cross section, so it is only for a good visual in editor!</param>
-        public static float RenderVesselRadarSnapshot(Vessel v, Transform t, bool inEditorZoom = false)
+        public static TargetInfo RenderVesselRadarSnapshot(Vessel v, Transform t, TargetInfo ti = null, bool inEditorZoom = false)
         {
             if (VesselModuleRegistry.ignoredVesselTypes.Contains(v.vesselType)) Debug.LogError($"[BDArmory.RadarUtils]: Rendering radar snapshot of {v.vesselName}, which should be being ignored!");
+            int numAspects = (BDArmorySettings.ASPECTED_RCS) ? rcsAspectsRealTime.GetLength(0) : rcsAspectsConstant.GetLength(0); // Number of aspects
+            float[,] rcsAspects = new float[numAspects, 2];
+            rcsAspects = (BDArmorySettings.ASPECTED_RCS) ? rcsAspectsRealTime : rcsAspectsConstant;
+            float[,] rcsMatrix = new float[numAspects, 3];
             const float radarDistance = 1000f;
             const float radarFOV = 2.0f;
             Vector3 presentationPosition = -t.forward * radarDistance;
+            rcsTotal = 0;
 
             SetupResources();
 
@@ -313,15 +536,20 @@ namespace BDArmory.Radar
                 if (HighLogic.LoadedSceneIsFlight)
                     v.SetPosition(v.transform.position - presentationPosition);
 
-                return 0f;
+                if (ti is not null)
+                {
+                    ti.radarBaseSignature = 0f;
+                    ti.radarSignatureMatrix = null;
+                }
+
+                return ti;
             }
 
             float rcsVariable = 0f;
-            if (worstRCSAspects is null) worstRCSAspects = new float[3, 3];
-            Array.Clear(worstRCSAspects, 0, 9);
+            if (editorRCSAspects is null) editorRCSAspects = new float[3, 3];
+            Array.Clear(editorRCSAspects, 0, 9);
             if (rcsValues is null) rcsValues = new double[numAspects];
             Array.Clear(rcsValues, 0, numAspects);
-            rcsTotal = 0;
             Vector3 aspect;
 
             // Loop through all aspects
@@ -349,38 +577,46 @@ namespace BDArmory.Radar
                 rcsVariable /= RCS_NORMALIZATION_FACTOR;
                 rcsValues[i] = (double)rcsVariable;
 
+                // Add values to RCS Matrix for real-time evaluation
+                rcsMatrix[i, 0] = rcsAspects[i, 0];
+                rcsMatrix[i, 1] = rcsAspects[i, 1];
+                rcsMatrix[i, 2] = rcsVariable;
+
                 // Remember worst three RCS aspects to display in editor
                 if (inEditorZoom)
                 {
-                    if (rcsVariable > worstRCSAspects[0, 2])
+                    if ((!BDArmorySettings.ASPECTED_RCS) || (BDArmorySettings.ASPECTED_RCS && i <= 2)) // Use worst aspects by default, for aspected RCS use first three evaluated aspects
                     {
-                        worstRCSAspects[2, 0] = worstRCSAspects[1, 0];
-                        worstRCSAspects[2, 1] = worstRCSAspects[1, 1];
-                        worstRCSAspects[2, 2] = worstRCSAspects[1, 2];
+                        if (rcsVariable > editorRCSAspects[0, 2])
+                        {
+                            editorRCSAspects[2, 0] = editorRCSAspects[1, 0];
+                            editorRCSAspects[2, 1] = editorRCSAspects[1, 1];
+                            editorRCSAspects[2, 2] = editorRCSAspects[1, 2];
 
-                        worstRCSAspects[1, 0] = worstRCSAspects[0, 0];
-                        worstRCSAspects[1, 1] = worstRCSAspects[0, 1];
-                        worstRCSAspects[1, 2] = worstRCSAspects[0, 2];
+                            editorRCSAspects[1, 0] = editorRCSAspects[0, 0];
+                            editorRCSAspects[1, 1] = editorRCSAspects[0, 1];
+                            editorRCSAspects[1, 2] = editorRCSAspects[0, 2];
 
-                        worstRCSAspects[0, 0] = rcsAspects[i, 0];
-                        worstRCSAspects[0, 1] = rcsAspects[i, 1];
-                        worstRCSAspects[0, 2] = rcsVariable;
-                    }
-                    else if (rcsVariable > worstRCSAspects[1, 2])
-                    {
-                        worstRCSAspects[2, 0] = worstRCSAspects[1, 0];
-                        worstRCSAspects[2, 1] = worstRCSAspects[1, 1];
-                        worstRCSAspects[2, 2] = worstRCSAspects[1, 2];
+                            editorRCSAspects[0, 0] = rcsAspects[i, 0];
+                            editorRCSAspects[0, 1] = rcsAspects[i, 1];
+                            editorRCSAspects[0, 2] = rcsVariable;
+                        }
+                        else if (rcsVariable > editorRCSAspects[1, 2])
+                        {
+                            editorRCSAspects[2, 0] = editorRCSAspects[1, 0];
+                            editorRCSAspects[2, 1] = editorRCSAspects[1, 1];
+                            editorRCSAspects[2, 2] = editorRCSAspects[1, 2];
 
-                        worstRCSAspects[1, 0] = rcsAspects[i, 0];
-                        worstRCSAspects[1, 1] = rcsAspects[i, 1];
-                        worstRCSAspects[1, 2] = rcsVariable;
-                    }
-                    else if (rcsVariable > worstRCSAspects[2, 2])
-                    {
-                        worstRCSAspects[2, 0] = rcsAspects[i, 0];
-                        worstRCSAspects[2, 1] = rcsAspects[i, 1];
-                        worstRCSAspects[2, 2] = rcsVariable;
+                            editorRCSAspects[1, 0] = rcsAspects[i, 0];
+                            editorRCSAspects[1, 1] = rcsAspects[i, 1];
+                            editorRCSAspects[1, 2] = rcsVariable;
+                        }
+                        else if (rcsVariable > editorRCSAspects[2, 2])
+                        {
+                            editorRCSAspects[2, 0] = rcsAspects[i, 0];
+                            editorRCSAspects[2, 1] = rcsAspects[i, 1];
+                            editorRCSAspects[2, 2] = rcsVariable;
+                        }
                     }
                 }
 
@@ -398,12 +634,12 @@ namespace BDArmory.Radar
             if (inEditorZoom)
             {
                 // Determine camera vectors for aspects
-                Vector3 aspect1 = Vector3.RotateTowards(t.up, -t.up, worstRCSAspects[0, 0] / 180f * Mathf.PI, 0);
-                aspect1 = Vector3.RotateTowards(aspect1, Vector3.Cross(t.right, t.up), -worstRCSAspects[0, 1] / 180f * Mathf.PI, 0);
-                Vector3 aspect2 = Vector3.RotateTowards(t.up, -t.up, worstRCSAspects[1, 0] / 180f * Mathf.PI, 0);
-                aspect2 = Vector3.RotateTowards(aspect2, Vector3.Cross(t.right, t.up), -worstRCSAspects[1, 1] / 180f * Mathf.PI, 0);
-                Vector3 aspect3 = Vector3.RotateTowards(t.up, -t.up, worstRCSAspects[2, 0] / 180f * Mathf.PI, 0);
-                aspect3 = Vector3.RotateTowards(aspect3, Vector3.Cross(t.right, t.up), -worstRCSAspects[2, 1] / 180f * Mathf.PI, 0);
+                Vector3 aspect1 = Vector3.RotateTowards(t.up, -t.up, editorRCSAspects[0, 0] / 180f * Mathf.PI, 0);
+                aspect1 = Vector3.RotateTowards(aspect1, Vector3.Cross(t.right, t.up), -editorRCSAspects[0, 1] / 180f * Mathf.PI, 0);
+                Vector3 aspect2 = Vector3.RotateTowards(t.up, -t.up, editorRCSAspects[1, 0] / 180f * Mathf.PI, 0);
+                aspect2 = Vector3.RotateTowards(aspect2, Vector3.Cross(t.right, t.up), -editorRCSAspects[1, 1] / 180f * Mathf.PI, 0);
+                Vector3 aspect3 = Vector3.RotateTowards(t.up, -t.up, editorRCSAspects[2, 0] / 180f * Mathf.PI, 0);
+                aspect3 = Vector3.RotateTowards(aspect3, Vector3.Cross(t.right, t.up), -editorRCSAspects[2, 1] / 180f * Mathf.PI, 0);
 
                 // Render three highest aspects
                 RenderSinglePass(t, inEditorZoom, aspect1, vesselbounds, radarDistance, radarFOV, rcsRendering1, drawTexture1);
@@ -437,7 +673,13 @@ namespace BDArmory.Radar
                 Debug.Log($"[BDArmory.RadarUtils]: - Vessel all-aspect rcs is: rcsTotal: {rcsTotal}");
             }
 
-            return rcsTotal;
+            if (ti is not null)
+            {
+                ti.radarBaseSignature = rcsTotal;
+                ti.radarSignatureMatrix = rcsMatrix;
+            }
+
+            return ti;
         }
 
         // Used to calculate third quartile for RCS dataset
@@ -880,7 +1122,7 @@ namespace BDArmory.Radar
 
                         // get vessel's radar signature
                         TargetInfo ti = GetVesselRadarSignature(loadedvessels.Current);
-                        float signature = ti.radarModifiedSignature;
+                        float signature = (BDArmorySettings.ASPECTED_RCS) ? GetVesselRadarSignatureAtAspect(ti, ray.origin) : ti.radarModifiedSignature;
                         signature *= GetRadarGroundClutterModifier(radar.radarGroundClutterFactor, radar.referenceTransform, ray.origin, loadedvessels.Current.CoM, ti);
                         signature *= GetStandoffJammingModifier(radar.vessel, radar.weaponManager.Team, ray.origin, loadedvessels.Current, signature);
                         // no ecm lockbreak factor here
@@ -964,7 +1206,7 @@ namespace BDArmory.Radar
                         float signature = 10f;
                         if (ti != null)
                         {
-                            signature = ti.radarModifiedSignature;
+                            signature = (BDArmorySettings.ASPECTED_RCS) ? GetVesselRadarSignatureAtAspect(ti, ray.origin) : ti.radarModifiedSignature;
                             // no ground clutter modifier for missiles
                             signature *= ti.radarLockbreakFactor;    //multiply lockbreak factor from active ecm
                         }                                                                 //do not multiply chaff factor here
@@ -1056,9 +1298,9 @@ namespace BDArmory.Radar
 
                         // get vessel's radar signature
                         TargetInfo ti = GetVesselRadarSignature(loadedvessels.Current);
-                        float signature = ti.radarModifiedSignature;
-                            //do not multiply chaff factor here
-                            signature *= GetRadarGroundClutterModifier(radar.radarGroundClutterFactor, referenceTransform, position, loadedvessels.Current.CoM, ti);
+                        float signature = (BDArmorySettings.ASPECTED_RCS) ? GetVesselRadarSignatureAtAspect(ti, position) : ti.radarModifiedSignature;
+                        //do not multiply chaff factor here
+                        signature *= GetRadarGroundClutterModifier(radar.radarGroundClutterFactor, referenceTransform, position, loadedvessels.Current.CoM, ti);
 
                         // evaluate range
                         float distance = (loadedvessels.Current.CoM - position).magnitude / 1000f;                                      //TODO: Performance! better if we could switch to sqrMagnitude...
@@ -1184,7 +1426,7 @@ namespace BDArmory.Radar
 
                 // get vessel's radar signature
                 TargetInfo ti = GetVesselRadarSignature(lockedVessel);
-                float signature = ti.radarModifiedSignature;
+                float signature = (BDArmorySettings.ASPECTED_RCS) ? GetVesselRadarSignatureAtAspect(ti, ray.origin) : ti.radarModifiedSignature;
                 signature *= GetRadarGroundClutterModifier(radar.radarGroundClutterFactor, radar.referenceTransform, ray.origin, lockedVessel.CoM, ti);
                 signature *= ti.radarLockbreakFactor;    //multiply lockbreak factor from active ecm
                 if (radar.weaponManager is not null) signature *= GetStandoffJammingModifier(radar.vessel, radar.weaponManager.Team, ray.origin, lockedVessel, signature);

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -364,7 +364,7 @@ namespace BDArmory.Radar
                 signatureAtAspect = rcs1;
 
             // Take weighted average of signature at aspect and overall signature to prevent non-stealthy craft from being overly stealthy in a single aspect, but also reduce impact of non-ideal aspects
-            signatureAtAspect = signatureAtAspect * (1 - BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_FACTOR) + ti.radarBaseSignature * BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_FACTOR;
+            signatureAtAspect = signatureAtAspect * (1 - BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT) + ti.radarBaseSignature * BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT;
 
             // Incorporate any signature modification
             signatureAtAspect *= ti.radarModifiedSignature / ti.radarBaseSignature;

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -139,96 +139,97 @@ namespace BDArmory.Radar
             { 157.5f, 0f},
             { 168.75f, 0f},
             { 5.625f, 8.42105f},
-            { 16.875f, 8.42105f},
-            { 28.125f, 8.42105f},
-            { 39.375f, 8.42105f},
-            { 50.625f, 8.42105f},
-            { 61.875f, 8.42105f},
-            { 73.125f, 8.42105f},
-            { 84.375f, 8.42105f},
-            { 95.625f, 8.42105f},
-            { 106.875f, 8.42105f},
-            { 118.125f, 8.42105f},
-            { 129.375f, 8.42105f},
-            { 140.625f, 8.42105f},
-            { 151.875f, 8.42105f},
-            { 163.125f, 8.42105f},
-            { 174.375f, 8.42105f},
-            { 0f, 18.94737f},
-            { 22.5f, 18.94737f},
-            { 45f, 18.94737f},
-            { 67.5f, 18.94737f},
-            { 90f, 18.94737f},
-            { 112.5f, 18.94737f},
-            { 135f, 18.94737f},
-            { 157.5f, 18.94737f},
-            { 180f, 18.94737f},
-            { 11.25f, 31.57895f},
-            { 33.75f, 31.57895f},
-            { 56.25f, 31.57895f},
-            { 78.75f, 31.57895f},
-            { 101.25f, 31.57895f},
-            { 123.75f, 31.57895f},
-            { 146.25f, 31.57895f},
-            { 168.75f, 31.57895f},
-            { 0f, 47.36842f},
-            { 45f, 47.36842f},
-            { 90f, 47.36842f},
-            { 135f, 47.36842f},
-            { 180f, 47.36842f},
-            { 22.5f, 66.31579f},
-            { 67.5f, 66.31579f},
-            { 112.5f, 66.31579f},
-            { 157.5f, 66.31579f},
-            { 0f, 90f},
-            { 90f, 90f},
-            { 180f, 90f},
             { 5.625f, -8.42105f},
+            { 16.875f, 8.42105f},
             { 16.875f, -8.42105f},
+            { 28.125f, 8.42105f},
             { 28.125f, -8.42105f},
+            { 39.375f, 8.42105f},
             { 39.375f, -8.42105f},
+            { 50.625f, 8.42105f},
             { 50.625f, -8.42105f},
+            { 61.875f, 8.42105f},
             { 61.875f, -8.42105f},
+            { 73.125f, 8.42105f},
             { 73.125f, -8.42105f},
+            { 84.375f, 8.42105f},
             { 84.375f, -8.42105f},
+            { 95.625f, 8.42105f},
             { 95.625f, -8.42105f},
+            { 106.875f, 8.42105f},
             { 106.875f, -8.42105f},
+            { 118.125f, 8.42105f},
             { 118.125f, -8.42105f},
+            { 129.375f, 8.42105f},
             { 129.375f, -8.42105f},
+            { 140.625f, 8.42105f},
             { 140.625f, -8.42105f},
+            { 151.875f, 8.42105f},
             { 151.875f, -8.42105f},
+            { 163.125f, 8.42105f},
             { 163.125f, -8.42105f},
+            { 174.375f, 8.42105f},
             { 174.375f, -8.42105f},
+            { 0f, 18.94737f},
             { 0f, -18.94737f},
+            { 22.5f, 18.94737f},
             { 22.5f, -18.94737f},
+            { 45f, 18.94737f},
             { 45f, -18.94737f},
+            { 67.5f, 18.94737f},
             { 67.5f, -18.94737f},
+            { 90f, 18.94737f},
             { 90f, -18.94737f},
+            { 112.5f, 18.94737f},
             { 112.5f, -18.94737f},
+            { 135f, 18.94737f},
             { 135f, -18.94737f},
+            { 157.5f, 18.94737f},
             { 157.5f, -18.94737f},
+            { 180f, 18.94737f},
             { 180f, -18.94737f},
+            { 11.25f, 31.57895f},
             { 11.25f, -31.57895f},
+            { 33.75f, 31.57895f},
             { 33.75f, -31.57895f},
+            { 56.25f, 31.57895f},
             { 56.25f, -31.57895f},
+            { 78.75f, 31.57895f},
             { 78.75f, -31.57895f},
+            { 101.25f, 31.57895f},
             { 101.25f, -31.57895f},
+            { 123.75f, 31.57895f},
             { 123.75f, -31.57895f},
+            { 146.25f, 31.57895f},
             { 146.25f, -31.57895f},
+            { 168.75f, 31.57895f},
             { 168.75f, -31.57895f},
+            { 0f, 47.36842f},
             { 0f, -47.36842f},
+            { 45f, 47.36842f},
             { 45f, -47.36842f},
+            { 90f, 47.36842f},
             { 90f, -47.36842f},
+            { 135f, 47.36842f},
             { 135f, -47.36842f},
+            { 180f, 47.36842f},
             { 180f, -47.36842f},
+            { 22.5f, 66.31579f},
             { 22.5f, -66.31579f},
+            { 67.5f, 66.31579f},
             { 67.5f, -66.31579f},
+            { 112.5f, 66.31579f},
             { 112.5f, -66.31579f},
+            { 157.5f, 66.31579f},
             { 157.5f, -66.31579f},
+            { 0f, 90f},
             { 0f, -90f},
+            { 90f, 90f},
             { 90f, -90f},
+            { 180f, 90f},
             { 180f, -90f},
         };
+        private static int numAspectsForOverallRTEval = 83; // Use the first N rows of rcsAspectsRealTime for evaluating overall craft RCS
         public static float[,] editorRCSAspects = new float[3, 3]; // Worst three aspects
         static double[] rcsValues;
         static Color32[] pixels;
@@ -361,6 +362,9 @@ namespace BDArmory.Radar
                 signatureAtAspect = w1 * rcs1 + w2 * rcs2 + w3 * rcs3;
             else
                 signatureAtAspect = rcs1;
+
+            // Take weighted average of signature at aspect and overall signature to prevent non-stealthy craft from being overly stealthy in a single aspect, but also reduce impact of non-ideal aspects
+            signatureAtAspect = signatureAtAspect * (1 - BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_FACTOR) + ti.radarBaseSignature * BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_FACTOR;
 
             // Incorporate any signature modification
             signatureAtAspect *= ti.radarModifiedSignature / ti.radarBaseSignature;
@@ -548,7 +552,10 @@ namespace BDArmory.Radar
             float rcsVariable = 0f;
             if (editorRCSAspects is null) editorRCSAspects = new float[3, 3];
             Array.Clear(editorRCSAspects, 0, 9);
-            if (rcsValues is null) rcsValues = new double[numAspects];
+            if (rcsValues is null)
+                rcsValues = new double[numAspects];
+            else
+                Array.Resize(ref rcsValues, numAspects);
             Array.Clear(rcsValues, 0, numAspects);
             Vector3 aspect;
 
@@ -627,8 +634,13 @@ namespace BDArmory.Radar
                 }
             }
 
+            // If dynamic aspects RCS is enabled, use a subset of the evaluated RCS values for the total RCS calc
+            if (BDArmorySettings.ASPECTED_RCS)
+                Array.Resize(ref rcsValues, numAspectsForOverallRTEval);
+
             // Use third quartile for the total RCS (gives better results than average)
             rcsTotal = (float)Quartile(rcsValues, 3);
+
 
             // If we are in the editor, render the three highest RCS aspects
             if (inEditorZoom)

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -390,7 +390,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static bool MISSILE_CM_SETTING_TOGGLE = false;
         [BDAPersistentSettingsField] public static bool VARIABLE_MISSILE_VISIBILITY = false;        //missile visual detection range dependant on boost/cruise/post-thrust state
         [BDAPersistentSettingsField] public static bool ASPECTED_RCS = false;                   //RCS evaluated in real-time based on aircraft's aspect
-        [BDAPersistentSettingsField] public static float ASPECTED_RCS_OVERALL_RCS_WEIGHT = 0.25f;   //When ASPECTED_RCS = true, final aspected RCS will be = [Aspected] * (1-ASPECTED_RCS_OVERALL_RCS_WEIGHT) + [Overall] * ASPECTED_RCS_OVERALL_RCS_WEIGHT
+        [BDAPersistentSettingsField] public static float ASPECTED_RCS_OVERALL_RCS_WEIGHT = 0.25f;   //When ASPECTED_RCS = true, final aspected RCS will be = (1-ASPECTED_RCS_OVERALL_RCS_WEIGHT) * [Aspected RCS] + ASPECTED_RCS_OVERALL_RCS_WEIGHT * [Overall RCS]
         [BDAPersistentSettingsField] public static bool ASPECTED_IR_SEEKERS = false;                //IR Missiles will be subject to thermal occlusion mechanic
         [BDAPersistentSettingsField] public static bool DUMB_IR_SEEKERS = false;                  // IR missiles will go after hottest thing they can see
         [BDAPersistentSettingsField] public static float FLARE_FACTOR = 1.6f;                       // Change this to make flares more or less effective, values close to or below 1.0 will cause flares to fail to decoy often

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -389,6 +389,7 @@ namespace BDArmory.Settings
         // Missile & Countermeasure Settings
         [BDAPersistentSettingsField] public static bool MISSILE_CM_SETTING_TOGGLE = false;
         [BDAPersistentSettingsField] public static bool VARIABLE_MISSILE_VISIBILITY = false;        //missile visual detection range dependant on boost/cruise/post-thrust state
+        [BDAPersistentSettingsField] public static bool ASPECTED_RCS = false;                   //RCS evaluated in real-time based on aircraft's aspect
         [BDAPersistentSettingsField] public static bool ASPECTED_IR_SEEKERS = false;                //IR Missiles will be subject to thermal occlusion mechanic
         [BDAPersistentSettingsField] public static bool DUMB_IR_SEEKERS = false;                  // IR missiles will go after hottest thing they can see
         [BDAPersistentSettingsField] public static float FLARE_FACTOR = 1.6f;                       // Change this to make flares more or less effective, values close to or below 1.0 will cause flares to fail to decoy often

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -390,6 +390,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static bool MISSILE_CM_SETTING_TOGGLE = false;
         [BDAPersistentSettingsField] public static bool VARIABLE_MISSILE_VISIBILITY = false;        //missile visual detection range dependant on boost/cruise/post-thrust state
         [BDAPersistentSettingsField] public static bool ASPECTED_RCS = false;                   //RCS evaluated in real-time based on aircraft's aspect
+        [BDAPersistentSettingsField] public static float ASPECTED_RCS_OVERALL_RCS_FACTOR = 0.25f;   //When ASPECTED_RCS = true, final aspected RCS will be = [Aspected] * (1-ASPECTED_RCS_OVERALL_RCS_FACTOR) + [Overall] * ASPECTED_RCS_OVERALL_RCS_FACTOR
         [BDAPersistentSettingsField] public static bool ASPECTED_IR_SEEKERS = false;                //IR Missiles will be subject to thermal occlusion mechanic
         [BDAPersistentSettingsField] public static bool DUMB_IR_SEEKERS = false;                  // IR missiles will go after hottest thing they can see
         [BDAPersistentSettingsField] public static float FLARE_FACTOR = 1.6f;                       // Change this to make flares more or less effective, values close to or below 1.0 will cause flares to fail to decoy often

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -390,7 +390,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static bool MISSILE_CM_SETTING_TOGGLE = false;
         [BDAPersistentSettingsField] public static bool VARIABLE_MISSILE_VISIBILITY = false;        //missile visual detection range dependant on boost/cruise/post-thrust state
         [BDAPersistentSettingsField] public static bool ASPECTED_RCS = false;                   //RCS evaluated in real-time based on aircraft's aspect
-        [BDAPersistentSettingsField] public static float ASPECTED_RCS_OVERALL_RCS_FACTOR = 0.25f;   //When ASPECTED_RCS = true, final aspected RCS will be = [Aspected] * (1-ASPECTED_RCS_OVERALL_RCS_FACTOR) + [Overall] * ASPECTED_RCS_OVERALL_RCS_FACTOR
+        [BDAPersistentSettingsField] public static float ASPECTED_RCS_OVERALL_RCS_WEIGHT = 0.25f;   //When ASPECTED_RCS = true, final aspected RCS will be = [Aspected] * (1-ASPECTED_RCS_OVERALL_RCS_WEIGHT) + [Overall] * ASPECTED_RCS_OVERALL_RCS_WEIGHT
         [BDAPersistentSettingsField] public static bool ASPECTED_IR_SEEKERS = false;                //IR Missiles will be subject to thermal occlusion mechanic
         [BDAPersistentSettingsField] public static bool DUMB_IR_SEEKERS = false;                  // IR missiles will go after hottest thing they can see
         [BDAPersistentSettingsField] public static float FLARE_FACTOR = 1.6f;                       // Change this to make flares more or less effective, values close to or below 1.0 will cause flares to fail to decoy often

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -27,6 +27,8 @@ namespace BDArmory.Targeting
 
         public float radarBaseSignature = -1;
         public bool radarBaseSignatureNeedsUpdate = true;
+        public float[,] radarSignatureMatrix = null;
+        public bool radarSignatureMatrixNeedsUpdate = true;
         public float radarRCSReducedSignature;
         public float radarModifiedSignature;
         public float radarLockbreakFactor = 1;
@@ -257,6 +259,7 @@ namespace BDArmory.Targeting
                     alreadyScheduledRCSUpdate = true;
                     yield return new WaitForSeconds(1.0f);    // Wait for any explosions to finish
                     radarBaseSignatureNeedsUpdate = true;     // Update RCS if vessel mass changed by more than 2.5% after a part was lost
+                    radarSignatureMatrixNeedsUpdate = true;
                     if (BDArmorySettings.DEBUG_RADAR) Debug.Log("[BDArmory.TargetInfo]: RCS mass update triggered for " + vessel.vesselName + ", difference: " + (massPercentageDifference * 100f).ToString("0.0"));
                 }
             }

--- a/BDArmory/UI/BDAEditorAnalysisWindow.cs
+++ b/BDArmory/UI/BDAEditorAnalysisWindow.cs
@@ -178,9 +178,13 @@ namespace BDArmory.UI
             GUI.DrawTexture(new Rect(220, 70, 200, 200), RadarUtils.GetTexture2, ScaleMode.StretchToFill);
             GUI.DrawTexture(new Rect(430, 70, 200, 200), RadarUtils.GetTexture3, ScaleMode.StretchToFill);
 
-            GUI.Label(new Rect(10, 275, 200, 20), string.Format("{0:0.00}", RadarUtils.editorRCSAspects[0, 2]) + " m^2", BDArmorySetup.BDGuiSkin.label);
-            GUI.Label(new Rect(220, 275, 200, 20), string.Format("{0:0.00}", RadarUtils.editorRCSAspects[1, 2]) + " m^2", BDArmorySetup.BDGuiSkin.label);
-            GUI.Label(new Rect(430, 275, 200, 20), string.Format("{0:0.00}", RadarUtils.editorRCSAspects[2, 2]) + " m^2", BDArmorySetup.BDGuiSkin.label);
+            float editorUIRCS0 = (!Settings.BDArmorySettings.ASPECTED_RCS) ? RadarUtils.editorRCSAspects[0, 2] : (RadarUtils.editorRCSAspects[0, 2] * (1 - Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_FACTOR) + RadarUtils.rcsTotal *  Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_FACTOR);
+            float editorUIRCS1 = (!Settings.BDArmorySettings.ASPECTED_RCS) ? RadarUtils.editorRCSAspects[1, 2] : (RadarUtils.editorRCSAspects[1, 2] * (1 - Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_FACTOR) + RadarUtils.rcsTotal * Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_FACTOR);
+            float editorUIRCS2 = (!Settings.BDArmorySettings.ASPECTED_RCS) ? RadarUtils.editorRCSAspects[2, 2] : (RadarUtils.editorRCSAspects[2, 2] * (1 - Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_FACTOR) + RadarUtils.rcsTotal * Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_FACTOR);
+
+            GUI.Label(new Rect(10, 275, 200, 20), string.Format("{0:0.00}", editorUIRCS0) + " m^2", BDArmorySetup.BDGuiSkin.label);
+            GUI.Label(new Rect(220, 275, 200, 20), string.Format("{0:0.00}", editorUIRCS1) + " m^2", BDArmorySetup.BDGuiSkin.label);
+            GUI.Label(new Rect(430, 275, 200, 20), string.Format("{0:0.00}", editorUIRCS2) + " m^2", BDArmorySetup.BDGuiSkin.label);
 
             GUIStyle style = BDArmorySetup.BDGuiSkin.label;
             style.fontStyle = FontStyle.Bold;

--- a/BDArmory/UI/BDAEditorAnalysisWindow.cs
+++ b/BDArmory/UI/BDAEditorAnalysisWindow.cs
@@ -178,9 +178,9 @@ namespace BDArmory.UI
             GUI.DrawTexture(new Rect(220, 70, 200, 200), RadarUtils.GetTexture2, ScaleMode.StretchToFill);
             GUI.DrawTexture(new Rect(430, 70, 200, 200), RadarUtils.GetTexture3, ScaleMode.StretchToFill);
 
-            float editorUIRCS0 = (!Settings.BDArmorySettings.ASPECTED_RCS) ? RadarUtils.editorRCSAspects[0, 2] : (RadarUtils.editorRCSAspects[0, 2] * (1 - Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_FACTOR) + RadarUtils.rcsTotal *  Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_FACTOR);
-            float editorUIRCS1 = (!Settings.BDArmorySettings.ASPECTED_RCS) ? RadarUtils.editorRCSAspects[1, 2] : (RadarUtils.editorRCSAspects[1, 2] * (1 - Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_FACTOR) + RadarUtils.rcsTotal * Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_FACTOR);
-            float editorUIRCS2 = (!Settings.BDArmorySettings.ASPECTED_RCS) ? RadarUtils.editorRCSAspects[2, 2] : (RadarUtils.editorRCSAspects[2, 2] * (1 - Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_FACTOR) + RadarUtils.rcsTotal * Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_FACTOR);
+            float editorUIRCS0 = (!Settings.BDArmorySettings.ASPECTED_RCS) ? RadarUtils.editorRCSAspects[0, 2] : (RadarUtils.editorRCSAspects[0, 2] * (1 - Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT) + RadarUtils.rcsTotal *  Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT);
+            float editorUIRCS1 = (!Settings.BDArmorySettings.ASPECTED_RCS) ? RadarUtils.editorRCSAspects[1, 2] : (RadarUtils.editorRCSAspects[1, 2] * (1 - Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT) + RadarUtils.rcsTotal * Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT);
+            float editorUIRCS2 = (!Settings.BDArmorySettings.ASPECTED_RCS) ? RadarUtils.editorRCSAspects[2, 2] : (RadarUtils.editorRCSAspects[2, 2] * (1 - Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT) + RadarUtils.rcsTotal * Settings.BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT);
 
             GUI.Label(new Rect(10, 275, 200, 20), string.Format("{0:0.00}", editorUIRCS0) + " m^2", BDArmorySetup.BDGuiSkin.label);
             GUI.Label(new Rect(220, 275, 200, 20), string.Format("{0:0.00}", editorUIRCS1) + " m^2", BDArmorySetup.BDGuiSkin.label);

--- a/BDArmory/UI/BDAEditorAnalysisWindow.cs
+++ b/BDArmory/UI/BDAEditorAnalysisWindow.cs
@@ -17,7 +17,7 @@ namespace BDArmory.UI
         private ApplicationLauncherButton toolbarButton = null;
 
         private bool showRcsWindow = false;
-        private string windowTitle = "BDArmory Radar Cross Section Analysis (Worst Three Aspects)";
+        private string windowTitle = !Settings.BDArmorySettings.ASPECTED_RCS ? "BDArmory Radar Cross Section Analysis (Worst Three Aspects)" : "BDArmory Radar Cross Section Analysis (Three Aspects)";
         private Rect windowRect = new Rect(300, 150, 650, 500);
 
         private bool takeSnapshot = false;
@@ -166,9 +166,9 @@ namespace BDArmory.UI
                 HideToolbarGUI();
             }
 
-            GUI.Label(new Rect(10, 40, 200, 20), $"Az {RadarUtils.worstRCSAspects[0, 0].ToString("0")}, El {RadarUtils.worstRCSAspects[0, 1].ToString("0")}", BDArmorySetup.BDGuiSkin.box);
-            GUI.Label(new Rect(220, 40, 200, 20), $"Az {RadarUtils.worstRCSAspects[1, 0].ToString("0")}, El {RadarUtils.worstRCSAspects[1, 1].ToString("0")}", BDArmorySetup.BDGuiSkin.box);
-            GUI.Label(new Rect(430, 40, 200, 20), $"Az {RadarUtils.worstRCSAspects[2, 0].ToString("0")}, El {RadarUtils.worstRCSAspects[2, 1].ToString("0")}", BDArmorySetup.BDGuiSkin.box);
+            GUI.Label(new Rect(10, 40, 200, 20), $"Az {RadarUtils.editorRCSAspects[0, 0].ToString("0")}, El {RadarUtils.editorRCSAspects[0, 1].ToString("0")}", BDArmorySetup.BDGuiSkin.box);
+            GUI.Label(new Rect(220, 40, 200, 20), $"Az {RadarUtils.editorRCSAspects[1, 0].ToString("0")}, El {RadarUtils.editorRCSAspects[1, 1].ToString("0")}", BDArmorySetup.BDGuiSkin.box);
+            GUI.Label(new Rect(430, 40, 200, 20), $"Az {RadarUtils.editorRCSAspects[2, 0].ToString("0")}, El {RadarUtils.editorRCSAspects[2, 1].ToString("0")}", BDArmorySetup.BDGuiSkin.box);
 
             if (takeSnapshot)
                 takeRadarSnapshot();
@@ -178,9 +178,9 @@ namespace BDArmory.UI
             GUI.DrawTexture(new Rect(220, 70, 200, 200), RadarUtils.GetTexture2, ScaleMode.StretchToFill);
             GUI.DrawTexture(new Rect(430, 70, 200, 200), RadarUtils.GetTexture3, ScaleMode.StretchToFill);
 
-            GUI.Label(new Rect(10, 275, 200, 20), string.Format("{0:0.00}", RadarUtils.worstRCSAspects[0, 2]) + " m^2", BDArmorySetup.BDGuiSkin.label);
-            GUI.Label(new Rect(220, 275, 200, 20), string.Format("{0:0.00}", RadarUtils.worstRCSAspects[1, 2]) + " m^2", BDArmorySetup.BDGuiSkin.label);
-            GUI.Label(new Rect(430, 275, 200, 20), string.Format("{0:0.00}", RadarUtils.worstRCSAspects[2, 2]) + " m^2", BDArmorySetup.BDGuiSkin.label);
+            GUI.Label(new Rect(10, 275, 200, 20), string.Format("{0:0.00}", RadarUtils.editorRCSAspects[0, 2]) + " m^2", BDArmorySetup.BDGuiSkin.label);
+            GUI.Label(new Rect(220, 275, 200, 20), string.Format("{0:0.00}", RadarUtils.editorRCSAspects[1, 2]) + " m^2", BDArmorySetup.BDGuiSkin.label);
+            GUI.Label(new Rect(430, 275, 200, 20), string.Format("{0:0.00}", RadarUtils.editorRCSAspects[2, 2]) + " m^2", BDArmorySetup.BDGuiSkin.label);
 
             GUIStyle style = BDArmorySetup.BDGuiSkin.label;
             style.fontStyle = FontStyle.Bold;
@@ -392,7 +392,7 @@ namespace BDArmory.UI
             v.parts = EditorLogic.fetch.ship.Parts;
             v.vesselType = VesselType.Plane; // Tell KSP that it's not debris (which we ignore in the snapshot).
             // RadarUtils.RenderVesselRadarSnapshot(v, EditorLogic.RootPart.transform);  //first rendering for true RCS
-            RadarUtils.RenderVesselRadarSnapshot(v, EditorLogic.RootPart.transform, true);  //create renders
+            RadarUtils.RenderVesselRadarSnapshot(v, EditorLogic.RootPart.transform, null, true);  //create renders
             takeSnapshot = false;
 
             // get RCS reduction measures (stealth/low observability)

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -2916,7 +2916,11 @@ namespace BDArmory.UI
                     BDArmorySettings.MISSILE_CM_SETTING_TOGGLE = GUI.Toggle(SLineRect(++line), BDArmorySettings.MISSILE_CM_SETTING_TOGGLE, StringUtils.Localize("#LOC_BDArmory_Settings_MissileCMToggle"));
                     if (BDArmorySettings.MISSILE_CM_SETTING_TOGGLE)
                     {
+                        BDArmorySettings.ASPECTED_RCS = GUI.Toggle(SLineRect(++line, 1), BDArmorySettings.ASPECTED_RCS, StringUtils.Localize("#LOC_BDArmory_Settings_AspectedRCS"));
+                        
+                        GUI.Label(SLeftSliderRect(++line, 1), $"{StringUtils.Localize("#LOC_BDArmory_Settings_FlareFactor")}:  ({BDArmorySettings.FLARE_FACTOR})", leftLabel);
                         BDArmorySettings.ASPECTED_IR_SEEKERS = GUI.Toggle(SLineRect(++line, 1), BDArmorySettings.ASPECTED_IR_SEEKERS, StringUtils.Localize("#LOC_BDArmory_Settings_AspectedIRSeekers"));
+                        
                         GUI.Label(SLeftSliderRect(++line, 1), $"{StringUtils.Localize("#LOC_BDArmory_Settings_FlareFactor")}:  ({BDArmorySettings.FLARE_FACTOR})", leftLabel);
                         BDArmorySettings.FLARE_FACTOR = BDAMath.RoundToUnit(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.FLARE_FACTOR, 0f, 3f), 0.05f);
 


### PR DESCRIPTION
- Add settings toggle ASPECTED_RCS that enables real-time RCS evaluation based on the target aircraft's azimuth and elevation relative to the radar evaluating it. Enable from the BDA settings menu under Missile & CM settings: "Real-Time Aspected RCS." The real-time aspected RCS is dependent on a weighted averaged against overall craft RCS, so lower overall craft RCS will lead to better aspected RCS. Overall craft RCS weighting in this average is dependent on ASPECTED_RCS_OVERALL_RCS_WEIGHT = 0.25 in the settings.cfg file.