### PR TITLE
APS/ MMG NRE fixes

### DIFF
--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2473,8 +2473,7 @@ namespace BDArmory.Control
             guardFiringMissile = true;
             float bombStartTime = Time.time;
             float bombAttemptDuration = Mathf.Max(targetScanInterval, 12f);
-            float radius = Mathf.Max((CurrentMissile.GetBlastRadius() * CurrentMissile.clusterbomb) * Mathf.Min(0.5f + maxMissilesOnTarget / 3f, 1.5f), 50);
-            MissileLauncher cm = CurrentMissile as MissileLauncher;
+            float radius = CurrentMissile.GetBlastRadius() * Mathf.Max(0.68f * CurrentMissile.clusterbomb, 1f) * Mathf.Min(0.68f + 1.4f * (maxMissilesOnTarget - 1f), 1.5f);
             radius = Mathf.Min(radius, 150f);
             float targetToleranceSqr = Mathf.Max(100, 0.013f * (float)guardTarget.srfSpeed * (float)guardTarget.srfSpeed);
            

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -4035,9 +4035,9 @@ namespace BDArmory.Control
 
             //TODO BDModularGuidance: Bombs and turrents
             MissileLauncher launcher = ml as MissileLauncher;
-            Transform referenceTransform = (launcher.multiLauncher != null && launcher.multiLauncher.overrideReferenceTransform) ? launcher.part.FindModelTransform(launcher.multiLauncher.launchTransformName).GetChild(0) : launcher.MissileReferenceTransform;
             if (launcher != null)
             {
+                Transform referenceTransform = (launcher.multiLauncher != null && launcher.multiLauncher.overrideReferenceTransform) ? launcher.part.FindModelTransform(launcher.multiLauncher.launchTransformName).GetChild(0) : launcher.MissileReferenceTransform;
                 if (launcher.rotaryRail && launcher.rotaryRail.readyMissile != ml)
                 {
                     return false;
@@ -5713,7 +5713,7 @@ namespace BDArmory.Control
                                 {
                                     if (!candidateAGM)
                                     {
-                                        if (Missile.TargetingMode == MissileBase.TargetingModes.Radar && (!_radarsEnabled || (vesselRadarData != null && !vesselRadarData.locked)) && !Missile.radarLOAL) candidateYield *= 0.1f;
+                                        if (mm.TargetingMode == MissileBase.TargetingModes.Radar && (!_radarsEnabled || (vesselRadarData != null && !vesselRadarData.locked)) && !mm.radarLOAL) candidateYield *= 0.1f;
                                         if (targetWeapon != null && targetYield > candidateYield) continue;
                                         //targetYield = candidateYield;
                                         //targetWeapon = item.Current;

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -3142,7 +3142,7 @@ namespace BDArmory.Control
                         float thrust = cm == null ? 30 : cm.thrust;
                         float timeToImpact = AIUtils.TimeToCPA(guardTarget, vessel.CoM, vessel.Velocity(), (thrust / missile.part.mass) * missile.GetForwardTransform(), 16);
                         if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileFire]: Blast standoff dist: {ml.StandOffDistance}; time2Impact: {timeToImpact}");
-                        if (ml.StandOffDistance > 0 && Vector3.Distance(transform.position + (vessel.Velocity() * timeToImpact), currentTarget.position + currentTarget.velocity) > ml.StandOffDistance) //if predicted craft position will be within blast radius when missile arrives, break off
+                        if (ml.StandOffDistance > 0 && Vector3.Distance(transform.position + (vessel.Velocity() * timeToImpact), currentTarget.position + (currentTarget.velocity * timeToImpact)) < ml.StandOffDistance) //if predicted craft position will be within blast radius when missile arrives, break off
                         {
                             DisengageAfterFiring = true;
                             if (BDArmorySettings.DEBUG_MISSILES) Debug.Log("[BDArmory.MissileFire]: Need to withdraw from projected blast zone!");

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2473,7 +2473,7 @@ namespace BDArmory.Control
             guardFiringMissile = true;
             float bombStartTime = Time.time;
             float bombAttemptDuration = Mathf.Max(targetScanInterval, 12f);
-            float radius = CurrentMissile.GetBlastRadius() * Mathf.Min(maxMissilesOnTarget / 2f, 1.5f);
+            float radius = Mathf.Max((CurrentMissile.GetBlastRadius() * CurrentMissile.clusterbomb) * Mathf.Min(0.5f + maxMissilesOnTarget / 3f, 1.5f), 50);
             MissileLauncher cm = CurrentMissile as MissileLauncher;
             radius = Mathf.Min(radius, 150f);
             float targetToleranceSqr = Mathf.Max(100, 0.013f * (float)guardTarget.srfSpeed * (float)guardTarget.srfSpeed);

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -7466,7 +7466,7 @@ namespace BDArmory.Control
                 while (weapon.MoveNext())
                 {
                     if (weapon.Current == null) continue;
-                    if (ballisticTurretID > PDBulletTgts.Count - 1) ballisticTurretID = 0;
+                    if (ballisticTurretID > PDBulletTgts.Count - 1) break; // ballisticTurretID = 0; //if APS turret count > incoming shell count, hold fire on surplus turrets
                     if (weapon.Current.eAPSType == ModuleWeapon.APSTypes.Ballistic || weapon.Current.eAPSType == ModuleWeapon.APSTypes.Omni)
                     {
                         if (PDBulletTgts.Count > 0)
@@ -7496,7 +7496,7 @@ namespace BDArmory.Control
                         }
                         else weapon.Current.tgtShell = null;
                     }
-                    if (rocketTurretID > PDRktTgts.Count - 1) rocketTurretID = 0;
+                    if (rocketTurretID > PDRktTgts.Count - 1) break; // rocketTurretID = 0;
                     if (weapon.Current.eAPSType == ModuleWeapon.APSTypes.Missile || weapon.Current.eAPSType == ModuleWeapon.APSTypes.Omni)
                     {
                         if (PDRktTgts.Count > 0)

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2332,6 +2332,8 @@ namespace BDArmory.Control
                             else //no cam, laser missiles now expensive unguided ordinance
                             {
                                 unguidedWeapon = true; //so let them be used as unguided ordinance
+                                if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileFire]: No Laser target! Available cams: {targetingPods.Count}; switching to unguided firing");
+                                break;
                             }
                             //search for a laser point that corresponds with target vessel
                             float attemptStartTime = Time.time;
@@ -2343,7 +2345,7 @@ namespace BDArmory.Control
                             MissileLauncher mlauncher = ml as MissileLauncher;
                             if (mlauncher != null)
                             {
-                                if (targetVessel && ml && mlauncher.missileTurret && laserPointDetected)
+                                if (targetVessel && ml && mlauncher.missileTurret && foundCam)
                                 {
                                     //foundCam.SlaveTurrets();
                                     float turretStartTime = attemptStartTime;
@@ -2361,7 +2363,7 @@ namespace BDArmory.Control
                                         yield return new WaitForFixedUpdate();
                                     }
                                 }
-                                if (targetVessel && ml && mlauncher.multiLauncher && mlauncher.multiLauncher.turret && laserPointDetected)
+                                if (targetVessel && ml && mlauncher.multiLauncher && mlauncher.multiLauncher.turret && foundCam)
                                 {
                                     //foundCam.SlaveTurrets();
                                     float turretStartTime = attemptStartTime;
@@ -2403,7 +2405,7 @@ namespace BDArmory.Control
                 if (unguidedWeapon) //unguidedWeapon
                 {
                     MissileLauncher mlauncher = ml as MissileLauncher;
-                    if (ml && mlauncher.multiLauncher && mlauncher.multiLauncher.overrideReferenceTransform)
+                    if (mlauncher && mlauncher.multiLauncher && mlauncher.multiLauncher.overrideReferenceTransform)
                     {
                         if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileFire]: {vessel.vesselName}'s {CurrentMissile.name} launched from MML, aborting unguided launch.");
                     }
@@ -3142,7 +3144,7 @@ namespace BDArmory.Control
                         float thrust = cm == null ? 30 : cm.thrust;
                         float timeToImpact = AIUtils.TimeToCPA(guardTarget, vessel.CoM, vessel.Velocity(), (thrust / missile.part.mass) * missile.GetForwardTransform(), 16);
                         if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileFire]: Blast standoff dist: {ml.StandOffDistance}; time2Impact: {timeToImpact}");
-                        if (ml.StandOffDistance > 0 && Vector3.Distance(transform.position + (vessel.Velocity() * timeToImpact), currentTarget.position + (currentTarget.velocity * timeToImpact)) < ml.StandOffDistance) //if predicted craft position will be within blast radius when missile arrives, break off
+                        if (ml.StandOffDistance > 0 && (transform.position + (timeToImpact * (Vector3)vessel.Velocity())).CloserToThan(currentTarget.position + (timeToImpact * currentTarget.velocity), ml.StandOffDistance)) //if predicted craft position will be within blast radius when missile arrives, break off
                         {
                             DisengageAfterFiring = true;
                             if (BDArmorySettings.DEBUG_MISSILES) Debug.Log("[BDArmory.MissileFire]: Need to withdraw from projected blast zone!");

--- a/BDArmory/CounterMeasure/VesselECMJInfo.cs
+++ b/BDArmory/CounterMeasure/VesselECMJInfo.cs
@@ -186,7 +186,7 @@ namespace BDArmory.CounterMeasure
             ti.radarLockbreakFactor = (ti.radarRCSReducedSignature == 0) ? 0f :
                 Mathf.Max(Mathf.Clamp01(ti.radarRCSReducedSignature / ti.radarModifiedSignature) * (1 - (totalLBstrength / ti.radarRCSReducedSignature / 100)), 0); // 0 is minimum lockbreak factor
         }
-        void FixedUpdate()
+        void OnFixedUpdate()
         {
             if (UI.BDArmorySetup.GameIsPaused) return;
             //Debug.Log($"[ECMDebug]: jammer on {vessel.GetName()} active! Jammer strength: {jStrength}");

--- a/BDArmory/CounterMeasure/VesselECMJInfo.cs
+++ b/BDArmory/CounterMeasure/VesselECMJInfo.cs
@@ -186,10 +186,11 @@ namespace BDArmory.CounterMeasure
             ti.radarLockbreakFactor = (ti.radarRCSReducedSignature == 0) ? 0f :
                 Mathf.Max(Mathf.Clamp01(ti.radarRCSReducedSignature / ti.radarModifiedSignature) * (1 - (totalLBstrength / ti.radarRCSReducedSignature / 100)), 0); // 0 is minimum lockbreak factor
         }
-        void OnFixedUpdate()
+        void FixedUpdate()
         {
             if (UI.BDArmorySetup.GameIsPaused) return;
-            if (jEnabled && jammerStrength > 0)
+            //Debug.Log($"[ECMDebug]: jammer on {vessel.GetName()} active! Jammer strength: {jStrength}");
+            if (jEnabled && jStrength > 0)
             {
                 using (var loadedvessels = UI.BDATargetManager.LoadedVessels.GetEnumerator())
                     while (loadedvessels.MoveNext())
@@ -197,9 +198,10 @@ namespace BDArmory.CounterMeasure
                         // ignore null, unloaded
                         if (loadedvessels.Current == null || !loadedvessels.Current.loaded || loadedvessels.Current == vessel) continue;
                         float distance = (loadedvessels.Current.CoM - vessel.CoM).magnitude;
-                        if (distance < jammerStrength * 10)
+                        if (distance < jStrength * 10)
                         {
                             RadarWarningReceiver.PingRWR(loadedvessels.Current, vessel.CoM, RadarWarningReceiver.RWRThreatTypes.Jamming, 0.2f);
+                            //Debug.Log($"[ECMDebug]: jammer on {vessel.GetName()} active! Pinging RWR on {loadedvessels.Current.GetName()}");
                         }
                     }
             }

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,4 +1,18 @@
 ﻿IMPROVEMENTS / FIXES
+- AI / WM
+	- AI GUI fixes for surface AI.
+	- Fix AI disengagement from launched nuclear/EMP ordinance if within projected blast radius.
+- Weapons
+	- Fix BurstFirelength and FireAngleOverride toggles not working in flight.
+	- Fix APS parts getting mixed in with global weapon shortnaming and overriding barrage settings.
+	- Anti-Ballistic APS no longer assigns multiple turrets to a single incoming shell.
+	- Missiles
+		- Have torpedoes head to last known contact point and start circling it, instead of current sink to bottom behavior.
+		- MultiMissileLauncher deploy anim toggle now affects symmetry twins.
+		- Fix various NullReferenceExceptions when trying to use Modular Missiles.
+
+v1.6.7.0
+IMPROVEMENTS / FIXES
 - General:
 	- Kerbal Foundries wheel and track HP now properly scales with wheel size.
 	- ProcArmor now has symmetry attach.

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,26 +1,28 @@
 ﻿IMPROVEMENTS / FIXES
+- General:
+	- Add tracking of 'named modules' (from non-dependency DLLs) to the VesselModuleRegistry.
+	- Optimise "Vector3.Distance(from, to) < dist" type checks.
+- UI
+	- rcsOverride enabled ECMJammers now properly affect RCs in the SPH/VAB RCS GUI.
+	- Fix Equivalent Armor Thickness readout in the Armor GUI
 - AI / WM
 	- AI GUI fixes for surface AI.
 	- Fix AI disengagement from launched nuclear/EMP ordinance if within projected blast radius.
+	- Expose the weave strength factor as a tunable parameter for the surface AI.
 - Weapons
 	- Fix BurstFirelength and FireAngleOverride toggles not working in flight.
 	- Fix APS parts getting mixed in with global weapon shortnaming and overriding barrage settings.
 	- Anti-Ballistic APS no longer assigns multiple turrets to a single incoming shell.
+	- Guns now properly respect crossfeed.
+	- Don't apply the unity integrator correction to the unsupported gravity component of the aiming (improves on-orbit aiming).
+	- Improve the estimate of the required OverlapSphere for Vessel-Relative Bullet Checks for hypervelocity craft.
 	- Missiles
 		- Have torpedoes head to last known contact point and start circling it, instead of current sink to bottom behavior.
 		- MultiMissileLauncher deploy anim toggle now affects symmetry twins.
 		- Fix various NullReferenceExceptions when trying to use Modular Missiles.
-
-v1.6.7.0
-IMPROVEMENTS / FIXES
-- General:
-	- Add tracking of 'named modules' (from non-dependency DLLs) to the VesselModuleRegistry.
-	- Optimise "Vector3.Distance(from, to) < dist" type checks.
-- AI:
-	- Expose the weave strength factor as a tunable parameter for the surface AI.
-- Weapons:
-	- Don't apply the unity integrator correction to the unsupported gravity component of the aiming (improves on-orbit aiming).
-	- Improve the estimate of the required OverlapSphere for Vessel-Relative Bullet Checks for hypervelocity craft.
+		- Antirad missiles using antiRadTypes = 9 now properly home in on active ECm jammers.
+		- Fix NRE when trying to fire laser-guided missiles from a turret with no targeting cam.
+		- Single stage Modular Missiles now activate their engine on launch without needing a AG setup.
 
 v1.6.7.0
 IMPROVEMENTS / FIXES

--- a/BDArmory/Distribution/GameData/BDArmory/Resources/BDAmmo_Universal.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Resources/BDAmmo_Universal.cfg
@@ -5,7 +5,7 @@ RESOURCE_DEFINITION
 	name = LaserBolt
 	title = Laser Plasma
 	density = .000168    // 1k 268kg
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -15,7 +15,7 @@ RESOURCE_DEFINITION
 	name = 7.62x39Ammo
 	title = 7.62x39 mm Ammo
 	density = .000268    // 1k 268kg
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -26,7 +26,7 @@ RESOURCE_DEFINITION
 	title = 7.7x56 mm Ammo
 	abbreviation = 7.7/56
 	density = .000259 //1k 259kg
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -36,7 +36,7 @@ RESOURCE_DEFINITION
 	title = 7.92x57mm Mau Ammo
 	abbreviation = 7.92Mau
 	density = .0001     //1k 100kg
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -46,7 +46,7 @@ RESOURCE_DEFINITION
 	title = 9x19 mm Parabellum Ammo
 	abbreviation = 9x19Para
 	density = 0.000011838  //1k 188.85g x
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -55,7 +55,7 @@ RESOURCE_DEFINITION
 {
 	name = 50CalAmmo
 	density = .000116942
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -67,7 +67,7 @@ name = 20x21Ammo
 title 20x21 mm Ammo
 abbreviation = 20/21
 density = 0.00011 //1k 110kg
-flowMode = ALL_VESSEL
+flowMode = STACK_PRIORITY_SEARCH
 transfer = PUMP
 isTweakable = true
 }
@@ -76,7 +76,7 @@ RESOURCE_DEFINITION
 {
 	name = 20x102Ammo
 	density = .000259
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -87,7 +87,7 @@ RESOURCE_DEFINITION
 	title = 20x163 mm Ammo
 	abbreviation = 20/163
 	density = .0007 //1k 700kg
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -98,7 +98,7 @@ RESOURCE_DEFINITION
 	title = 23x115 mm Ammo
 	abbreviation = 23/115
 	density = 0.000498  //1k 498kg
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -108,7 +108,7 @@ RESOURCE_DEFINITION
 	title = 23x152 mm Ammo
 	abbreviation = 23/152
 	density = 0.000511 //1k 511kg
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -119,7 +119,7 @@ RESOURCE_DEFINITION
 	abbreviation = 25/137
 	density = 0.000528 //1k 528kg
 	
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -130,7 +130,7 @@ RESOURCE_DEFINITION
 	title = 30x165 mm Ammo
 	abbreviation = 30long
 	density = 0.000727
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -140,7 +140,7 @@ RESOURCE_DEFINITION
 	title = 30x173 mm Ammo
 	abbreviation = 30AP
 	density = 0.000741
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -150,7 +150,7 @@ RESOURCE_DEFINITION
 	title = 30x173HE mm Ammo
 	abbreviation = 30HE
 	density = 0.000741
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -160,7 +160,7 @@ RESOURCE_DEFINITION
 	title = 37 mm FlaK Ammo
 	abbreviation = 37FlaK
 	density = 0.0021
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -170,7 +170,7 @@ RESOURCE_DEFINITION
 	title = 40x53 mm Ammo
 	abbreviation = 40short
 	density = 0.001690
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -180,7 +180,7 @@ RESOURCE_DEFINITION
 	title = 40x53 mm HE Ammo
 	abbreviation = 40HEshort
 	density = 0.001690
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -190,7 +190,7 @@ RESOURCE_DEFINITION
 	title = 40x311 mm Ammo
 	abbreviation = 40/311
 	density = 0.00211
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -199,7 +199,7 @@ RESOURCE_DEFINITION
 	name = 54cmMortarShells
 	title = 54 cm Mortar Shell
 	density = 1
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -209,7 +209,7 @@ name = 57x438Ammo
 title = 57x438 mm Ammo
 abbreviation = 57/438
 density = .005675 
-flowMode = ALL_VESSEL
+flowMode = STACK_PRIORITY_SEARCH
 transfer = PUMP
 isTweakable = true
 }
@@ -220,7 +220,7 @@ RESOURCE_DEFINITION
 	title = Tungsten Shell
 	abbreviation = Tung
 	density = .015968
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -231,7 +231,7 @@ name = 75x714Ammo
 title = 75x714 mm Ammo
 abbreviation = 75/714
 density = .00151
-flowMode = ALL_VESSEL
+flowMode = STACK_PRIORITY_SEARCH
 transfer = PUMP
 isTweakable = true
 }
@@ -243,7 +243,7 @@ name = 76x636Ammo
 title = 76x636mm Ammo
 abbreviation = 76/636
 density = 0.0125
-flowMode = ALL_VESSEL
+flowMode = STACK_PRIORITY_SEARCH
 transfer = PUMP
 isTweakable = true
 }
@@ -254,7 +254,7 @@ RESOURCE_DEFINITION
 	title = 76.2 mm (3") Shell
 	abbreviation = 3"
 	density = 0.0056
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -265,7 +265,7 @@ RESOURCE_DEFINITION
 	title = 90 mm (3.5") Shell
 	abbreviation = 90mm
 	density = 0.0147
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -276,7 +276,7 @@ RESOURCE_DEFINITION
 	title = 100 mm (4") Shell
 	abbreviation = 100mm
 	density = 0.0187
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -284,7 +284,7 @@ RESOURCE_DEFINITION
 {
 	name = CannonShells
 	density = 0.0186
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -294,7 +294,7 @@ RESOURCE_DEFINITION
 	title = 105mm Shell
 	abbreviation = 105mm
 	density = 0.0186
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -304,7 +304,7 @@ RESOURCE_DEFINITION
 	title = 105mm HE Shell
 	abbreviation = 105mmHE
 	density = 0.0186
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -325,7 +325,7 @@ RESOURCE_DEFINITION
 	title = 120 mm Shell
 	abbreviation = 120mm
 	density = 0.0187 //18.7kg
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -355,7 +355,7 @@ RESOURCE_DEFINITION
 	title = 5 inch/62 Shell
 	abbreviation = 5" //127
 	density = .03268
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -366,7 +366,7 @@ RESOURCE_DEFINITION
 	title = 5inch1/4  Shell
 	abbreviation = 5.25"
 	density = .03568
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -397,7 +397,7 @@ RESOURCE_DEFINITION
 	title = 155mm (6.1") Shell
 	abbreviation = 6.1-155
 	density = 0.04562
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -417,7 +417,7 @@ RESOURCE_DEFINITION
 	title = 203mm (8") Shell
 	abbreviation = 8"
 	density = 0.06602
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -467,7 +467,7 @@ RESOURCE_DEFINITION
 	name = M65ShellAmmo
 	title = M65 Shell
 	density = .8522
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -520,7 +520,7 @@ RESOURCE_DEFINITION
 	title = Type 4 AA Rocket
 	abbreviation = Ty4AAR
 	density = 0.022 //10 220
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = false
 }
@@ -530,7 +530,7 @@ RESOURCE_DEFINITION
 	title = Anti-Tank Rocket
 	abbreviation = ATRa
 	density = .008212 //10 8.2?
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -540,7 +540,7 @@ RESOURCE_DEFINITION
 	title = Hades 122mm UG Rocket
 	abbreviation = Had122	
 	density = .0322 //10 322
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -550,7 +550,7 @@ RESOURCE_DEFINITION
 	title = Hydra-70 rockets
 	abbreviation = Hyd70
 	density = .0122
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -561,7 +561,7 @@ RESOURCE_DEFINITION
 	title = S-8KOM rockets
 	abbreviation = S8KOM
 	density = .0036
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }
@@ -571,7 +571,7 @@ RESOURCE_DEFINITION
 	title = Rockets
 	abbreviation = Rockets
 	density = .01
-	flowMode = ALL_VESSEL
+	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
 }

--- a/BDArmory/Guidances/MissileGuidance.cs
+++ b/BDArmory/Guidances/MissileGuidance.cs
@@ -513,6 +513,7 @@ namespace BDArmory.Guidances
             //Vector3 simMissileVel = 500 * (targetPosition - missile.transform.position).normalized;
 
             MissileLauncher launcher = missile as MissileLauncher;
+            BDModularGuidance modLauncher = missile as BDModularGuidance;
             /*
             float optSpeed = 400; //TODO: Add parameter
             if (launcher != null)
@@ -526,7 +527,7 @@ namespace BDArmory.Guidances
             */
             Vector3 vel = missile.vessel.Velocity();
             Vector3 VelOpt = vel.normalized * (launcher != null ? launcher.optimumAirspeed : 1500);
-            float accel = launcher.thrust / missile.part.mass;
+            float accel = launcher != null ? (launcher.thrust / missile.part.mass) : modLauncher != null ? (modLauncher.thrust/modLauncher.mass) : 10;
             Vector3 deltaVel = targetVessel.Velocity() - vel;
             Vector3 DeltaOptvel = targetVessel.Velocity() - VelOpt;
             float T = Mathf.Clamp((VelOpt - vel).magnitude / accel, 0, 8); //time to optimal airspeed
@@ -561,11 +562,12 @@ namespace BDArmory.Guidances
         public static Vector3 GetAirToAirFireSolution(MissileBase missile, Vector3 targetPosition, Vector3 targetVelocity)
         {
             MissileLauncher launcher = missile as MissileLauncher;
+            BDModularGuidance modLauncher = missile as BDModularGuidance;
             float leadTime = 0;
             Vector3 leadPosition = targetPosition;
             Vector3 vel = missile.vessel.Velocity();
             Vector3 leadDirection, velOpt;
-            float accel = launcher.thrust / missile.part.mass;
+            float accel = launcher != null ? launcher.thrust / missile.part.mass : modLauncher.thrust / modLauncher.mass;
             float leadTimeError = 1f;
             int count = 0;
             do

--- a/BDArmory/Radar/RadarWarningReceiver.cs
+++ b/BDArmory/Radar/RadarWarningReceiver.cs
@@ -74,7 +74,7 @@ namespace BDArmory.Radar
         const float minPingInterval = 0.12f;
         const float pingPersistTime = 1;
 
-        const int dataCount = 10;
+        const int dataCount = 12;
 
         internal float rwrDisplayRange = BDArmorySettings.MAX_ACTIVE_RADAR_RANGE;
         internal static float RwrSize = 256;

--- a/BDArmory/UI/BDAEditorAnalysisWindow.cs
+++ b/BDArmory/UI/BDAEditorAnalysisWindow.cs
@@ -22,6 +22,7 @@ namespace BDArmory.UI
 
         private bool takeSnapshot = false;
         private float rcsReductionFactor;
+        private float rcsOverride = -1;
         private float rcsGCF = 1.0f;
 
         private ModuleRadar[] radars;
@@ -190,7 +191,7 @@ namespace BDArmory.UI
             GUIStyle style = BDArmorySetup.BDGuiSkin.label;
             style.fontStyle = FontStyle.Bold;
             GUI.Label(new Rect(10, 300, 600, 20), "Base radar cross section for vessel: " + string.Format("{0:0.00} m^2 (without ECM/countermeasures)", RadarUtils.rcsTotal), style);
-            GUI.Label(new Rect(10, 320, 600, 20), "Total radar cross section for vessel: " + string.Format("{0:0.00} m^2 (with RCS reduction/stealth/ground clutter)", RadarUtils.rcsTotal * rcsReductionFactor * rcsGCF), style);
+            GUI.Label(new Rect(10, 320, 600, 20), "Total radar cross section for vessel: " + string.Format("{0:0.00} m^2 (with RCS reduction/stealth/ground clutter)", rcsOverride > 0 ? rcsOverride * rcsGCF : RadarUtils.rcsTotal * rcsReductionFactor * rcsGCF), style);
 
             style.fontStyle = FontStyle.Normal;
             GUI.Label(new Rect(10, 380, 600, 20), "** (Range evaluation not accounting for ECM/countermeasures)", style);
@@ -231,7 +232,7 @@ namespace BDArmory.UI
                         for (float distance = selected_radar.radarMaxDistanceDetect; distance >= 0; distance--)
                         {
                             text_detection = $"Detection: undetectable by this radar.";
-                            if (selected_radar.radarDetectionCurve.Evaluate(distance) <= (RadarUtils.rcsTotal * rcsReductionFactor * rcsGCF))
+                            if (selected_radar.radarDetectionCurve.Evaluate(distance) <= (rcsOverride > 0 ? rcsOverride * rcsGCF : RadarUtils.rcsTotal * rcsReductionFactor * rcsGCF))
                             {
                                 text_detection = $"Detection: detected at {distance} km and closer";
                                 break;
@@ -248,7 +249,7 @@ namespace BDArmory.UI
                         text_locktrack = $"Lock/Track: untrackable by this radar.";
                         for (float distance = selected_radar.radarMaxDistanceLockTrack; distance >= 0; distance--)
                         {
-                            if (selected_radar.radarLockTrackCurve.Evaluate(distance) <= (RadarUtils.rcsTotal * rcsReductionFactor * rcsGCF))
+                            if (selected_radar.radarLockTrackCurve.Evaluate(distance) <= (rcsOverride > 0 ? rcsOverride * rcsGCF : RadarUtils.rcsTotal * rcsReductionFactor * rcsGCF))
                             {
                                 text_locktrack = $"Lock/Track: tracked at {distance} km and closer";
                                 break;
@@ -307,7 +308,7 @@ namespace BDArmory.UI
             GUIStyle style = BDArmorySetup.BDGuiSkin.label;
             style.fontStyle = FontStyle.Bold;
             GUI.Label(new Rect(10, 300, 600, 20), "Base radar cross section for vessel: " + string.Format("{0:0.00} m^2 (without ECM/countermeasures)", RadarUtils.rcsTotal), style);
-            GUI.Label(new Rect(10, 320, 600, 20), "Total radar cross section for vessel: " + string.Format("{0:0.00} m^2 (with RCS reduction/stealth/ground clutter)", RadarUtils.rcsTotal * rcsReductionFactor * rcsGCF), style);
+            GUI.Label(new Rect(10, 320, 600, 20), "Total radar cross section for vessel: " + string.Format("{0:0.00} m^2 (with RCS reduction/stealth/ground clutter)", rcsOverride > 0 ? rcsOverride * rcsGCF : RadarUtils.rcsTotal * rcsReductionFactor * rcsGCF), style);
 
             style.fontStyle = FontStyle.Normal;
             GUI.Label(new Rect(10, 380, 600, 20), "** (Range evaluation not accounting for ECM/countermeasures)", style);
@@ -348,7 +349,7 @@ namespace BDArmory.UI
                         for (float distance = selected_radar.radarMaxDistanceDetect; distance >= 0; distance--)
                         {
                             text_detection = $"Detection: undetectable by this radar.";
-                            if (selected_radar.radarDetectionCurve.Evaluate(distance) <= (RadarUtils.rcsTotal * rcsReductionFactor * rcsGCF))
+                            if (selected_radar.radarDetectionCurve.Evaluate(distance) <= (rcsOverride > 0 ? rcsOverride * rcsGCF : RadarUtils.rcsTotal * rcsReductionFactor * rcsGCF))
                             {
                                 text_detection = $"Detection: detected at {distance} km and closer";
                                 break;
@@ -365,7 +366,7 @@ namespace BDArmory.UI
                         text_locktrack = $"Lock/Track: untrackable by this radar.";
                         for (float distance = selected_radar.radarMaxDistanceLockTrack; distance >= 0; distance--)
                         {
-                            if (selected_radar.radarLockTrackCurve.Evaluate(distance) <= (RadarUtils.rcsTotal * rcsReductionFactor * rcsGCF))
+                            if (selected_radar.radarLockTrackCurve.Evaluate(distance) <= (rcsOverride > 0 ? rcsOverride * rcsGCF : RadarUtils.rcsTotal * rcsReductionFactor * rcsGCF))
                             {
                                 text_locktrack = $"Lock/Track: tracked at {distance} km and closer";
                                 break;
@@ -402,6 +403,7 @@ namespace BDArmory.UI
 
             // get RCS reduction measures (stealth/low observability)
             rcsReductionFactor = 1.0f;
+
             int rcsCount = 0;
             List<Part>.Enumerator parts = EditorLogic.fetch.ship.Parts.GetEnumerator();
             while (parts.MoveNext())
@@ -413,6 +415,7 @@ namespace BDArmory.UI
                     {
                         rcsReductionFactor *= rcsJammer.rcsReductionFactor;
                         rcsCount++;
+                        if (rcsOverride < rcsJammer.rcsOverride) rcsOverride = rcsJammer.rcsOverride;
                     }
                 }
             }

--- a/BDArmory/UI/BDAEditorArmorWindow.cs
+++ b/BDArmory/UI/BDAEditorArmorWindow.cs
@@ -1039,7 +1039,7 @@ namespace BDArmory.UI
                 */
                 //armorValue = ProjectileUtils.CalculatePenetration(30, newCaliber, 0.388f, 1109, ArmorDuctility, ArmorDensity, ArmorStrength, 30, 0.8f, false);
                 armorValue = ProjectileUtils.CalculatePenetration(30, 1109, 0.388f, 0.8f, ArmorStrength, ArmorVfactor, ArmorMu1, ArmorMu2, ArmorMu3); //why is this hardcoded? it needs to be the selected armor mat's vars
-                relValue = Mathf.Round(steelValue / armorValue * 10) / 10;
+                BDAMath.RoundToUnit(steelValue / armorValue, 0.1f)
                 exploValue = ArmorStrength * (1 + ArmorDuctility) * (ArmorDensity / 1000);
             }
         }

--- a/BDArmory/UI/BDAEditorArmorWindow.cs
+++ b/BDArmory/UI/BDAEditorArmorWindow.cs
@@ -1039,7 +1039,7 @@ namespace BDArmory.UI
                 */
                 //armorValue = ProjectileUtils.CalculatePenetration(30, newCaliber, 0.388f, 1109, ArmorDuctility, ArmorDensity, ArmorStrength, 30, 0.8f, false);
                 armorValue = ProjectileUtils.CalculatePenetration(30, 1109, 0.388f, 0.8f, ArmorStrength, ArmorVfactor, ArmorMu1, ArmorMu2, ArmorMu3); //why is this hardcoded? it needs to be the selected armor mat's vars
-                BDAMath.RoundToUnit(steelValue / armorValue, 0.1f)
+                relValue = BDAMath.RoundToUnit(steelValue / armorValue, 0.1f);
                 exploValue = ArmorStrength * (1 + ArmorDuctility) * (ArmorDensity / 1000);
             }
         }

--- a/BDArmory/UI/BDAEditorArmorWindow.cs
+++ b/BDArmory/UI/BDAEditorArmorWindow.cs
@@ -1039,7 +1039,7 @@ namespace BDArmory.UI
                 */
                 //armorValue = ProjectileUtils.CalculatePenetration(30, newCaliber, 0.388f, 1109, ArmorDuctility, ArmorDensity, ArmorStrength, 30, 0.8f, false);
                 armorValue = ProjectileUtils.CalculatePenetration(30, 1109, 0.388f, 0.8f, ArmorStrength, ArmorVfactor, ArmorMu1, ArmorMu2, ArmorMu3); //why is this hardcoded? it needs to be the selected armor mat's vars
-                relValue = Mathf.Round(armorValue / steelValue * 10) / 10;
+                relValue = Mathf.Round(steelValue / armorValue * 10) / 10;
                 exploValue = ArmorStrength * (1 + ArmorDuctility) * (ArmorDensity / 1000);
             }
         }

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -585,12 +585,10 @@ namespace BDArmory.UI
             if (priorHeatScore > 0) // Flares can only decoy if we already had a target
             {
                 flareData = GetFlareTarget(ray, scanRadius, highpassThreshold, lockedSensorFOVBias, lockedSensorVelocityBias, priorHeatTarget);
-                Debug.Log("[MMGDebug] 3");
                 float flareEft = 1;
                 var mB = missileVessel.GetComponent<MissileBase>();
                 if (mB != null) flareEft = mB.flareEffectivity;
                 flareData.signalStrength *= flareEft;
-                Debug.Log("[MMGDebug] 4");
                 flareSuccess = ((!flareData.Equals(TargetSignatureData.noTarget)) && (flareData.signalStrength > highpassThreshold));
             }
             // No targets above highpassThreshold

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -508,36 +508,31 @@ namespace BDArmory.UI
                     //Debug.Log($"[BDATargetManager] looking at {vessel.GetName()}; has MF: {mf}; Guardmode: {(mf != null ? mf.guardMode.ToString() : "N/A")}");
                     continue;
                 }
-
                 TargetInfo tInfo = vessel.gameObject.GetComponent<TargetInfo>();
 
                 if (tInfo == null)
                 {
-                    var WM = VesselModuleRegistry.GetMissileFire(vessel, true);
-                    if (WM != null)
+                    if (mf != null)
                     {
                         tInfo = vessel.gameObject.AddComponent<TargetInfo>();
                     }
                     else
-                        return finalData; //This is causing Heaters to not work under manual control - Need Guardmode to generate TargetInfos. Could either add missing TI here, or have UpdateGuardScan proc all the time, not just in guardmode
-
+                        return finalData; 
                 }
                 // If no weaponManager or no target or the target is not a missile with engines on..??? and the target weighs less than 50kg, abort.
                 if (mf == null ||
                     !tInfo ||
-                    !(mf && tInfo.isMissile && (tInfo.MissileBaseModule.MissileState == MissileBase.MissileStates.Boost || tInfo.MissileBaseModule.MissileState == MissileBase.MissileStates.Cruise)))
+                    !(mf && tInfo && tInfo.isMissile && (tInfo.MissileBaseModule.MissileState == MissileBase.MissileStates.Boost || tInfo.MissileBaseModule.MissileState == MissileBase.MissileStates.Cruise)))
                 {
                     if (vessel.GetTotalMass() < minMass)
                         continue;
                 }
-
                 // Abort if target is friendly.
                 if (mf != null)
                 {
                     if (mf.Team.IsFriendly(tInfo.Team))
                         continue;
                 }
-
                 // Abort if target is a missile that we've shot
                 if (tInfo.isMissile)
                 {
@@ -557,7 +552,6 @@ namespace BDArmory.UI
                         if (!OtherUtils.CheckSightLineExactDistance(ray.origin, vessel.CoM + vessel.Velocity(), Vector3.Distance(vessel.CoM, ray.origin), 5, 5))
                             continue;
                     }
-
                     IRSig = GetVesselHeatSignature(vessel, BDArmorySettings.ASPECTED_IR_SEEKERS ? missileVessel.CoM : Vector3.zero, frontAspectHeatModifier); //change vector3.zero to missile.transform.position to have missile IR detection dependant on target aspect
                     float score = IRSig.Item1 * Mathf.Clamp01(15 / angle);
                     score *= (1400 * 1400) / Mathf.Max((vessel.CoM - ray.origin).sqrMagnitude, 90000); // Clamp below 300m
@@ -565,9 +559,7 @@ namespace BDArmory.UI
                     // Add bias targets closer to center of seeker FOV, only once missile seeker can see target
                     if ((priorHeatScore > 0f) && (angle < scanRadius))
                         score *= GetSeekerBias(angle, Vector3.Angle(vessel.Velocity(), priorHeatTarget.velocity), lockedSensorFOVBias, lockedSensorVelocityBias);
-
                     score *= Mathf.Clamp(Vector3.Angle(vessel.transform.position - ray.origin, -VectorUtils.GetUpDirection(ray.origin)) / 90, 0.5f, 1.5f);
-
                     if ((finalScore > 0f) && (score > 0f) && (priorHeatScore > 0)) // If we were passed a target heat score, look for the most similar non-zero heat score after picking a target
                     {
                         if (Mathf.Abs(score - priorHeatScore) < Mathf.Abs(finalScore - priorHeatScore))
@@ -587,18 +579,20 @@ namespace BDArmory.UI
                     //Debug.Log($"[IR DEBUG] heatscore of {vessel.GetName()} is {score}");
                 }
             }
-
             // see if there are flares decoying us:
             bool flareSuccess = false;
             TargetSignatureData flareData = TargetSignatureData.noTarget;
             if (priorHeatScore > 0) // Flares can only decoy if we already had a target
             {
                 flareData = GetFlareTarget(ray, scanRadius, highpassThreshold, lockedSensorFOVBias, lockedSensorVelocityBias, priorHeatTarget);
-                flareData.signalStrength *= missileVessel.GetComponent<MissileBase>().flareEffectivity;
+                Debug.Log("[MMGDebug] 3");
+                float flareEft = 1;
+                var mB = missileVessel.GetComponent<MissileBase>();
+                if (mB != null) flareEft = mB.flareEffectivity;
+                flareData.signalStrength *= flareEft;
+                Debug.Log("[MMGDebug] 4");
                 flareSuccess = ((!flareData.Equals(TargetSignatureData.noTarget)) && (flareData.signalStrength > highpassThreshold));
             }
-
-
             // No targets above highpassThreshold
             if (finalScore < highpassThreshold)
             {
@@ -617,8 +611,6 @@ namespace BDArmory.UI
                 flareSuccess = (flareData.signalStrength > finalScore) && flareSuccess;
             else
                 flareSuccess = false;
-
-
 
             if (flareSuccess) // return matching flare
                 return flareData;

--- a/BDArmory/UI/BDArmoryAIGUI.cs
+++ b/BDArmory/UI/BDArmoryAIGUI.cs
@@ -2451,28 +2451,29 @@ namespace BDArmory.UI
                             GUI.Label(ContextLabelRect(leftIndent, driverLines), StringUtils.Localize("#LOC_BDArmory_DriverAI_SlopeAngle"), contextLabel);//"undershoot"
                             driverLines++;
                         }
-
-                        if (!NumFieldsEnabled)
+                        if (ActiveDriver.SurfaceType != AIUtils.VehicleMovementType.Submarine)
                         {
-                            ActiveDriver.CombatAltitude =
-                                GUI.HorizontalSlider(SettingSliderRect(leftIndent, driverLines, contentWidth),
-                                    ActiveDriver.CombatAltitude, -200, -15);
-                            ActiveDriver.CombatAltitude = Mathf.Round(ActiveDriver.CombatAltitude);
-                        }
-                        else
-                        {
-                            var field = inputFields["CombatAltitude"];
-                            field.tryParseValue(GUI.TextField(SettingTextRect(leftIndent, driverLines, contentWidth), field.possibleValue, 8, field.style));
-                            ActiveDriver.CombatAltitude = (float)field.currentValue;
-                        }
-                        GUI.Label(SettinglabelRect(leftIndent, driverLines), StringUtils.Localize("#LOC_BDArmory_CombatAltitude") + ": " + ActiveDriver.CombatAltitude.ToString("0"), Label);//"Steer Ki"
-                        driverLines++;
-                        if (contextTipsEnabled)
-                        {
-                            GUI.Label(ContextLabelRect(leftIndent, driverLines), StringUtils.Localize("#LOC_BDArmory_DriverAI_CombatAlt"), contextLabel);//"undershoot"
+                            if (!NumFieldsEnabled)
+                            {
+                                ActiveDriver.CombatAltitude =
+                                    GUI.HorizontalSlider(SettingSliderRect(leftIndent, driverLines, contentWidth),
+                                        ActiveDriver.CombatAltitude, -200, -15);
+                                ActiveDriver.CombatAltitude = Mathf.Round(ActiveDriver.CombatAltitude);
+                            }
+                            else
+                            {
+                                var field = inputFields["CombatAltitude"];
+                                field.tryParseValue(GUI.TextField(SettingTextRect(leftIndent, driverLines, contentWidth), field.possibleValue, 8, field.style));
+                                ActiveDriver.CombatAltitude = (float)field.currentValue;
+                            }
+                            GUI.Label(SettinglabelRect(leftIndent, driverLines), StringUtils.Localize("#LOC_BDArmory_CombatAltitude") + ": " + ActiveDriver.CombatAltitude.ToString("0"), Label);//"Steer Ki"
                             driverLines++;
-                        }                        
-
+                            if (contextTipsEnabled)
+                            {
+                                GUI.Label(ContextLabelRect(leftIndent, driverLines), StringUtils.Localize("#LOC_BDArmory_DriverAI_CombatAlt"), contextLabel);//"undershoot"
+                                driverLines++;
+                            }
+                        }
                         if (!NumFieldsEnabled)
                         {
                             ActiveDriver.CruiseSpeed =

--- a/BDArmory/UI/BDArmoryAIGUI.cs
+++ b/BDArmory/UI/BDArmoryAIGUI.cs
@@ -2451,7 +2451,7 @@ namespace BDArmory.UI
                             GUI.Label(ContextLabelRect(leftIndent, driverLines), StringUtils.Localize("#LOC_BDArmory_DriverAI_SlopeAngle"), contextLabel);//"undershoot"
                             driverLines++;
                         }
-                        if (ActiveDriver.SurfaceType != AIUtils.VehicleMovementType.Submarine)
+                        if (ActiveDriver.SurfaceType == AIUtils.VehicleMovementType.Submarine)
                         {
                             if (!NumFieldsEnabled)
                             {

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -2953,7 +2953,7 @@ namespace BDArmory.UI
                         GUI.Label(SLeftSliderRect(++line, 1), $"{StringUtils.Localize("#LOC_BDArmory_Settings_TimeScale")}; ({BDArmorySettings.TIME_SCALE:G2}x)", leftLabel);
                         if (BDArmorySettings.TIME_SCALE != (BDArmorySettings.TIME_SCALE = BDAMath.RoundToUnit(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.TIME_SCALE, 0f, BDArmorySettings.TIME_SCALE_MAX), BDArmorySettings.TIME_SCALE > 5f ? 1f : 0.1f)))
                         {
-                            if (!GameIsPaused) Time.timeScale = BDArmorySettings.TIME_SCALE;
+                            Time.timeScale = BDArmorySettings.TIME_SCALE;
                         }
                     }
                     BDArmorySettings.MISSILE_CM_SETTING_TOGGLE = GUI.Toggle(SLineRect(++line), BDArmorySettings.MISSILE_CM_SETTING_TOGGLE, StringUtils.Localize("#LOC_BDArmory_Settings_MissileCMToggle"));

--- a/BDArmory/Weapons/Missiles/BDModularGuidance.cs
+++ b/BDArmory/Weapons/Missiles/BDModularGuidance.cs
@@ -1035,7 +1035,7 @@ namespace BDArmory.Weapons.Missiles
             if (StagesNumber == 1)
             {
                 if (SpawnUtils.CountActiveEngines(vessel) < 1)
-                    SpawnUtils.ActivateAllEngines(vessel);
+                    SpawnUtils.ActivateAllEngines(vessel, true, false);
             }
 
             _nextStage++;

--- a/BDArmory/Weapons/Missiles/BDModularGuidance.cs
+++ b/BDArmory/Weapons/Missiles/BDModularGuidance.cs
@@ -1032,6 +1032,12 @@ namespace BDArmory.Weapons.Missiles
             vessel.ActionGroups.ToggleGroup(
                 (KSPActionGroup)Enum.Parse(typeof(KSPActionGroup), "Custom0" + (int)_nextStage));
 
+            if (StagesNumber == 1)
+            {
+                if (SpawnUtils.CountActiveEngines(vessel) < 1)
+                    SpawnUtils.ActivateAllEngines(vessel);
+            }
+
             _nextStage++;
 
             vessel.OnFlyByWire += GuidanceSteer;

--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -639,7 +639,7 @@ namespace BDArmory.Weapons.Missiles
                 targetVessel = null;
                 TargetAcquired = false;
                 predictedHeatTarget.exists = false;
-                predictedHeatTarget.signalStrength = 0;
+                predictedHeatTarget.signalStrength = 0; //have this instead set to originalHeatTarget missile had on initial lock?
                 return;
             }
 

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -2478,7 +2478,7 @@ namespace BDArmory.Weapons.Missiles
             }
             else
             {
-                SLWTarget = TargetPosition; //head to last known contact and then begin circlung
+                SLWTarget = TargetPosition; //head to last known contact and then begin circling
             }
 
             if (FlightGlobals.getAltitudeAtPos(SLWTarget) > 0) SLWTarget -= ((MissileGuidance.GetRaycastRadarAltitude(SLWTarget) + 2) * VectorUtils.GetUpDirection(vessel.transform.position));// see about implementing a 'set target running depth'?

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -2414,7 +2414,7 @@ namespace BDArmory.Weapons.Missiles
             }
             else
             {
-                aamTarget = transform.position + (20 * vessel.Velocity().normalized);
+                aamTarget = transform.position + (2000 * vessel.Velocity().normalized);
             }
 
             if (TimeIndex > dropTime + 0.25f)
