### PR TITLE
Backend changes + RCS Weight Slider

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -7,6 +7,7 @@
 	- Make the delay for the "read and interpret" logic of numeric input fields customisable (default 0.5s).
 - Detectors:
 	- Fix Conformal Decals throwing off RCS calculation in editor (SPH/VAB).
+	- Hide scenery during RCS calculation in editor (SPH/VAB) to prevent scenery from affecting calculation.
 	- Add for/aft/side/top/bot RCS readout to the On-Screen Telem debug option when ASPECTED_RCS is enabled.
 	- Add slider for ASPECTED_RCS_OVERALL_RCS_WEIGHT to the BDA Settings menu.
 

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -10,7 +10,10 @@
 	- Hide scenery during RCS calculation in editor (SPH/VAB) to prevent scenery from affecting calculation.
 	- Add for/aft/side/top/bot RCS readout to the On-Screen Telem debug option when ASPECTED_RCS is enabled.
 	- Add slider for ASPECTED_RCS_OVERALL_RCS_WEIGHT to the BDA Settings menu.
-
+- Competition:
+	- Fix a bug in the score window for teams competitions.
+	- Automatically enable the teams score toggle in the score window if the "Teams" slider in the vessel spawner window is set to teams mode on start-up.
+	- Dump a "team scores.log" file to the Tournament folder for teams tournaments after each round.
 
 v1.6.4.0
 IMPROVEMENTS / FIXES

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -8,6 +8,7 @@
 - Detectors:
 	- Fix Conformal Decals throwing off RCS calculation in editor (SPH/VAB).
 	- Add for/aft/side/top/bot RCS readout to the On-Screen Telem debug option when ASPECTED_RCS is enabled.
+	- Add slider for ASPECTED_RCS_OVERALL_RCS_WEIGHT to the BDA Settings menu.
 
 
 v1.6.4.0

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -1178,6 +1178,7 @@ Localization
         //Missile & CM Settings
         #LOC_BDArmory_Settings_MissileCMToggle = Show Missile & Countermeasure Settings
         #LOC_BDArmory_Settings_AspectedRCS = Real-Time Aspected RCS
+        #LOC_BDArmory_Settings_AspectedRCSOverallRCSWeight = Overall RCS Weight
         #LOC_BDArmory_Settings_AspectedIRSeekers = IR Occlusion Affects Missiles
         #LOC_BDArmory_Settings_FlareFactor = Max Flare Start Heat Mult.
         #LOC_BDArmory_Settings_ChaffFactor = Chaff Pos. Distortion Mult.

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -501,8 +501,6 @@ namespace BDArmory.Radar
             const float radarFOV = 2.0f;
             Vector3 presentationPosition = -t.forward * radarDistance;
             rcsTotal = 0;
-            minRCSHeatmap = float.MaxValue;
-            maxRCSHeatmap = 0f;
 
             SetupResources();
 
@@ -664,23 +662,12 @@ namespace BDArmory.Radar
                 }
             }
 
-            /* If dynamic aspects RCS is enabled, save heatmap values and use a subset of the evaluated RCS values for the total RCS calc
+            // Re-size array for overall RCS calc when aspected RCS is enabled
             if (BDArmorySettings.ASPECTED_RCS)
-            {
-                minRCSHeatmap = (float)Percentile(rcsValues, 10d);
-                maxRCSHeatmap = (float)Percentile(rcsValues, 90d);
                 Array.Resize(ref rcsValues, numAspectsForOverallRTEval);
-            }*/
 
             // Use third quartile for the total RCS (gives better results than average)
             rcsTotal = (float)Percentile(rcsValues, 75d);
-
-            /* Rescale min/max RCS with new overall RCS
-            if (BDArmorySettings.ASPECTED_RCS)
-            {
-                minRCSHeatmap = (1 - BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT) * minRCSHeatmap + BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT * rcsTotal;
-                maxRCSHeatmap = (1 - BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT) * maxRCSHeatmap + BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT * rcsTotal;
-            }*/
 
             // If we are in the editor, render the three highest RCS aspects
             if (inEditorZoom)
