### PR TITLE
Fixes and Simple flareEffectivity

### DIFF
--- a/BDArmory/CounterMeasure/VesselECMJInfo.cs
+++ b/BDArmory/CounterMeasure/VesselECMJInfo.cs
@@ -96,6 +96,9 @@ namespace BDArmory.CounterMeasure
 
         public void AddJammer(ModuleECMJammer jammer)
         {
+            if (jammers is null)
+                Start();
+
             if (!jammers.Contains(jammer))
             {
                 jammers.Add(jammer);

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -4,6 +4,7 @@
 	- Don't auto-switch vessels when MouseAimFlight is active.
 	- Fixed an issue where modules on a vessel re-entering the PRE range weren't being updated in the VesselModuleRegistry.
 	- Fix an issue with chaff vessel modules summoning the Kraken on undocking.
+	- Fix an NRE related to jammers enabling.
 - AI:
 	- Make the autotuning re-centering distance customisable.
 	- Add unclamped max values for auto-tuning speed and altitude.
@@ -12,6 +13,8 @@
 	- Disable gravity easing when using 'Warp Here' above 10m altitude.
 - Weapons:
 	- Fix various NREs related to missiles and multi-missile launchers.
+	- Fix missiles fired from same source vessel causing each other to explode when they cross within proximity detonation distance.
+	- Add flareEffectivity = 1 in missile configs. Modifies how the missile targeting is affected by flares, 1 is fully affected (normal behavior), lower values mean less affected (0 is ignores flares), higher values means more affected.
 - Competition:
 	- Make the saving of backup tournaments optional (hidden setting TOURNAMENT_BACKUPS in settings.cfg).
 	- Added a ranked tournament mode.

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/sidewinder/sidewinder.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/sidewinder/sidewinder.cfg
@@ -85,6 +85,7 @@ PART
 		uncagedLock = false // true: Allows missile to be cued to a radar target, also controls launch conditions, see above
         // allAspect = false // DEPRECATED - use uncagedLock instead
         lockedSensorFOV = 6 // How much the seeker can see in the direction it is looking (in terms of angle cone).
+        flareEffectivity = 1 // Modifies how the missile targeting is affected by flares, 1 is fully affected (normal behavior), lower values mean less affected (0 is ignores flares), higher values means more affected. This is a simple multiplier for flares, use the locked sensor bias curves for more sophisticated flare rejection behavior.
         lockedSensorFOVBias
         {
             // floatcurve to define how the missile weights targets and flares off the center of where the seeker is looking

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -550,6 +550,7 @@ namespace BDArmory.UI
             if (priorHeatScore > 0) // Flares can only decoy if we already had a target
             {
                 flareData = GetFlareTarget(ray, scanRadius, highpassThreshold, lockedSensorFOVBias, lockedSensorVelocityBias, priorHeatTarget);
+                flareData.signalStrength *= missileVessel.GetComponent<MissileBase>().flareEffectivity;
                 flareSuccess = ((!flareData.Equals(TargetSignatureData.noTarget)) && (flareData.signalStrength > highpassThreshold));
             }
 

--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -128,7 +128,10 @@ namespace BDArmory.Weapons.Missiles
         public float frontAspectHeatModifier = 1f;                   // Modifies heat value returned to missiles outside of ~50 deg exhaust cone from non-prop engines. Only takes affect when ASPECTED_IR_SEEKERS = true in settings.cfg
 
         [KSPField]
-        public float chaffEffectivity = 1f;                            // Modifies  how the missile targeting is affected by chaff, 1 is fully affected (normal behavior), lower values mean less affected (0 is ignores chaff), higher values means more affected
+        public float chaffEffectivity = 1f;                            // Modifies how the missile targeting is affected by chaff, 1 is fully affected (normal behavior), lower values mean less affected (0 is ignores chaff), higher values means more affected
+
+        [KSPField]
+        public float flareEffectivity = 1f;                            // Modifies how the missile targeting is affected by flares, 1 is fully affected (normal behavior), lower values mean less affected (0 is ignores flares), higher values means more affected
 
         [KSPField]
         public bool allAspect = false;                                 // DEPRECATED, replaced by uncagedIRLock. uncagedIRLock is automatically set to this value upon loading (to maintain compatability with old BDA mods)
@@ -1341,7 +1344,8 @@ namespace BDArmory.Weapons.Missiles
 
                                         if (partHit == null) continue;
                                         if (ProjectileUtils.IsIgnoredPart(partHit)) continue; // Ignore ignored parts.
-                                        if (partHit.vessel == vessel || partHit.vessel == SourceVessel) continue;
+                                        if (partHit.vessel == vessel || partHit.vessel == SourceVessel) continue; // Ignore source vessel
+                                        if (partHit.IsMissile() && partHit.GetComponent<MissileBase>().SourceVessel == SourceVessel) continue; // Ignore other missiles fired by same vessel
                                         if (partHit.vessel.vesselType == VesselType.Debris) continue; // Ignore debris
 
                                         if (BDArmorySettings.DEBUG_MISSILES) Debug.Log("[BDArmory.MissileBase]: Missile proximity sphere hit | Distance overlap = " + optimalDistance + "| Part name = " + partHit.name);


### PR DESCRIPTION
- Fix missiles fired from same source vessel causing each other to explode.
- Add flareEffectivity = 1 in missile configs. Modifies how the missile targeting is affected by flares, 1 is fully affected (normal behavior), lower values mean less affected (0 is ignores flares), higher values means more affected.
- Fix NRE in VesselECMJInfo.cs