@@ -2478,10 +2478,10 @@ namespace BDArmory.Weapons.Missiles
             }
             else
             {
-                SLWTarget = transform.position + (20 * vessel.Velocity().normalized);
+                SLWTarget = TargetPosition; //head to last known contact and then begin circlung
             }
-            TargetPosition -= VectorUtils.GetUpDirection(TargetPosition) * 5;
-            if (FlightGlobals.getAltitudeAtPos(SLWTarget) > 0) SLWTarget -= (MissileGuidance.GetRaycastRadarAltitude(SLWTarget) * VectorUtils.GetUpDirection(vessel.transform.position));
+
+            if (FlightGlobals.getAltitudeAtPos(SLWTarget) > 0) SLWTarget -= ((MissileGuidance.GetRaycastRadarAltitude(SLWTarget) + 2) * VectorUtils.GetUpDirection(vessel.transform.position));// see about implementing a 'set target running depth'?
             //allow inverse contRod-style target offset for srf targets for 'under-the-keel' proximity detonation? or at least not having the torps have a target alt of 0 (and thus be vulnerable to surface PD?)
             if (TimeIndex > dropTime + 0.25f)
             {

--- a/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
@@ -110,6 +110,17 @@ namespace BDArmory.Weapons.Missiles
             if (deployState != null)
             {
                 deployState.normalizedTime = HighLogic.LoadedSceneIsFlight ? 0 : toggleBay ? 1 : 0;
+                using (List<Part>.Enumerator pSym = part.symmetryCounterparts.GetEnumerator())
+                    while (pSym.MoveNext())
+                    {
+                        if (pSym.Current == null) continue;
+                        if (pSym.Current != part && pSym.Current.vessel == vessel)
+                        {
+                            var ml = pSym.Current.FindModuleImplementing<MultiMissileLauncher>();
+                            if (ml == null) continue;
+                            ml.deployState.normalizedTime = toggleBay ? 1 : 0;
+                        }
+                    }
             }
         }
 

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -1659,52 +1659,38 @@ namespace BDArmory.Weapons
         [KSPEvent(advancedTweakable = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_FireAngleOverride_Enable", active = true)]//Disable fire angle override
         public void ToggleOverrideAngle()
         {
-            using (var weapon = VesselModuleRegistry.GetModules<ModuleWeapon>(vessel).GetEnumerator())
-                while (weapon.MoveNext())
-                {
-                    if (weapon.Current == null) continue;
-                    if (weapon.Current.name != part.name) continue;
+            FireAngleOverride = !FireAngleOverride;
+            if (FireAngleOverride == false)
+            {
+                Events["ToggleOverrideAngle"].guiName = StringUtils.Localize("#LOC_BDArmory_FireAngleOverride_Enable");// Enable Firing Angle Override
+            }
+            else
+            {
+                Events["ToggleOverrideAngle"].guiName = StringUtils.Localize("#LOC_BDArmory_FireAngleOverride_Disable");// Disable Firing Angle Override
+            }
 
-                    weapon.Current.FireAngleOverride = !weapon.Current.FireAngleOverride;
-                    if (weapon.Current.FireAngleOverride == false)
-                    {
-                        weapon.Current.Events["ToggleOverrideAngle"].guiName = StringUtils.Localize("#LOC_BDArmory_FireAngleOverride_Enable");// Enable Firing Angle Override
-                    }
-                    else
-                    {
-                        weapon.Current.Events["ToggleOverrideAngle"].guiName = StringUtils.Localize("#LOC_BDArmory_FireAngleOverride_Disable");// Disable Firing Angle Override
-                    }
+            Fields["FiringTolerance"].guiActive = FireAngleOverride;
+            Fields["FiringTolerance"].guiActiveEditor = FireAngleOverride;
 
-                    weapon.Current.Fields["FiringTolerance"].guiActive = weapon.Current.FireAngleOverride;
-                    weapon.Current.Fields["FiringTolerance"].guiActiveEditor = weapon.Current.FireAngleOverride;
-
-                    GUIUtils.RefreshAssociatedWindows(weapon.Current.part);
-                }
+            GUIUtils.RefreshAssociatedWindows(part);
         }
         [KSPEvent(advancedTweakable = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_BurstLengthOverride_Enable", active = true)]//Burst length override
         public void ToggleBurstLengthOverride()
         {
-            using (var weapon = VesselModuleRegistry.GetModules<ModuleWeapon>(vessel).GetEnumerator())
-                while (weapon.MoveNext())
-                {
-                    if (weapon.Current == null) continue;
-                    if (weapon.Current.name != part.name) continue;
+            BurstOverride = !BurstOverride;
+            if (!BurstOverride)
+            {
+                Events["ToggleBurstLengthOverride"].guiName = StringUtils.Localize("#LOC_BDArmory_BurstLengthOverride_Enable");// Enable Firing Angle Override
+            }
+            else
+            {
+                Events["ToggleBurstLengthOverride"].guiName = StringUtils.Localize("#LOC_BDArmory_BurstLengthOverride_Disable");// Disable Firing Angle Override
+            }
 
-                    weapon.Current.BurstOverride = !weapon.Current.BurstOverride;
-                    if (!weapon.Current.BurstOverride)
-                    {
-                        weapon.Current.Events["ToggleBurstLengthOverride"].guiName = StringUtils.Localize("#LOC_BDArmory_BurstLengthOverride_Enable");// Enable Firing Angle Override
-                    }
-                    else
-                    {
-                        weapon.Current.Events["ToggleBurstLengthOverride"].guiName = StringUtils.Localize("#LOC_BDArmory_BurstLengthOverride_Disable");// Disable Firing Angle Override
-                    }
+            Fields["fireBurstLength"].guiActive = BurstOverride;
+            Fields["fireBurstLength"].guiActiveEditor = BurstOverride;
 
-                    weapon.Current.Fields["fireBurstLength"].guiActive = weapon.Current.BurstOverride;
-                    weapon.Current.Fields["fireBurstLength"].guiActiveEditor = weapon.Current.BurstOverride;
-
-                    GUIUtils.RefreshAssociatedWindows(weapon.Current.part);
-                }
+            GUIUtils.RefreshAssociatedWindows(part);
         }
 
         void FAOCos(BaseField field, object obj)

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -3026,7 +3026,7 @@ namespace BDArmory.Weapons
             }
             if (externalAmmo)
             {
-                if (part.RequestResource(ammoName.GetHashCode(), (double)AmmoPerShot, ResourceFlowMode.STAGE_PRIORITY_FLOW_BALANCE) > 0)
+                if (part.RequestResource(ammoName.GetHashCode(), (double)AmmoPerShot) > 0)
                 {
                     return true;
                 }

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -1118,6 +1118,7 @@ namespace BDArmory.Weapons
                             while (weapon.MoveNext())
                             {
                                 if (weapon.Current == null) continue;
+                                if (weapon.Current.isAPS) continue;
                                 if (weapon.Current.GetShortName() != this.GetShortName()) continue;
                                 if (weapon.Current.roundsPerMinute >= 1500 || (weapon.Current.eWeaponType == WeaponTypes.Laser && !weapon.Current.pulseLaser)) continue;
                                 weapon.Current.canRippleFire = false;
@@ -1658,59 +1659,51 @@ namespace BDArmory.Weapons
         [KSPEvent(advancedTweakable = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_FireAngleOverride_Enable", active = true)]//Disable fire angle override
         public void ToggleOverrideAngle()
         {
-            using (List<Part>.Enumerator craftPart = EditorLogic.fetch.ship.parts.GetEnumerator())
-                while (craftPart.MoveNext())
+            using (var weapon = VesselModuleRegistry.GetModules<ModuleWeapon>(vessel).GetEnumerator())
+                while (weapon.MoveNext())
                 {
-                    if (craftPart.Current == null) continue;
-                    if (craftPart.Current.name != part.name) continue;
-                    using (List<ModuleWeapon>.Enumerator weapon = craftPart.Current.FindModulesImplementing<ModuleWeapon>().GetEnumerator())
-                        while (weapon.MoveNext())
-                        {
-                            if (weapon.Current == null) continue;
-                            weapon.Current.FireAngleOverride = !weapon.Current.FireAngleOverride;
-                            if (weapon.Current.FireAngleOverride == false)
-                            {
-                                weapon.Current.Events["ToggleOverrideAngle"].guiName = StringUtils.Localize("#LOC_BDArmory_FireAngleOverride_Enable");// Enable Firing Angle Override
-                            }
-                            else
-                            {
-                                weapon.Current.Events["ToggleOverrideAngle"].guiName = StringUtils.Localize("#LOC_BDArmory_FireAngleOverride_Disable");// Disable Firing Angle Override
-                            }
+                    if (weapon.Current == null) continue;
+                    if (weapon.Current.name != part.name) continue;
 
-                            weapon.Current.Fields["FiringTolerance"].guiActive = weapon.Current.FireAngleOverride;
-                            weapon.Current.Fields["FiringTolerance"].guiActiveEditor = weapon.Current.FireAngleOverride;
+                    weapon.Current.FireAngleOverride = !weapon.Current.FireAngleOverride;
+                    if (weapon.Current.FireAngleOverride == false)
+                    {
+                        weapon.Current.Events["ToggleOverrideAngle"].guiName = StringUtils.Localize("#LOC_BDArmory_FireAngleOverride_Enable");// Enable Firing Angle Override
+                    }
+                    else
+                    {
+                        weapon.Current.Events["ToggleOverrideAngle"].guiName = StringUtils.Localize("#LOC_BDArmory_FireAngleOverride_Disable");// Disable Firing Angle Override
+                    }
 
-                            GUIUtils.RefreshAssociatedWindows(weapon.Current.part);
-                        }
+                    weapon.Current.Fields["FiringTolerance"].guiActive = weapon.Current.FireAngleOverride;
+                    weapon.Current.Fields["FiringTolerance"].guiActiveEditor = weapon.Current.FireAngleOverride;
+
+                    GUIUtils.RefreshAssociatedWindows(weapon.Current.part);
                 }
         }
         [KSPEvent(advancedTweakable = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_BurstLengthOverride_Enable", active = true)]//Burst length override
         public void ToggleBurstLengthOverride()
         {
-            using (List<Part>.Enumerator craftPart = EditorLogic.fetch.ship.parts.GetEnumerator())
-                while (craftPart.MoveNext())
+            using (var weapon = VesselModuleRegistry.GetModules<ModuleWeapon>(vessel).GetEnumerator())
+                while (weapon.MoveNext())
                 {
-                    if (craftPart.Current == null) continue;
-                    if (craftPart.Current.name != part.name) continue;
-                    using (List<ModuleWeapon>.Enumerator weapon = craftPart.Current.FindModulesImplementing<ModuleWeapon>().GetEnumerator())
-                        while (weapon.MoveNext())
-                        {
-                            if (weapon.Current == null) continue;
-                            weapon.Current.BurstOverride = !weapon.Current.BurstOverride;
-                            if (weapon.Current.BurstOverride == false)
-                            {
-                                weapon.Current.Events["ToggleBurstLengthOverride"].guiName = StringUtils.Localize("#LOC_BDArmory_BurstLengthOverride_Enable");// Enable Firing Angle Override
-                            }
-                            else
-                            {
-                                weapon.Current.Events["ToggleBurstLengthOverride"].guiName = StringUtils.Localize("#LOC_BDArmory_BurstLengthOverride_Disable");// Disable Firing Angle Override
-                            }
+                    if (weapon.Current == null) continue;
+                    if (weapon.Current.name != part.name) continue;
 
-                            weapon.Current.Fields["fireBurstLength"].guiActive = weapon.Current.BurstOverride;
-                            weapon.Current.Fields["fireBurstLength"].guiActiveEditor = weapon.Current.BurstOverride;
+                    weapon.Current.BurstOverride = !weapon.Current.BurstOverride;
+                    if (!weapon.Current.BurstOverride)
+                    {
+                        weapon.Current.Events["ToggleBurstLengthOverride"].guiName = StringUtils.Localize("#LOC_BDArmory_BurstLengthOverride_Enable");// Enable Firing Angle Override
+                    }
+                    else
+                    {
+                        weapon.Current.Events["ToggleBurstLengthOverride"].guiName = StringUtils.Localize("#LOC_BDArmory_BurstLengthOverride_Disable");// Disable Firing Angle Override
+                    }
 
-                            GUIUtils.RefreshAssociatedWindows(weapon.Current.part);
-                        }
+                    weapon.Current.Fields["fireBurstLength"].guiActive = weapon.Current.BurstOverride;
+                    weapon.Current.Fields["fireBurstLength"].guiActiveEditor = weapon.Current.BurstOverride;
+
+                    GUIUtils.RefreshAssociatedWindows(weapon.Current.part);
                 }
         }
 
@@ -6289,6 +6282,7 @@ namespace BDArmory.Weapons
                         {
                             var wpn = p.GetComponent<ModuleWeapon>();
                             if (wpn == null) continue;
+                            if (wpn.isAPS && !wpn.dualModeAPS) continue;
                             if (wpn.GetWeaponClass() != wpnClass) continue;
                             wpn.WeaponDisplayName = newName;
                             wpn.shortName = newName;

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -1660,7 +1660,7 @@ namespace BDArmory.Weapons
         public void ToggleOverrideAngle()
         {
             FireAngleOverride = !FireAngleOverride;
-            if (FireAngleOverride == false)
+            if (!FireAngleOverride)
             {
                 Events["ToggleOverrideAngle"].guiName = StringUtils.Localize("#LOC_BDArmory_FireAngleOverride_Enable");// Enable Firing Angle Override
             }


### PR DESCRIPTION
-Add veeType = Sub for AI GUI 
-have torpedoes head to last known contact point and start circling it, instead of current sink to bottom behavior.
-Fix BurstFirelength and FireAngleoverride toggle non-function in flight
-Fix APS getting mixed in with global weapon shortnaming and overriding barrage settings
-MML toggle deploy anim toggle now affects symmetry twins
-Fix NREs with MMGs
-Fix multiple anti-ballistic APS getting assigned to the same shell if APS count > tgtShell count