### PR TITLE
Local tourney NPC implementation framework

### DIFF
--- a/BDArmory/Competition/BDATournament.cs
+++ b/BDArmory/Competition/BDATournament.cs
@@ -121,6 +121,11 @@ namespace BDArmory.Competition
         public bool AddPlayer(string player, string fileName, int currentRound = 0)
         {
             if (playersToFileNames.ContainsKey(player)) return false; // They're already there.
+            if (CircularSpawning.Instance.NPCList.Contains(fileName))
+            {
+                Debug.Log($"[BDArmory.BDATournament]: Culling NPC {fileName} from scores.");
+                return false;
+            }
             if (!File.Exists(fileName)) { Debug.LogWarning($"[BDArmory.BDATournament]: {fileName} does not exist for {player}."); return false; }
             if (currentRound < 0) { Debug.LogWarning($"[BDArmory.BDATournament]: Invalid round {currentRound}, setting to 0."); currentRound = 0; }
             if (BDArmorySettings.DEBUG_COMPETITION) Debug.Log($"[BDArmory.BDATournament]: Adding {player} with file {fileName} in round {currentRound}");
@@ -1511,7 +1516,9 @@ namespace BDArmory.Competition
             competitionStarted = true;
             // Register all the active vessels as part of the tournament.
             foreach (var kvp in CircularSpawning.Instance.GetSpawnedVesselURLs())
-                tournamentState.scores.AddPlayer(kvp.Key, kvp.Value, roundIndex);
+            {
+                if (!CircularSpawning.Instance.NPCList.Contains(kvp.Value)) tournamentState.scores.AddPlayer(kvp.Key, kvp.Value, roundIndex);
+            }
             yield return new WaitWhile(() => TournamentCoordinator.Instance.IsRunning);
         }
 
@@ -1568,7 +1575,9 @@ namespace BDArmory.Competition
             competitionStarted = true;
             // Register all the active vessels as part of the tournament.
             foreach (var kvp in CircularSpawning.Instance.GetSpawnedVesselURLs())
-                tournamentState.scores.AddPlayer(kvp.Key, kvp.Value, roundIndex);
+            {
+                if (!CircularSpawning.Instance.NPCList.Contains(kvp.Value)) tournamentState.scores.AddPlayer(kvp.Key, kvp.Value, roundIndex);
+            }
             // Wait for the competition to finish.
             while (BDACompetitionMode.Instance.competitionIsActive)
                 yield return new WaitForSeconds(1);

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -362,6 +362,7 @@ Localization
         #LOC_BDArmory_Settings_TournamentDelayBetweenHeats = Delay Between Heats
         #LOC_BDArmory_Settings_TournamentTimeWarpBetweenRounds = TimeWarp Between Rounds
         #LOC_BDArmory_Settings_TournamentRounds = Rounds
+        #LOC_BDArmory_Settings_NPC_Count = NPC Count
         #LOC_BDArmory_Settings_TournamentVesselsPerHeat = Vessels Per Heat
         #LOC_BDArmory_Settings_TournamentVesselsPerTeam = Vessels Per Team Per Heat
         #LOC_BDArmory_Settings_TournamentTeamsPerHeat = Teams Per Heat

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -210,6 +210,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static bool NO_ENGINES = false;
         [BDAPersistentSettingsField] public static bool WAYPOINTS_MODE = false;         // Waypoint section of Vessel Spawner Window.
         [BDAPersistentSettingsField] public static string PINATA_NAME = "Pinata";
+        [BDAPersistentSettingsField] public static int NPC_COUNT = 0;
 
         //Battle Damage settings
         [BDAPersistentSettingsField] public static bool BATTLEDAMAGE_TOGGLE = false;    // Main battle damage toggle.

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -432,6 +432,9 @@ namespace BDArmory.UI
             // Ensure AutoSpawn folder exists.
             if (!Directory.Exists(Path.Combine(KSPUtil.ApplicationRootPath, "AutoSpawn")))
             { Directory.CreateDirectory(Path.Combine(KSPUtil.ApplicationRootPath, "AutoSpawn")); }
+            // Ensure AutoSpawn/NPC folder exists.
+            if (!Directory.Exists(Path.Combine(KSPUtil.ApplicationRootPath, "AutoSpawn", "NPC")))
+            { Directory.CreateDirectory(Path.Combine(KSPUtil.ApplicationRootPath, "AutoSpawn", "NPC")); }
             // Ensure GameData/Custom/Flags folder exists.
             if (!Directory.Exists(Path.Combine(KSPUtil.ApplicationRootPath, "GameData", "Custom", "Flags")))
             { Directory.CreateDirectory(Path.Combine(KSPUtil.ApplicationRootPath, "GameData", "Custom", "Flags")); }

