### PR TITLE
GM "Kill Disabled Craft" Setting

### DIFF
--- a/BDArmory/Competition/BDACompetitionMode.cs
+++ b/BDArmory/Competition/BDACompetitionMode.cs
@@ -1097,7 +1097,7 @@ namespace BDArmory.Competition
             if (vessel == null || vessel.vesselName == null) return;
             if (BDArmorySettings.COMPETITION_GM_KILL_ENGINE)
             {
-                if (VesselModuleRegistry.GetModuleCount<ModuleEngines>(vessel) == 0)
+                if (SpawnUtils.CountActiveEngines(vessel) == 0)
                     StartCoroutine(DelayedGMKill(vessel, BDArmorySettings.COMPETITION_GM_KILL_TIME, " lost all engines. Terminated by GM."));
             }
             if (BDArmorySettings.COMPETITION_GM_KILL_WEAPON)
@@ -1107,34 +1107,28 @@ namespace BDArmory.Competition
             }
             if (BDArmorySettings.COMPETITION_GM_KILL_DISABLED)
             {
-                if (vessel.IsControllable)
+                var mf = VesselModuleRegistry.GetModule<MissileFire>(vessel);
+                if (mf != null)
                 {
-                    var mf = VesselModuleRegistry.GetModule<MissileFire>(vessel);
-                    if (mf != null)
+                    if (!vessel.IsControllable || !mf.HasWeaponsAndAmmo()) // Check first for not controllable or no weapons or ammo
+                        StartCoroutine(DelayedGMKill(vessel, BDArmorySettings.COMPETITION_GM_KILL_TIME, " lost all weapons or ammo. Terminated by GM."));
+                    else // Check for engines first, then wheels for tanks/amphibious if needed 
                     {
-                        if (!mf.HasWeaponsAndAmmo()) // Check first for no weapons or ammo
-                            StartCoroutine(DelayedGMKill(vessel, BDArmorySettings.COMPETITION_GM_KILL_TIME, " lost all weapons or ammo. Terminated by GM."));
-                        else // Check for engines first, then wheels for tanks/amphibious if needed 
+                        if (SpawnUtils.CountActiveEngines(vessel) == 0)
                         {
-                            if (VesselModuleRegistry.GetModuleCount<ModuleEngines>(vessel) == 0)
+                            var surfaceAI = VesselModuleRegistry.GetModule<BDModuleSurfaceAI>(vessel); // Get the surface AI if the vessel has one.
+                            if (surfaceAI == null) // No engines on an AI that needs them, craft is disabled
+                                StartCoroutine(DelayedGMKill(vessel, BDArmorySettings.COMPETITION_GM_KILL_TIME, " lost all engines. Terminated by GM."));
+                            else if ((surfaceAI.SurfaceType & AIUtils.VehicleMovementType.Land) != 0) // Check for wheels on craft capable of moving on land
                             {
-                                var surfaceAI = VesselModuleRegistry.GetModule<BDModuleSurfaceAI>(vessel); // Get the surface AI if the vessel has one.
-                                if (surfaceAI != null && (surfaceAI.SurfaceType == AIUtils.VehicleMovementType.Land) || (surfaceAI.SurfaceType == AIUtils.VehicleMovementType.Amphibious) || (surfaceAI.SurfaceType == AIUtils.VehicleMovementType.Stationary))
-                                {
-                                    if (surfaceAI.SurfaceType != AIUtils.VehicleMovementType.Stationary) // Check for wheels on non-stationary craft
-                                    {
-                                        if (VesselModuleRegistry.GetModuleCount<ModuleWheelBase>(vessel) + VesselModuleRegistry.GetModuleCount(vessel, "KSPWheelBase") <= 1) // 1 wheel is disabled
-                                            StartCoroutine(DelayedGMKill(vessel, BDArmorySettings.COMPETITION_GM_KILL_TIME, " lost wheels or tracks. Terminated by GM."));
-                                    }
-                                }
-                                else // No engines on an AI that needs them, craft is disabled
-                                    StartCoroutine(DelayedGMKill(vessel, BDArmorySettings.COMPETITION_GM_KILL_TIME, " lost all engines. Terminated by GM."));
+                                if ((VesselModuleRegistry.GetModuleCount<ModuleWheelBase>(vessel) + 
+                                        VesselModuleRegistry.GetModuleCount(vessel, "KSPWheelBase") +
+                                        VesselModuleRegistry.GetModuleCount(vessel, "FSwheel")) <= 1) // 1 wheel is disabled
+                                    StartCoroutine(DelayedGMKill(vessel, BDArmorySettings.COMPETITION_GM_KILL_TIME, " lost wheels or tracks. Terminated by GM."));
                             }
                         }
                     }
                 }
-                else
-                    StartCoroutine(DelayedGMKill(vessel, BDArmorySettings.COMPETITION_GM_KILL_TIME, " no longer controllable. Terminated by GM."));
             }
             if (BDArmorySettings.COMPETITION_GM_KILL_HP > 0)
             {

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -453,6 +453,7 @@ Localization
         #LOC_BDArmory_Settings_CompetitionAltitudeLimitLow = Altitude Limit Low
         #LOC_BDArmory_Settings_CompetitionGMWeaponKill = Kill Weaponless Craft
         #LOC_BDArmory_Settings_CompetitionGMEngineKill = Kill Engineless Craft
+        #LOC_BDArmory_Settings_CompetitionGMDisableKill = Kill Disabled Craft
         #LOC_BDArmory_Settings_CompetitionGMHPKill = Kill Damaged Craft
         #LOC_BDArmory_Settings_CompetitionGMKillDelay = GM Kill Delay
         #LOC_BDArmory_Settings_CompetitionStarting  = Starting Competition...

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -117,6 +117,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static bool COMPETITION_ALTITUDE__LIMIT_ASL = false;       // Does Killer GM use ASL or AGL for latitide ceiling/floor?
         [BDAPersistentSettingsField] public static bool COMPETITION_GM_KILL_WEAPON = false;             // Competition GM will kill weaponless craft?
         [BDAPersistentSettingsField] public static bool COMPETITION_GM_KILL_ENGINE = false;             // Competition GM will kill engineless craft?
+        [BDAPersistentSettingsField] public static bool COMPETITION_GM_KILL_DISABLED = false;           // Competition GM will kill craft that are disabled (no weapons or ammo, no engine [Pilot/VTOL/Ship/Sub] or no wheels [Surface])
         [BDAPersistentSettingsField] public static float COMPETITION_GM_KILL_HP = 0;                    // Competition GM will kill craft with low HP craft?
         [BDAPersistentSettingsField] public static float COMPETITION_GM_KILL_TIME = 0;                  // CompetitionGM Kill time
         [BDAPersistentSettingsField] public static float COMPETITION_NONCOMPETITOR_REMOVAL_DELAY = 30; // Competition non-competitor removal delay in seconds.

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -3797,8 +3797,9 @@ namespace BDArmory.UI
                         BDArmorySettings.COMPETITION_KILLER_GM_FREQUENCY = Mathf.Round(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.COMPETITION_KILLER_GM_FREQUENCY / 10f, 1, 6)) * 10f; // For now, don't control the killerGMEnabled flag (it's controlled by right clicking M).
                     }
                     // Craft autokill criteria
