### PR TITLE
Bomb dropping fixes

### DIFF
--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2473,7 +2473,7 @@ namespace BDArmory.Control
             guardFiringMissile = true;
             float bombStartTime = Time.time;
             float bombAttemptDuration = Mathf.Max(targetScanInterval, 12f);
-            float radius = CurrentMissile.GetBlastRadius() * CurrentMissile.clusterbomb * Mathf.Min(0.68f + 1.4f * (maxMissilesOnTarget - 1f), 1.5f);
+            float radius = CurrentMissile.GetBlastRadius() * Mathf.Max(0.68f * CurrentMissile.clusterbomb, 1f) * Mathf.Min(0.68f + 1.4f * (maxMissilesOnTarget - 1f), 1.5f);
             radius = Mathf.Min(radius, 150f);
             float targetToleranceSqr = Mathf.Max(100, 0.013f * (float)guardTarget.srfSpeed * (float)guardTarget.srfSpeed);
 

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2473,9 +2473,7 @@ namespace BDArmory.Control
             guardFiringMissile = true;
             float bombStartTime = Time.time;
             float bombAttemptDuration = Mathf.Max(targetScanInterval, 12f);
-            float radius = CurrentMissile.GetBlastRadius() * Mathf.Min(0.68f + 1.4f * (maxMissilesOnTarget - 1f), 1.5f);
-            var cb = CurrentMissile.GetPart(). FindModuleImplementing<ClusterBomb>();
-            if (cb != null) { radius *= Mathf.Max(0.68f * cb.submunitions.Count(), 1f); }
+            float radius = CurrentMissile.GetBlastRadius() * CurrentMissile.clusterbomb * Mathf.Min(0.68f + 1.4f * (maxMissilesOnTarget - 1f), 1.5f);
             radius = Mathf.Min(radius, 150f);
             float targetToleranceSqr = Mathf.Max(100, 0.013f * (float)guardTarget.srfSpeed * (float)guardTarget.srfSpeed);
 

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2473,7 +2473,7 @@ namespace BDArmory.Control
             guardFiringMissile = true;
             float bombStartTime = Time.time;
             float bombAttemptDuration = Mathf.Max(targetScanInterval, 12f);
-            float radius = CurrentMissile.GetBlastRadius() * Mathf.Max(0.68f + 1.4f * (maxMissilesOnTarget - 1f), 1.5f);
+            float radius = CurrentMissile.GetBlastRadius() * Mathf.Min(0.68f + 1.4f * (maxMissilesOnTarget - 1f), 1.5f);
             var cb = CurrentMissile.GetPart(). FindModuleImplementing<ClusterBomb>();
             if (cb != null) { radius *= Mathf.Max(0.68f * cb.submunitions.Count(), 1f); }
             radius = Mathf.Min(radius, 150f);

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2473,8 +2473,9 @@ namespace BDArmory.Control
             guardFiringMissile = true;
             float bombStartTime = Time.time;
             float bombAttemptDuration = Mathf.Max(targetScanInterval, 12f);
-            float radius = CurrentMissile.GetBlastRadius() * Mathf.Min(maxMissilesOnTarget / 2f, 1.5f);
-            MissileLauncher cm = CurrentMissile as MissileLauncher;
+            float radius = CurrentMissile.GetBlastRadius() * Mathf.Max(0.68f + 1.4f * (maxMissilesOnTarget - 1f), 1.5f);
+            var cb = CurrentMissile.GetPart(). FindModuleImplementing<ClusterBomb>();
+            if (cb != null) { radius *= Mathf.Max(0.68f * cb.submunitions.Count(), 1f); }
             radius = Mathf.Min(radius, 150f);
             float targetToleranceSqr = Mathf.Max(100, 0.013f * (float)guardTarget.srfSpeed * (float)guardTarget.srfSpeed);
 


### PR DESCRIPTION
- Loosen blast radius tolerance for when bombs are dropped as max missiles per target is set higher (up to max of 1.5*Blast Radius).
- Include cluster bomb submunition count for bomb dropping calculation (fixes AI refusing to drop cluster bombs due to small blast radius of bomblet).