@@ -697,11 +684,6 @@ namespace BDArmory.Radar
                 RenderSinglePass(t, inEditorZoom, aspect1, vesselbounds, radarDistance, radarFOV, rcsRendering1, drawTexture1);
                 RenderSinglePass(t, inEditorZoom, aspect2, vesselbounds, radarDistance, radarFOV, rcsRendering2, drawTexture2);
                 RenderSinglePass(t, inEditorZoom, aspect3, vesselbounds, radarDistance, radarFOV, rcsRendering3, drawTexture3);
-
-                /*if (!BDArmorySettings.ASPECTED_RCS)
-                    RenderSinglePass(t, inEditorZoom, aspect3, vesselbounds, radarDistance, radarFOV, rcsRendering3, drawTexture3);
-                else
-                    RCSHeatMap(rcsMatrix, drawTexture3); // Put heat-map in place of 3rd view */
 
             }
             else

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -659,23 +659,23 @@ namespace BDArmory.Radar
                 }
             }
 
-            // If dynamic aspects RCS is enabled, save heatmap values and use a subset of the evaluated RCS values for the total RCS calc
+            /* If dynamic aspects RCS is enabled, save heatmap values and use a subset of the evaluated RCS values for the total RCS calc
             if (BDArmorySettings.ASPECTED_RCS)
             {
                 minRCSHeatmap = (float)Percentile(rcsValues, 10d);
                 maxRCSHeatmap = (float)Percentile(rcsValues, 90d);
                 Array.Resize(ref rcsValues, numAspectsForOverallRTEval);
-            }
+            }*/
 
             // Use third quartile for the total RCS (gives better results than average)
             rcsTotal = (float)Percentile(rcsValues, 75d);
 
-            // Rescale min/max RCS with new overall RCS
+            /* Rescale min/max RCS with new overall RCS
             if (BDArmorySettings.ASPECTED_RCS)
             {
                 minRCSHeatmap = (1 - BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT) * minRCSHeatmap + BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT * rcsTotal;
                 maxRCSHeatmap = (1 - BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT) * maxRCSHeatmap + BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT * rcsTotal;
-            }
+            }*/
 
             // If we are in the editor, render the three highest RCS aspects
             if (inEditorZoom)
@@ -691,10 +691,13 @@ namespace BDArmory.Radar
                 // Render three highest aspects
                 RenderSinglePass(t, inEditorZoom, aspect1, vesselbounds, radarDistance, radarFOV, rcsRendering1, drawTexture1);
                 RenderSinglePass(t, inEditorZoom, aspect2, vesselbounds, radarDistance, radarFOV, rcsRendering2, drawTexture2);
-                if (!BDArmorySettings.ASPECTED_RCS)
+                RenderSinglePass(t, inEditorZoom, aspect3, vesselbounds, radarDistance, radarFOV, rcsRendering3, drawTexture3);
+                
+                /*if (!BDArmorySettings.ASPECTED_RCS)
                     RenderSinglePass(t, inEditorZoom, aspect3, vesselbounds, radarDistance, radarFOV, rcsRendering3, drawTexture3);
                 else
-                    RCSHeatMap(rcsMatrix, drawTexture3); // Put heat-map in place of 3rd view
+                    RCSHeatMap(rcsMatrix, drawTexture3); // Put heat-map in place of 3rd view */
+                
             }
             else
             {
@@ -805,6 +808,7 @@ namespace BDArmory.Radar
             }
         }
 