-                    BDArmorySettings.COMPETITION_GM_KILL_WEAPON = GUI.Toggle(SLineRect(++line), BDArmorySettings.COMPETITION_GM_KILL_WEAPON, "#LOC_BDArmory_Settings_CompetitionGMWeaponKill"); // StringUtils.Localize("#LLOC_BDArmory_Settings_CompetitionAltitudeLimitASL"));                    
-                    BDArmorySettings.COMPETITION_GM_KILL_ENGINE = GUI.Toggle(SLineRect(++line), BDArmorySettings.COMPETITION_GM_KILL_ENGINE, "#LOC_BDArmory_Settings_CompetitionGMEngineKill"); // StringUtils.Localize("#LLOC_BDArmory_Settings_CompetitionAltitudeLimitASL"));                    
+                    BDArmorySettings.COMPETITION_GM_KILL_WEAPON = GUI.Toggle(SLineRect(++line), BDArmorySettings.COMPETITION_GM_KILL_WEAPON, StringUtils.Localize("#LOC_BDArmory_Settings_CompetitionGMWeaponKill"));                 
+                    BDArmorySettings.COMPETITION_GM_KILL_ENGINE = GUI.Toggle(SLineRect(++line), BDArmorySettings.COMPETITION_GM_KILL_ENGINE, StringUtils.Localize("#LOC_BDArmory_Settings_CompetitionGMEngineKill"));
+                    BDArmorySettings.COMPETITION_GM_KILL_DISABLED = GUI.Toggle(SLineRect(++line), BDArmorySettings.COMPETITION_GM_KILL_DISABLED, StringUtils.Localize("#LOC_BDArmory_Settings_CompetitionGMDisableKill"));
                     string GMKillHP;
                     if (BDArmorySettings.COMPETITION_GM_KILL_HP <= 0f) GMKillHP = StringUtils.Localize("#LOC_BDArmory_Generic_Off");
                     else GMKillHP = $"<{Mathf.RoundToInt((BDArmorySettings.COMPETITION_GM_KILL_HP))}%";

--- a/BDArmory/Utils/FireSpitterUtils.cs
+++ b/BDArmory/Utils/FireSpitterUtils.cs
@@ -54,11 +54,11 @@ namespace BDArmory.Utils
             hasCheckedForFSEngine = true;
             foreach (var type in FSAssembly.GetTypes())
             {
-                if (type.Name == "FSengine" || type.Name == "FSengineBladed")
+                if (type.Name == "FSengine")
                 {
                     FSEngineType = type;
                     hasFSEngine = true;
-                    if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.FireSpitter]: Found {type.Name} type.");
+                    if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.FireSpitter]: Found FSengine type.");
                 }
             }
             return hasFSEngine;

--- a/BDArmory/Utils/FireSpitterUtils.cs
+++ b/BDArmory/Utils/FireSpitterUtils.cs
@@ -54,11 +54,11 @@ namespace BDArmory.Utils
             hasCheckedForFSEngine = true;
             foreach (var type in FSAssembly.GetTypes())
             {
-                if (type.Name == "FSengine")
+                if (type.Name == "FSengine" || type.Name == "FSengineBladed")
                 {
                     FSEngineType = type;
                     hasFSEngine = true;
-                    if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.FireSpitter]: Found FSengine type.");
+                    if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.FireSpitter]: Found {type.Name} type.");
                 }
             }
             return hasFSEngine;


### PR DESCRIPTION
- Add "Kill Disabled Craft" setting to GM kill craft that satisfy any of the following:
-- Is not controllable
-- Has no weapons or ammo
-- Has no engines (flying and water)
-- Has no engines, wheels, or tracks (surface and amphibious)