--- a/BDArmory/UI/VesselSpawnerWindow.cs
+++ b/BDArmory/UI/VesselSpawnerWindow.cs
@@ -250,6 +250,7 @@ namespace BDArmory.UI
                     BDArmorySettings.VESSEL_SPAWN_NUMBER_OF_TEAMS,
                     (TournamentStyle)BDArmorySettings.TOURNAMENT_STYLE,
                     (TournamentRoundType)BDArmorySettings.TOURNAMENT_ROUND_TYPE
+                    //BDArmorySettings.NPC_Count // May break compat with older tourneys
                 );
             if (BDInputUtils.GetKeyDown(BDInputSettingsFields.TOURNAMENT_RUN))
                 BDATournament.Instance.RunTournament();
@@ -637,6 +638,9 @@ namespace BDArmory.UI
                     value = Mathf.RoundToInt(GUI.HorizontalSlider(SRightSliderRect(line), value, 1f, 37f));
                     BDArmorySettings.TOURNAMENT_ROUNDS = value <= 20 ? value : value <= 36 ? (value - 16) * 5 : BDArmorySettings.TOURNAMENT_ROUNDS_CUSTOM;
 
+                    GUI.Label(SLeftSliderRect(++line), $"{StringUtils.Localize("#LOC_BDArmory_Settings_NPC_Count")}: ({BDArmorySettings.NPC_COUNT})", leftLabel); // Delay between heats
+                    BDArmorySettings.NPC_COUNT = Mathf.RoundToInt(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.NPC_COUNT, 0f, 10));
+                    //Add window for setting pinata name/ NPC team?
                     if (BDArmorySettings.VESSEL_SPAWN_NUMBER_OF_TEAMS == 0) // FFA
                     {
                         GUI.Label(SLeftSliderRect(++line), $"{StringUtils.Localize("#LOC_BDArmory_Settings_TournamentVesselsPerHeat")}:  ({(BDArmorySettings.TOURNAMENT_VESSELS_PER_HEAT > 0 ? BDArmorySettings.TOURNAMENT_VESSELS_PER_HEAT.ToString() : (BDArmorySettings.TOURNAMENT_VESSELS_PER_HEAT == -1 ? "Auto" : "Inf"))})", leftLabel); // Vessels Per Heat

--- a/BDArmory/VesselSpawning/CircularSpawning.cs
+++ b/BDArmory/VesselSpawning/CircularSpawning.cs
@@ -177,6 +177,7 @@ namespace BDArmory.VesselSpawning
             bool PinataMode = false;
 
             int NPC_Count = 0;
+            NPCList.Clear();
             if (BDArmorySettings.NPC_COUNT > 0)
             {
                 var NPCFolder = Path.Combine(AutoSpawnPath, "NPC");
@@ -209,6 +210,7 @@ namespace BDArmory.VesselSpawning
                         if (!String.IsNullOrEmpty(BDArmorySettings.PINATA_NAME) && craftUrl.Contains(BDArmorySettings.PINATA_NAME)) PinataMode = true; //have separate Pinata and NPC support to allow both simultaneously?
                         spawnConfig.craftFiles.Add(craftUrl);
                         NPC_Count++;
+                        NPCList.Add(craftUrl);
                     }
                 }
                 if (!Directory.Exists(NPCFolder))

--- a/BDArmory/VesselSpawning/CircularSpawning.cs
+++ b/BDArmory/VesselSpawning/CircularSpawning.cs
@@ -175,13 +175,54 @@ namespace BDArmory.VesselSpawning
             int spawnedVesselCount = 0; // Reset our spawned vessel count.
             var spawnAirborne = spawnConfig.altitude > 10;
             bool PinataMode = false;
-            foreach (var craftUrl in spawnConfig.craftFiles)
+
+            int NPC_Count = 0;
+            if (BDArmorySettings.NPC_COUNT > 0)
             {
-                if (!String.IsNullOrEmpty(BDArmorySettings.PINATA_NAME) && craftUrl.Contains(BDArmorySettings.PINATA_NAME)) PinataMode = true;
+                var NPCFolder = Path.Combine(AutoSpawnPath, "NPC");
+                if (Directory.Exists(NPCFolder))
+                {
+                    List<string> NPCs = Directory.GetFiles(NPCFolder).Where(f => f.EndsWith(".craft")).ToList();
+                    if (NPCs.Count == 0)
+                    {
+                        LogMessage("Vessel spawning: found no NPC files in " + Path.Combine(AutoSpawnPath, "NPC"));
+                        vesselsSpawning = false;
+                        spawnFailureReason = SpawnFailureReason.NoCraft;
+                        SpawnUtils.RevertSpawnLocationCamera(true, true);
+                        yield break;
+                    }
+                    if (NPCs.Count > BDArmorySettings.NPC_COUNT)
+                    {
+                        NPCs.Shuffle();
+                        NPCs.RemoveRange(BDArmorySettings.NPC_COUNT, NPCs.Count - BDArmorySettings.NPC_COUNT);
+                    }
+                    if (NPCs.Count < BDArmorySettings.NPC_COUNT)
+                    {
+                        while (NPCs.Count < BDArmorySettings.NPC_COUNT)
+                        {
+                            NPCs.Add(NPCs[0]);
+                            NPCs.Shuffle();
+                        }
+                    }
+                    foreach (var craftUrl in NPCs) //Add in NPCs to spawn list
+                    {
+                        if (!String.IsNullOrEmpty(BDArmorySettings.PINATA_NAME) && craftUrl.Contains(BDArmorySettings.PINATA_NAME)) PinataMode = true; //have separate Pinata and NPC support to allow both simultaneously?
+                        spawnConfig.craftFiles.Add(craftUrl);
+                        NPC_Count++;
+                    }
+                }
+                if (!Directory.Exists(NPCFolder))
+                {
+                    LogMessage($"NPC spawn directory doesn't exist!");
+                    vesselsSpawning = false;
+                    spawnFailureReason = SpawnFailureReason.NoCraft;
+                    SpawnUtils.RevertSpawnLocationCamera(true, true);
+                    yield break;
+                }
             }
             var spawnDistance = spawnConfig.craftFiles.Count > 1 ? (spawnConfig.absDistanceOrFactor ? spawnConfig.distance : (spawnConfig.distance + spawnConfig.distance * (spawnConfig.craftFiles.Count - (PinataMode ? 1 : 0)))) : 0f; // If it's a single craft, spawn it at the spawn point.
 
-            LogMessage("Spawning " + (spawnConfig.craftFiles.Count - (PinataMode ? 1 : 0)) + " vessels at an altitude of " + spawnConfig.altitude.ToString("G0") + "m" + (spawnConfig.craftFiles.Count > 8 ? ", this may take some time..." : "."));
+            LogMessage("Spawning " + (spawnConfig.craftFiles.Count - NPC_Count) + " vessels " + (NPC_Count > 0 ? ("and " + NPC_Count + " NPC") : "") + " at an altitude of " + spawnConfig.altitude.ToString("G0") + "m" + (spawnConfig.craftFiles.Count > 8 ? ", this may take some time..." : "."));
             #endregion
 
             yield return AcquireSpawnPoint(spawnConfig, 2f * spawnDistance, spawnAirborne);
@@ -202,12 +243,17 @@ namespace BDArmory.VesselSpawning
                 foreach (var craftUrl in spawnConfig.craftFiles)
                 {
                     // Figure out spawn point and orientation
-                    var heading = 360f * spawnedVesselCount / spawnConfig.craftFiles.Count - (PinataMode ? 1 : 0);
+                    var heading = 360f * spawnedVesselCount / spawnConfig.craftFiles.Count + NPC_Count - (PinataMode ? 1 : 0);
                     var direction = (Quaternion.AngleAxis(heading, radialUnitVector) * refDirection).ProjectOnPlanePreNormalized(radialUnitVector).normalized;
                     Vector3 position = spawnPoint;
                     if (!PinataMode || (PinataMode && !craftUrl.Contains(BDArmorySettings.PINATA_NAME)))//leave pinata craft at center
                     {
                         position = spawnPoint + spawnDistance * direction;
+                        ++spawnedVesselCount;
+                    }
+                    else //spawn multiple Pinatas with slight offset to prevent on-spanw telefragging
+                    {
+                        position = spawnPoint + 100 * direction;
                         ++spawnedVesselCount;
                     }
                     if (spawnDistance > BDArmorySettings.COMPETITION_DISTANCE / 2f / Mathf.Sin(Mathf.PI / spawnConfig.craftFiles.Count)) direction *= -1f; //have vessels spawning further than comp dist spawn pointing inwards instead of outwards

--- a/BDArmory/VesselSpawning/VesselSpawnerBase.cs
+++ b/BDArmory/VesselSpawning/VesselSpawnerBase.cs
@@ -969,6 +969,7 @@ namespace BDArmory.VesselSpawning
         }
 
         public Dictionary<string, string> GetSpawnedVesselURLs() => spawnedVesselURLs.ToDictionary(kvp => kvp.Key, kvp => kvp.Value); // Return a copy.
+        public List<string> NPCList = new List<string>();
         #endregion
         #endregion
     }


### PR DESCRIPTION
Adds the base logic for spawning in NPCs for local tournaments
-Adds NPC support for FFA tourneys, (both random and ranked) to add in a specified number of NPC craft to each heat.
-Adds /NPC folder to /AutoSpawn/
-Setting the NPC Count per heat to lower than the number of craft in the /NPC/ directory will randomly shuffle spawned NPCs from the pool of available craft
-Setting NPC Count to higher than the number of craft in the /NPC/ directory will spawn duplicates of the NPC craft
-Adds support for spawning in multiple Pinatas at a time