+        // Currently unused
         public static void RCSHeatMap(float[,] rcsMatrix, Texture2D rcsMap)
         {
             float az;

--- a/BDArmory/UI/BDAEditorAnalysisWindow.cs
+++ b/BDArmory/UI/BDAEditorAnalysisWindow.cs
@@ -17,7 +17,7 @@ namespace BDArmory.UI
         private ApplicationLauncherButton toolbarButton = null;
 
         private bool showRcsWindow = false;
-        private string windowTitle = !Settings.BDArmorySettings.ASPECTED_RCS ? "BDArmory Radar Cross Section Analysis (Worst Three Aspects)" : "BDArmory Radar Cross Section Analysis (Three Aspects)";
+        private string windowTitle = !Settings.BDArmorySettings.ASPECTED_RCS ? "BDArmory Radar Cross Section Analysis (Worst Three Aspects)" : "BDArmory Radar Cross Section Analysis (Front/Side/Heatmap)";
         private Rect windowRect = new Rect(300, 150, 650, 500);
 
         private bool takeSnapshot = false;
@@ -168,7 +168,10 @@ namespace BDArmory.UI
 
             GUI.Label(new Rect(10, 40, 200, 20), $"Az {RadarUtils.editorRCSAspects[0, 0].ToString("0")}, El {RadarUtils.editorRCSAspects[0, 1].ToString("0")}", BDArmorySetup.BDGuiSkin.box);
             GUI.Label(new Rect(220, 40, 200, 20), $"Az {RadarUtils.editorRCSAspects[1, 0].ToString("0")}, El {RadarUtils.editorRCSAspects[1, 1].ToString("0")}", BDArmorySetup.BDGuiSkin.box);
-            GUI.Label(new Rect(430, 40, 200, 20), $"Az {RadarUtils.editorRCSAspects[2, 0].ToString("0")}, El {RadarUtils.editorRCSAspects[2, 1].ToString("0")}", BDArmorySetup.BDGuiSkin.box);
+            if (!Settings.BDArmorySettings.ASPECTED_RCS)
+                GUI.Label(new Rect(430, 40, 200, 20), $"Az {RadarUtils.editorRCSAspects[2, 0].ToString("0")}, El {RadarUtils.editorRCSAspects[2, 1].ToString("0")}", BDArmorySetup.BDGuiSkin.box);
+            else
+                GUI.Label(new Rect(430, 40, 200, 20), $"Az (x: 0 - 180), El (y: -90 - 90)", BDArmorySetup.BDGuiSkin.box);
 
             if (takeSnapshot)
                 takeRadarSnapshot();
@@ -184,7 +187,10 @@ namespace BDArmory.UI
 
             GUI.Label(new Rect(10, 275, 200, 20), string.Format("{0:0.00}", editorUIRCS0) + " m^2", BDArmorySetup.BDGuiSkin.label);
             GUI.Label(new Rect(220, 275, 200, 20), string.Format("{0:0.00}", editorUIRCS1) + " m^2", BDArmorySetup.BDGuiSkin.label);
-            GUI.Label(new Rect(430, 275, 200, 20), string.Format("{0:0.00}", editorUIRCS2) + " m^2", BDArmorySetup.BDGuiSkin.label);
+            if (!Settings.BDArmorySettings.ASPECTED_RCS)
+                GUI.Label(new Rect(430, 275, 200, 20), string.Format("{0:0.00}", editorUIRCS2) + " m^2", BDArmorySetup.BDGuiSkin.label);
+            else
+                GUI.Label(new Rect(430, 275, 200, 20), $"Grn: {RadarUtils.minRCSHeatmap.ToString("0.0")}, Yel: {RadarUtils.rcsTotal.ToString("0.0")}, Red: {RadarUtils.maxRCSHeatmap.ToString("0.0")}", BDArmorySetup.BDGuiSkin.label);
 
             GUIStyle style = BDArmorySetup.BDGuiSkin.label;
             style.fontStyle = FontStyle.Bold;

--- a/BDArmory/UI/BDAEditorAnalysisWindow.cs
+++ b/BDArmory/UI/BDAEditorAnalysisWindow.cs
@@ -168,10 +168,7 @@ namespace BDArmory.UI
 
             GUI.Label(new Rect(10, 40, 200, 20), $"Az {RadarUtils.editorRCSAspects[0, 0].ToString("0")}, El {RadarUtils.editorRCSAspects[0, 1].ToString("0")}", BDArmorySetup.BDGuiSkin.box);
             GUI.Label(new Rect(220, 40, 200, 20), $"Az {RadarUtils.editorRCSAspects[1, 0].ToString("0")}, El {RadarUtils.editorRCSAspects[1, 1].ToString("0")}", BDArmorySetup.BDGuiSkin.box);
-            if (!Settings.BDArmorySettings.ASPECTED_RCS)
-                GUI.Label(new Rect(430, 40, 200, 20), $"Az {RadarUtils.editorRCSAspects[2, 0].ToString("0")}, El {RadarUtils.editorRCSAspects[2, 1].ToString("0")}", BDArmorySetup.BDGuiSkin.box);
-            else
-                GUI.Label(new Rect(430, 40, 200, 20), $"Az (x: 0 - 180), El (y: -90 - 90)", BDArmorySetup.BDGuiSkin.box);
+            GUI.Label(new Rect(430, 40, 200, 20), $"Az {RadarUtils.editorRCSAspects[2, 0].ToString("0")}, El {RadarUtils.editorRCSAspects[2, 1].ToString("0")}", BDArmorySetup.BDGuiSkin.box);
 
             if (takeSnapshot)
                 takeRadarSnapshot();
@@ -187,10 +184,8 @@ namespace BDArmory.UI
 
             GUI.Label(new Rect(10, 275, 200, 20), string.Format("{0:0.00}", editorUIRCS0) + " m^2", BDArmorySetup.BDGuiSkin.label);
             GUI.Label(new Rect(220, 275, 200, 20), string.Format("{0:0.00}", editorUIRCS1) + " m^2", BDArmorySetup.BDGuiSkin.label);
-            if (!Settings.BDArmorySettings.ASPECTED_RCS)
-                GUI.Label(new Rect(430, 275, 200, 20), string.Format("{0:0.00}", editorUIRCS2) + " m^2", BDArmorySetup.BDGuiSkin.label);
-            else
-                GUI.Label(new Rect(430, 275, 200, 20), $"Grn: {RadarUtils.minRCSHeatmap.ToString("0.0")}, Yel: {RadarUtils.rcsTotal.ToString("0.0")}, Red: {RadarUtils.maxRCSHeatmap.ToString("0.0")}", BDArmorySetup.BDGuiSkin.label);
+            GUI.Label(new Rect(430, 275, 200, 20), string.Format("{0:0.00}", editorUIRCS2) + " m^2", BDArmorySetup.BDGuiSkin.label);
+            
 
             GUIStyle style = BDArmorySetup.BDGuiSkin.label;
             style.fontStyle = FontStyle.Bold;

--- a/BDArmory/UI/BDAEditorAnalysisWindow.cs
+++ b/BDArmory/UI/BDAEditorAnalysisWindow.cs
@@ -17,7 +17,7 @@ namespace BDArmory.UI
         private ApplicationLauncherButton toolbarButton = null;
 
         private bool showRcsWindow = false;
-        private string windowTitle = !Settings.BDArmorySettings.ASPECTED_RCS ? "BDArmory Radar Cross Section Analysis (Worst Three Aspects)" : "BDArmory Radar Cross Section Analysis (Front/Side/Heatmap)";
+        private string windowTitle = !Settings.BDArmorySettings.ASPECTED_RCS ? "BDArmory Radar Cross Section Analysis (Worst Three Aspects)" : "BDArmory Radar Cross Section Analysis (Front/Side/Rear)";
         private Rect windowRect = new Rect(300, 150, 650, 500);
 
         private bool takeSnapshot = false;

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -2918,6 +2918,11 @@ namespace BDArmory.UI
                     if (BDArmorySettings.MISSILE_CM_SETTING_TOGGLE)
                     {
                         BDArmorySettings.ASPECTED_RCS = GUI.Toggle(SLineRect(++line, 1), BDArmorySettings.ASPECTED_RCS, StringUtils.Localize("#LOC_BDArmory_Settings_AspectedRCS"));
+                        if (BDArmorySettings.ASPECTED_RCS)
+                        {
+                            GUI.Label(SLeftSliderRect(++line, 1), $"{StringUtils.Localize("#LOC_BDArmory_Settings_AspectedRCSOverallRCSWeight")}:  ({BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT})", leftLabel);
+                            BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT = BDAMath.RoundToUnit(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.ASPECTED_RCS_OVERALL_RCS_WEIGHT, 0f, 1f), 0.05f);
+                        }
 
                         GUI.Label(SLeftSliderRect(++line, 1), $"{StringUtils.Localize("#LOC_BDArmory_Settings_FlareFactor")}:  ({BDArmorySettings.FLARE_FACTOR})", leftLabel);
                         BDArmorySettings.ASPECTED_IR_SEEKERS = GUI.Toggle(SLineRect(++line, 1), BDArmorySettings.ASPECTED_IR_SEEKERS, StringUtils.Localize("#LOC_BDArmory_Settings_AspectedIRSeekers"));


### PR DESCRIPTION
- Hide scenery during RCS calculation in editor (SPH/VAB) to prevent scenery from affecting calculation.
- Add slider for ASPECTED_RCS_OVERALL_RCS_WEIGHT to the BDA Settings menu.
- Backend changes to streamline RCS evaluation