### PR TITLE
Missile(defense) improvements...

### DIFF
--- a/BDArmory/Competition/BDACompetitionMode.cs
+++ b/BDArmory/Competition/BDACompetitionMode.cs
@@ -1102,8 +1102,12 @@ namespace BDArmory.Competition
             }
             if (BDArmorySettings.COMPETITION_GM_KILL_WEAPON)
             {
-                if (VesselModuleRegistry.GetModuleCount<IBDWeapon>(vessel) == 0)
-                    StartCoroutine(DelayedGMKill(vessel, BDArmorySettings.COMPETITION_GM_KILL_TIME, " lost all weapons. Terminated by GM."));
+                var mf = VesselModuleRegistry.GetModule<MissileFire>(vessel);
+                if (mf != null)
+                {
+                    if (!vessel.IsControllable || !mf.HasWeaponsAndAmmo()) // Check first for not controllable or no weapons or ammo
+                        StartCoroutine(DelayedGMKill(vessel, BDArmorySettings.COMPETITION_GM_KILL_TIME, " lost all weapons. Terminated by GM."));
+                }
             }
             if (BDArmorySettings.COMPETITION_GM_KILL_DISABLED)
             {

--- a/BDArmory/Control/BDModuleVTOLAI.cs
+++ b/BDArmory/Control/BDModuleVTOLAI.cs
@@ -35,7 +35,6 @@ namespace BDArmory.Control
         float weaveAdjustment = 0;
         float weaveDirection = 1;
         const float weaveLimit = 15;
-        const float weaveFactor = 6.5f;
 
         Vector3 upDir;
 
@@ -113,6 +112,10 @@ namespace BDArmory.Control
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_MaxBankAngle"),// Max Bank angle
             UI_FloatRange(minValue = 0f, maxValue = 90f, stepIncrement = 1f, scene = UI_Scene.All)]
         public float MaxBankAngle = 30;
+
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_WeaveFactor"),//Weave Factor
+    UI_FloatRange(minValue = 0f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_Scene.All)]
+        public float weaveFactor = 6.5f;
 
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_MinEngagementRange"),//Min engagement range
             UI_FloatRange(minValue = 0f, maxValue = 6000f, stepIncrement = 100f, scene = UI_Scene.All)]

--- a/BDArmory/Control/BDModuleVTOLAI.cs
+++ b/BDArmory/Control/BDModuleVTOLAI.cs
@@ -34,7 +34,7 @@ namespace BDArmory.Control
         Vector3? dodgeVector;
         float weaveAdjustment = 0;
         float weaveDirection = 1;
-        const float weaveLimit = 15;
+        const float weaveLimit = 2.3f;
 
         Vector3 upDir;
 
@@ -115,7 +115,7 @@ namespace BDArmory.Control
 
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_WeaveFactor"),//Weave Factor
     UI_FloatRange(minValue = 0f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_Scene.All)]
-        public float weaveFactor = 6.5f;
+        public float WeaveFactor = 6.5f;
 
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_MinEngagementRange"),//Min engagement range
             UI_FloatRange(minValue = 0f, maxValue = 6000f, stepIncrement = 100f, scene = UI_Scene.All)]
@@ -565,8 +565,8 @@ namespace BDArmory.Control
                 targetVelocity = MaxSpeed;
                 if (weaponManager.underFire || weaponManager.incomingMissileDistance < 2500)
                 {
-                    if (Mathf.Abs(weaveAdjustment) + Time.deltaTime * weaveFactor > weaveLimit) weaveDirection *= -1;
-                    weaveAdjustment += weaveFactor * weaveDirection * Time.deltaTime;
+                    if (Mathf.Abs(weaveAdjustment) + Time.deltaTime * WeaveFactor > weaveLimit * WeaveFactor) weaveDirection *= -1;
+                    weaveAdjustment += WeaveFactor * weaveDirection * Time.deltaTime;
                 }
                 else
                 {

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2092,7 +2092,7 @@ namespace BDArmory.Control
                             //wait for missile turret to point at target
                             attemptStartTime = Time.time;
                             mlauncher = ml as MissileLauncher;
-                            if (mlauncher)
+                            if (targetVessel && mlauncher)
                             {
                                 float angle = 999;
                                 float turretStartTime = attemptStartTime;
@@ -2107,7 +2107,7 @@ namespace BDArmory.Control
                                         yield return wait;
                                     }
                                 }
-                                if (ml && mlauncher.multiLauncher && mlauncher.multiLauncher.turret && heatTarget.exists)
+                                if (mlauncher.multiLauncher && mlauncher.multiLauncher.turret && heatTarget.exists)
                                 {
                                     while (heatTarget.exists && Time.time - turretStartTime < Mathf.Max(targetScanInterval / 2f, 2) && targetVessel && mlauncher && angle > mlauncher.missileTurret.fireFOV)
                                     {
@@ -2250,7 +2250,7 @@ namespace BDArmory.Control
 
                             attemptStartTime = Time.time;
                             MissileLauncher mlauncher = ml as MissileLauncher;
-                            if (mlauncher)
+                            if (targetVessel && mlauncher)
                             {
                                 float angle = 999;
                                 float turretStartTime = attemptStartTime;
@@ -2323,7 +2323,7 @@ namespace BDArmory.Control
                                 yield return wait;
                             }
                             MissileLauncher mlauncher = ml as MissileLauncher;
-                            if (mlauncher && foundCam)
+                            if (targetVessel && mlauncher && foundCam)
                             {
                                 float angle = 999;
                                 float turretStartTime = attemptStartTime;
@@ -2436,7 +2436,7 @@ namespace BDArmory.Control
                         if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileFire]: {vessel.vesselName} attempting to fire unguided missile on target {targetVessel.GetName()}");
 
                         float attemptStartTime = Time.time;
-                        if (mlauncher)
+                        if (targetVessel && mlauncher)
                         {
                             float angle = 999;
                             float turretStartTime = attemptStartTime;

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2850,11 +2850,11 @@ namespace BDArmory.Control
             }
         }
 
-        public void FireECM()
+        public void FireECM(float duration)
         {
             if (!isECMJamming)
             {
-                StartCoroutine(ECMRoutine());
+                StartCoroutine(ECMRoutine(duration));
             }
         }
 
@@ -2907,7 +2907,7 @@ namespace BDArmory.Control
             }
         }
 
-        IEnumerator ECMRoutine()
+        IEnumerator ECMRoutine(float duration)
         {
             isECMJamming = true;
             //yield return new WaitForSecondsFixed(UnityEngine.Random.Range(0.2f, 1f));
@@ -2923,7 +2923,7 @@ namespace BDArmory.Control
                     }
                     ecm.Current.EnableJammer();
                 }
-            yield return new WaitForSecondsFixed(10.0f);
+            yield return new WaitForSecondsFixed(duration);
             isECMJamming = false;
 
             using (var ecm1 = VesselModuleRegistry.GetModules<ModuleECMJammer>(vessel).GetEnumerator())
@@ -7047,7 +7047,7 @@ namespace BDArmory.Control
                         StartCoroutine(UnderAttackRoutine());
 
                         FireChaff();
-                        FireECM();
+                        FireECM(10);
                     }
                     //laser missiles
                     if (results.foundAGM) //Assume Laser Warning Reciever regardless of omniDetection? or move laser missiles to the passive missiles section?
@@ -7080,6 +7080,7 @@ namespace BDArmory.Control
                                             rd.Current.DisableRadar();
                                     }
                                 _radarsEnabled = false;
+                                //FireECM(0); //disable jammers
                             }
                             StartCoroutine(UnderAttackRoutine());
                         }
@@ -7119,6 +7120,7 @@ namespace BDArmory.Control
                                                 }
                                             _radarsEnabled = false;
                                         }
+                                        //FireECM(0); uh oh, blip ECM!
                                     }
                                 }
                                 else //assume heater
@@ -7130,6 +7132,8 @@ namespace BDArmory.Control
                             StartCoroutine(UnderAttackRoutine());
                         }
                     }
+                    if (results.incomingMissiles[0].guidanceType == MissileBase.TargetingModes.Gps)
+                        FireECM(cmThreshold);
                 }
                 else
                 {
@@ -7147,6 +7151,7 @@ namespace BDArmory.Control
                                     }
                                 _radarsEnabled = false;
                             }
+                            FireECM(0); // kill active noisemakers
                             FireDecoys();
                             StartCoroutine(UnderAttackRoutine());
                         }
@@ -7156,7 +7161,7 @@ namespace BDArmory.Control
                         StartCoroutine(UnderAttackRoutine());
 
                         FireBubbles();
-                        FireECM();
+                        FireECM(10);
                     }
                 }
             }

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -1988,7 +1988,7 @@ namespace BDArmory.Control
                                                 break;
                                                 // turretStartTime -= 2 * Time.fixedDeltaTime;
                                             }
-                                            yield return new WaitForFixedUpdate();
+                                            yield return wait;
                                         }
                                     }
                                     if (targetVessel && ml && mlauncher.multiLauncher && mlauncher.multiLauncher.turret && vesselRadarData.locked)
@@ -2003,7 +2003,7 @@ namespace BDArmory.Control
                                                 break;
                                                 // turretStartTime -= 2 * Time.fixedDeltaTime;
                                             }
-                                            yield return new WaitForFixedUpdate();
+                                            yield return wait;
                                         }
                                     }
                                 }
@@ -2137,7 +2137,7 @@ namespace BDArmory.Control
                                             break;
                                             // turretStartTime -= 3 * Time.fixedDeltaTime;
                                         }
-                                        yield return new WaitForFixedUpdate();
+                                        yield return wait;
                                     }
                                 }
                                 if (ml && mlauncher.multiLauncher && mlauncher.multiLauncher.turret && heatTarget.exists)
@@ -2155,7 +2155,7 @@ namespace BDArmory.Control
                                             break;
                                             // turretStartTime -= 3 * Time.fixedDeltaTime;
                                         }
-                                        yield return new WaitForFixedUpdate();
+                                        yield return wait;
                                     }
                                 }
                             }
@@ -2181,6 +2181,7 @@ namespace BDArmory.Control
                             if (SetCargoBays())
                             {
                                 yield return new WaitForSecondsFixed(2f);
+                                if (vessel == null || targetVessel == null) break;
                             }
                             designatedGPSInfo = new GPSTargetInfo(VectorUtils.WorldPositionToGeoCoords(targetVessel.CoM, vessel.mainBody), targetVessel.vesselName.Substring(0, Mathf.Min(12, targetVessel.vesselName.Length)));
                             MissileLauncher mlauncher;
@@ -2202,9 +2203,10 @@ namespace BDArmory.Control
                                             break;
                                             // turretStartTime -= 3 * Time.fixedDeltaTime;
                                         }
-                                        yield return new WaitForFixedUpdate();
+                                        yield return wait;
                                     }
-                                    designatedGPSInfo = new GPSTargetInfo(VectorUtils.WorldPositionToGeoCoords(targetVessel.CoM, vessel.mainBody), targetVessel.vesselName.Substring(0, Mathf.Min(12, targetVessel.vesselName.Length)));
+                                    if (vessel && targetVessel) 
+                                        designatedGPSInfo = new GPSTargetInfo(VectorUtils.WorldPositionToGeoCoords(targetVessel.CoM, vessel.mainBody), targetVessel.vesselName.Substring(0, Mathf.Min(12, targetVessel.vesselName.Length)));
                                 }
                                 if (ml && mlauncher.multiLauncher && mlauncher.multiLauncher.turret)
                                 {
@@ -2221,9 +2223,10 @@ namespace BDArmory.Control
                                             break;
                                             // turretStartTime -= 3 * Time.fixedDeltaTime;
                                         }
-                                        yield return new WaitForFixedUpdate();
+                                        yield return wait;
                                     }
-                                    designatedGPSInfo = new GPSTargetInfo(VectorUtils.WorldPositionToGeoCoords(targetVessel.CoM, vessel.mainBody), targetVessel.vesselName.Substring(0, Mathf.Min(12, targetVessel.vesselName.Length)));
+                                    if (vessel && targetVessel)
+                                        designatedGPSInfo = new GPSTargetInfo(VectorUtils.WorldPositionToGeoCoords(targetVessel.CoM, vessel.mainBody), targetVessel.vesselName.Substring(0, Mathf.Min(12, targetVessel.vesselName.Length)));
                                 }
                             }
                             yield return wait;
@@ -2271,7 +2274,7 @@ namespace BDArmory.Control
                                         mlauncher.multiLauncher.turret.SlavedAim();
                                     }
                                 }
-                                yield return new WaitForFixedUpdate();
+                                yield return wait;
                             }
                             mlauncher = ml as MissileLauncher;
                             if (mlauncher != null)
@@ -2291,7 +2294,7 @@ namespace BDArmory.Control
                                             break;
                                             // turretStartTime -= 3 * Time.fixedDeltaTime;
                                         }
-                                        yield return new WaitForFixedUpdate();
+                                        yield return wait;
                                     }
                                 }
                                 if (ml && mlauncher.multiLauncher && mlauncher.multiLauncher.turret && antiRadTargetAcquired)
@@ -2309,7 +2312,7 @@ namespace BDArmory.Control
                                             break;
                                             // turretStartTime -= 3 * Time.fixedDeltaTime;
                                         }
-                                        yield return new WaitForFixedUpdate();
+                                        yield return wait;
                                     }
                                 }
                             }
@@ -2356,7 +2359,7 @@ namespace BDArmory.Control
                             float attemptDuration = targetScanInterval * 0.75f;
                             while (Time.time - attemptStartTime < attemptDuration && (!laserPointDetected || (foundCam && (foundCam.groundTargetPosition - targetVessel.CoM).sqrMagnitude > 100)))
                             {
-                                yield return new WaitForFixedUpdate();
+                                yield return wait;
                             }
                             MissileLauncher mlauncher = ml as MissileLauncher;
                             if (mlauncher && foundCam)
@@ -2405,6 +2408,7 @@ namespace BDArmory.Control
                             if (SetCargoBays())
                             {
                                 yield return new WaitForSecondsFixed(2f);
+                                if (vessel == null || targetVessel == null) break;
                             }
                             designatedGPSInfo = new GPSTargetInfo(VectorUtils.WorldPositionToGeoCoords(MissileGuidance.GetAirToAirFireSolution(ml, targetVessel.CoM, targetVessel.Velocity()), vessel.mainBody), targetVessel.vesselName.Substring(0, Mathf.Min(12, targetVessel.vesselName.Length)));
 
@@ -2427,8 +2431,10 @@ namespace BDArmory.Control
                                             break;
                                             // turretStartTime -= 3 * Time.fixedDeltaTime;
                                         }
-                                        yield return new WaitForFixedUpdate();
+                                        yield return wait;
                                     }
+                                    if (vessel && targetVessel)
+                                        designatedGPSInfo = new GPSTargetInfo(VectorUtils.WorldPositionToGeoCoords(MissileGuidance.GetAirToAirFireSolution(ml, targetVessel.CoM, targetVessel.Velocity()), vessel.mainBody), targetVessel.vesselName.Substring(0, Mathf.Min(12, targetVessel.vesselName.Length)));
                                 }
                                 if (ml && mlauncher.multiLauncher && mlauncher.multiLauncher.turret)
                                 {
@@ -2445,8 +2451,10 @@ namespace BDArmory.Control
                                             break;
                                             // turretStartTime -= 3 * Time.fixedDeltaTime;
                                         }
-                                        yield return new WaitForFixedUpdate();
+                                        yield return wait;
                                     }
+                                    if (vessel && targetVessel)
+                                        designatedGPSInfo = new GPSTargetInfo(VectorUtils.WorldPositionToGeoCoords(MissileGuidance.GetAirToAirFireSolution(ml, targetVessel.CoM, targetVessel.Velocity()), vessel.mainBody), targetVessel.vesselName.Substring(0, Mathf.Min(12, targetVessel.vesselName.Length)));
                                 }
                             }
                             yield return wait;
@@ -2913,19 +2921,22 @@ namespace BDArmory.Control
         {
             isECMJamming = true;
             //yield return new WaitForSecondsFixed(UnityEngine.Random.Range(0.2f, 1f));
-            using (var ecm = VesselModuleRegistry.GetModules<ModuleECMJammer>(vessel).GetEnumerator())
-                while (ecm.MoveNext())
-                {
-                    if (ecm.Current == null) continue;
-                    if (ecm.Current.manuallyEnabled) continue;
-                    if (ecm.Current.jammerEnabled)
+            if (duration > 0)
+            {
+                using (var ecm = VesselModuleRegistry.GetModules<ModuleECMJammer>(vessel).GetEnumerator())
+                    while (ecm.MoveNext())
                     {
-                        ecm.Current.manuallyEnabled = true;
-                        continue;
+                        if (ecm.Current == null) continue;
+                        if (ecm.Current.manuallyEnabled) continue;
+                        if (ecm.Current.jammerEnabled)
+                        {
+                            ecm.Current.manuallyEnabled = true;
+                            continue;
+                        }
+                        ecm.Current.EnableJammer();
                     }
-                    ecm.Current.EnableJammer();
-                }
-            yield return new WaitForSecondsFixed(duration);
+                yield return new WaitForSecondsFixed(duration);
+            }
             isECMJamming = false;
 
             using (var ecm1 = VesselModuleRegistry.GetModules<ModuleECMJammer>(vessel).GetEnumerator())
@@ -7253,7 +7264,7 @@ namespace BDArmory.Control
             if (!guardTarget) return;
             if (selectedWeapon == null) return;
             int TurretID = 0;
-            int MissileID = 0;
+            int MissileTgtID = 0;
             List<TargetInfo> firedTargets = new List<TargetInfo>();
             using (var weapon = VesselModuleRegistry.GetModules<ModuleWeapon>(vessel).GetEnumerator())
                 while (weapon.MoveNext())
@@ -7305,18 +7316,18 @@ namespace BDArmory.Control
                                 }
                                 TurretID++;
                             }
-                            if (MissileID > Mathf.Min((missilesAssigned.Count - 1), multiTargetNum))
+                            if (MissileTgtID > Mathf.Min((missilesAssigned.Count - 1), multiTargetNum))
                             {
-                                MissileID = 0; //if more turrets than targets, loop target list
+                                MissileTgtID = 0; //if more turrets than targets, loop target list
                             }
-                            if (missilesAssigned.Count > 0 && missilesAssigned[MissileID].Vessel != null) //if missile, override non-missile target
+                            if (missilesAssigned.Count > 0 && missilesAssigned[MissileTgtID].Vessel != null) //if missile, override non-missile target
                             {
                                 if (weapon.Current.engageMissile)
                                 {
-                                    if (TargetInTurretRange(weapon.Current.turret, 7, missilesAssigned[MissileID].Vessel.CoM, weapon.Current))
+                                    if (TargetInTurretRange(weapon.Current.turret, 7, missilesAssigned[MissileTgtID].Vessel.CoM, weapon.Current))
                                     {
-                                        weapon.Current.visualTargetVessel = missilesAssigned[MissileID].Vessel; // if target within turret fire zone, assign
-                                        firedTargets.Add(missilesAssigned[MissileID]);
+                                        weapon.Current.visualTargetVessel = missilesAssigned[MissileTgtID].Vessel; // if target within turret fire zone, assign
+                                        firedTargets.Add(missilesAssigned[MissileTgtID]);
                                     }
                                     else //assigned target outside turret arc, try the other targets on the list
                                     {
@@ -7333,7 +7344,7 @@ namespace BDArmory.Control
                                             }
                                     }
                                 }
-                                MissileID++;
+                                MissileTgtID++;
                             }
                         }
                         else

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -7050,7 +7050,7 @@ namespace BDArmory.Control
                         FireECM(10);
                     }
                     //laser missiles
-                    if (results.foundAGM) //Assume Laser Warning Reciever regardless of omniDetection? or move laser missiles to the passive missiles section?
+                    if (results.foundAGM) //Assume Laser Warning Receiver regardless of omniDetection? Or move laser missiles to the passive missiles section?
                     {
                         StartCoroutine(UnderAttackRoutine());
 
@@ -7062,7 +7062,7 @@ namespace BDArmory.Control
                         }
                     }
                     //passive missiles
-                    if ((results.foundHeatMissile && !results.foundTorpedo) || results.foundAntiRadiationMissile)
+                    if (results.foundHeatMissile || results.foundAntiRadiationMissile)
                     {
                         if (rwr && rwr.omniDetection)
                         {
@@ -7080,8 +7080,11 @@ namespace BDArmory.Control
                                             rd.Current.DisableRadar();
                                     }
                                 _radarsEnabled = false;
-                                //FireECM(0); //disable jammers
+                                FireECM(0); //disable jammers
                             }
+                            
+                            if (results.incomingMissiles[0].guidanceType == MissileBase.TargetingModes.Gps)
+                                FireECM(cmThreshold);
                             StartCoroutine(UnderAttackRoutine());
                         }
                         else //one passive missile is going to be indistinguishable from another, until it gets close enough to evaluate
@@ -7098,6 +7101,13 @@ namespace BDArmory.Control
                                             _radarsEnabled = false;
                                         }
                                 }
+                                /*
+                                if (incomingMissileDistance <= guardRange * 0.33f) //within ID range?
+                                {
+                                    if (results.incomingMissiles[0].guidanceType == MissileBase.TargetingModes.Gps)
+                                        FireECM(cmThreshold);
+                                }
+                                */ //uncomment if we want AI enable jammers to jam incoming GPS oridnance
                             }
                             else //likely a heatseeker, but could be an AA HARM...
                             {
@@ -7121,6 +7131,9 @@ namespace BDArmory.Control
                                             _radarsEnabled = false;
                                         }
                                         //FireECM(0); uh oh, blip ECM!
+                                        //if (results.incomingMissiles[0].guidanceType == MissileBase.TargetingModes.Gps)
+                                        //    FireECM(cmThreshold);
+                                        //uncomment if we want AI to disable ECMJammers when incoming Antirad/enable jammers when incoming GPS oridnance
                                     }
                                 }
                                 else //assume heater
@@ -7132,12 +7145,10 @@ namespace BDArmory.Control
                             StartCoroutine(UnderAttackRoutine());
                         }
                     }
-                    if (results.incomingMissiles[0].guidanceType == MissileBase.TargetingModes.Gps)
-                        FireECM(cmThreshold);
                 }
                 else
                 {
-                    if (results.foundHeatMissile) //standin for passive acoustic homing. Will ahve to expand this if facing *actual* heat-seeking torpedoes
+                    if (results.foundHeatMissile) //standin for passive acoustic homing. Will have to expand this if facing *actual* heat-seeking torpedoes
                     {
                         if ((rwr && rwr.omniDetection) || (incomingMissileDistance <= Mathf.Min(guardRange * 0.33f, 2500))) //within ID range?
                         {

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2178,11 +2178,11 @@ namespace BDArmory.Control
                         }
                     case MissileBase.TargetingModes.Gps:
                         {
-                            designatedGPSInfo = new GPSTargetInfo(VectorUtils.WorldPositionToGeoCoords(targetVessel.CoM, vessel.mainBody), targetVessel.vesselName.Substring(0, Mathf.Min(12, targetVessel.vesselName.Length)));
                             if (SetCargoBays())
                             {
                                 yield return new WaitForSecondsFixed(2f);
                             }
+                            designatedGPSInfo = new GPSTargetInfo(VectorUtils.WorldPositionToGeoCoords(targetVessel.CoM, vessel.mainBody), targetVessel.vesselName.Substring(0, Mathf.Min(12, targetVessel.vesselName.Length)));
                             MissileLauncher mlauncher;
                             mlauncher = ml as MissileLauncher;
                             if (mlauncher != null)
@@ -2204,6 +2204,7 @@ namespace BDArmory.Control
                                         }
                                         yield return new WaitForFixedUpdate();
                                     }
+                                    designatedGPSInfo = new GPSTargetInfo(VectorUtils.WorldPositionToGeoCoords(targetVessel.CoM, vessel.mainBody), targetVessel.vesselName.Substring(0, Mathf.Min(12, targetVessel.vesselName.Length)));
                                 }
                                 if (ml && mlauncher.multiLauncher && mlauncher.multiLauncher.turret)
                                 {
@@ -2222,6 +2223,7 @@ namespace BDArmory.Control
                                         }
                                         yield return new WaitForFixedUpdate();
                                     }
+                                    designatedGPSInfo = new GPSTargetInfo(VectorUtils.WorldPositionToGeoCoords(targetVessel.CoM, vessel.mainBody), targetVessel.vesselName.Substring(0, Mathf.Min(12, targetVessel.vesselName.Length)));
                                 }
                             }
                             yield return wait;

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2995,7 +2995,7 @@ namespace BDArmory.Control
             for (int i = 0; i < count; ++i)
             {
                 DropCMs((int)(CMDropper.CountermeasureTypes.Flare | CMDropper.CountermeasureTypes.Chaff | CMDropper.CountermeasureTypes.Smoke));
-                if (i < count - 1) // Don't wait on the last one.
+                if (i <= count) // Don't wait on the last one.
                     yield return new WaitForSecondsFixed(1f);
             }
             isFlaring = false;
@@ -7219,7 +7219,7 @@ namespace BDArmory.Control
                     {
                         if (weapon.Current.turret)
                         {
-                            if (TurretID > Mathf.Min((targetsAssigned.Count - 1), multiTargetNum))
+                            if (TurretID >= Mathf.Min((targetsAssigned.Count), multiTargetNum))
                             {
                                 TurretID = 0; //if more turrets than targets, loop target list
                             }
@@ -7252,7 +7252,7 @@ namespace BDArmory.Control
                                 }
                                 TurretID++;
                             }
-                            if (MissileTgtID > Mathf.Min((missilesAssigned.Count - 1), multiTargetNum))
+                            if (MissileTgtID >= Mathf.Min((missilesAssigned.Count), multiTargetNum))
                             {
                                 MissileTgtID = 0; //if more turrets than targets, loop target list
                             }
@@ -7444,7 +7444,7 @@ namespace BDArmory.Control
                         if (missile == null) continue;
                         if (!missile.engageMissile) continue;
                         if (missile.HasFired || missile.launched) continue;
-                        if (MissileID > PDMslTgts.Count - 1) MissileID = 0;
+                        if (MissileID >= PDMslTgts.Count) MissileID = 0;
                         if (PDMslTgts.Count > 0)
                         {
                             float targetDist = Vector3.Distance(missile.MissileReferenceTransform.position, PDMslTgts[MissileID].Vessel.CoM);
@@ -7524,14 +7524,14 @@ namespace BDArmory.Control
                     {
                         if (PDBulletTgts.Count > 0)
                         {
-                            if (ballisticTurretID > PDBulletTgts.Count - 1)
+                            if (ballisticTurretID >= PDBulletTgts.Count)
                             {
                                 if ((weapon.Current.isReloading || weapon.Current.isOverheated) || weapon.Current.baseDeviation > 0.05 && (weapon.Current.eWeaponType == ModuleWeapon.WeaponTypes.Ballistic || (weapon.Current.eWeaponType == ModuleWeapon.WeaponTypes.Laser && weapon.Current.pulseLaser)))
                                       //if more APS turrets than targets, and APS is a rotary weapon using volume of fire instead of precision, roll over target list to assign multiple turrets to the incoming shell
                                     ballisticTurretID = 0;
                                     //else assign one turret per target, and hold fire on the rest
                             }
-                            if (ballisticTurretID <= PDBulletTgts.Count - 1)
+                            if (ballisticTurretID < PDBulletTgts.Count)
                             {
                                 if (PDBulletTgts[ballisticTurretID] != null && PDBulletTgts[ballisticTurretID].transform.position.FurtherFromThan(weapon.Current.fireTransforms[0].position, weapon.Current.engageRangeMax * 1.25f)) ballisticTurretID = 0; //reset cycle so out of range guns engage closer targets
                                 if (PDBulletTgts[ballisticTurretID] != null) //second check in case of turretID reset
@@ -7563,12 +7563,12 @@ namespace BDArmory.Control
                     {
                         if (PDRktTgts.Count > 0)
                         {
-                            if (rocketTurretID > PDRktTgts.Count - 1)
+                            if (rocketTurretID >= PDRktTgts.Count)
                             {
                                 if ((weapon.Current.isReloading || weapon.Current.isOverheated) || weapon.Current.baseDeviation > 0.05 && (weapon.Current.eWeaponType == ModuleWeapon.WeaponTypes.Ballistic || (weapon.Current.eWeaponType == ModuleWeapon.WeaponTypes.Laser && weapon.Current.pulseLaser)))
                                     rocketTurretID = 0;
                             }
-                            if (rocketTurretID <= PDRktTgts.Count - 1)
+                            if (rocketTurretID < PDRktTgts.Count)
                             {
                                 if (PDRktTgts[rocketTurretID] != null && PDRktTgts[rocketTurretID].transform.position.FurtherFromThan(weapon.Current.fireTransforms[0].position, weapon.Current.engageRangeMax * 1.25f)) rocketTurretID = 0; //reset cycle so out of range guns engage closer targets
                                 if (PDRktTgts[rocketTurretID] != null)
@@ -7600,7 +7600,7 @@ namespace BDArmory.Control
                             }
                         }
                         else weapon.Current.tgtRocket = null;
-                        if (TurretID > PDMslTgts.Count - 1) TurretID = 0;
+                        if (TurretID >= PDMslTgts.Count) TurretID = 0;
                         if (PDMslTgts.Count > 0)
                         {
                             if (PDMslTgts[TurretID].Vessel != null && PDMslTgts[TurretID].transform.position.FurtherFromThan(weapon.Current.fireTransforms[0].position, weapon.Current.engageRangeMax * 1.25f)) TurretID = 0; //reset cycle so out of range guns engage closer targets

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -5314,7 +5314,7 @@ namespace BDArmory.Control
                                         if (!mlauncher.radarLOAL) candidateTDPS *= 0.001f; //no radar lock, skip to something else unless nothing else available
                                         else
                                         {
-                                            if (mlauncher.radarTimeout < ((distance - mlauncher.activeRadarRange) / mlauncher.optimumAirspeed)) candidateTDPS *= 0.5f; //outside missile self-lock zone -FIXME DISTANCE
+                                            if (mlauncher.radarTimeout < ((distance - mlauncher.activeRadarRange) / mlauncher.optimumAirspeed)) candidateTDPS *= 0.5f; //outside missile self-lock zone 
                                         }
                                     }
                                 }
@@ -5952,7 +5952,7 @@ namespace BDArmory.Control
                                     if (!SLW.radarLOAL) candidateTDPS *= 0.001f; //no radar lock, skip to something else unless nothing else available
                                     else
                                     {
-                                        if (SLW.radarTimeout < ((distance - SLW.activeRadarRange) / SLW.optimumAirspeed)) candidateTDPS *= 0.5f; //outside missile self-lock zone - FIXME DISTANCE
+                                        if (SLW.radarTimeout < ((distance - SLW.activeRadarRange) / SLW.optimumAirspeed)) candidateTDPS *= 0.5f; //outside missile self-lock zone 
                                     }
                                 }
                             }

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2995,7 +2995,7 @@ namespace BDArmory.Control
             for (int i = 0; i < count; ++i)
             {
                 DropCMs((int)(CMDropper.CountermeasureTypes.Flare | CMDropper.CountermeasureTypes.Chaff | CMDropper.CountermeasureTypes.Smoke));
-                if (i <= count) // Don't wait on the last one.
+                if (i < count - 1) // Don't wait on the last one.
                     yield return new WaitForSecondsFixed(1f);
             }
             isFlaring = false;

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -9,6 +9,7 @@
 	- AI GUI fixes for surface AI.
 	- Fix AI disengagement from launched nuclear/EMP ordinance if within projected blast radius.
 	- Expose the weave strength factor as a tunable parameter for the surface and VTOL AI.
+	- AI will now toggle/disable ECM Jammers if underfire from GPS/antiradition ordinance.
 - Weapons:
 	- Fix BurstFirelength and FireAngleOverride toggles not working in flight.
 	- Fix APS parts getting mixed in with global weapon shortnaming and overriding barrage settings.
@@ -29,6 +30,7 @@
 		- Single stage Modular Missiles now activate their engine on launch without needing an AG setup.
 		- Continuously-updating GPS-guided ordinance can now be jammed by a ECM jammer if within the jammer's garble radius.
 		- Missile Interception reworked, tied to PD logic. Missiles set to engage missiles will automatically launch to intercept incoming missiles (assuming viable launch geometry).
+		- Hopefully fix the Missile Turret phantom force issue.
 - Competition:
 	- Include last-damaged-by tracking for bullet explosions that damage vessels, not just hits.
 	- GM kill when weaponless now looks for no weapons with ammo instead of no weapons.

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -4,7 +4,8 @@
 	- Optimise "Vector3.Distance(from, to) < dist" type checks.
 - UI:
 	- rcsOverride enabled ECMJammers now properly affect RCs in the SPH/VAB RCS GUI.
-	- Fix Equivalent Armor Thickness readout in the Armor GUI
+	- Fix Equivalent Armor Thickness readout in the Armor GUI.
+	- Fix custom ammobelt UI overwriting belts on heterogeneous weapon groups.
 - AI / WM:
 	- AI GUI fixes for surface AI.
 	- Fix AI disengagement from launched nuclear/EMP ordinance if within projected blast radius.
@@ -17,7 +18,7 @@
 	- Guns now properly respect crossfeed.
 	- Don't apply the unity integrator correction to the unsupported gravity component of the aiming (improves on-orbit aiming).
 	- Improve the estimate of the required OverlapSphere for Vessel-Relative Bullet Checks for hypervelocity craft.
-	- Increased Abrams Turret Accuracy; Abrams can now hit a tank-sized target from 2km again.
+	- Abrams Turret maxDeviation decreased to 0.1; Abrams bullet spread should reliably hit a tank-sized target from 2km again.
 	- Missiles:
 		- Add new Inertial guidance mode.
 		  - Add new 'inertialDrift' missileLauncher field for INS drift, in meters/sec.

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -31,6 +31,7 @@
 		- Continuously-updating GPS-guided ordinance can now be jammed by a ECM jammer if within the jammer's garble radius.
 		- Missile Interception reworked, tied to PD logic. Missiles set to engage missiles will automatically launch to intercept incoming missiles (assuming viable launch geometry).
 		- Hopefully fix the Missile Turret phantom force issue.
+		- Fix GPS missiles fired from a cargo/custom bay losing lock immediately on firing.
 - Competition:
 	- Include last-damaged-by tracking for bullet explosions that damage vessels, not just hits.
 	- GM kill when weaponless now looks for no weapons with ammo instead of no weapons.

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -8,7 +8,7 @@
 - AI / WM:
 	- AI GUI fixes for surface AI.
 	- Fix AI disengagement from launched nuclear/EMP ordinance if within projected blast radius.
-	- Expose the weave strength factor as a tunable parameter for the surface AI.
+	- Expose the weave strength factor as a tunable parameter for the surface and VTOL AI.
 - Weapons:
 	- Fix BurstFirelength and FireAngleOverride toggles not working in flight.
 	- Fix APS parts getting mixed in with global weapon shortnaming and overriding barrage settings.

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -17,14 +17,20 @@
 	- Don't apply the unity integrator correction to the unsupported gravity component of the aiming (improves on-orbit aiming).
 	- Improve the estimate of the required OverlapSphere for Vessel-Relative Bullet Checks for hypervelocity craft.
 	- Missiles:
+		- Add new Inertial guidance mode.
+		  - Add new 'inertialDrift' missileLauncher field for INS drift, in meters/sec.
 		- Have torpedoes head to last known contact point and start circling it, instead of current sink to bottom behavior.
 		- MultiMissileLauncher deploy anim toggle now affects symmetry twins.
 		- Fix various NullReferenceExceptions when trying to use Modular Missiles.
 		- Antirad missiles using antiRadTypes = 9 now properly home in on active ECM jammers.
+		- Craft without Radar/radarlock will now wait to fire radar LOAL missiles until target distance is close enough that radarTimeout < (tgtDist - activeRadarRange) / optimalAirspeed.
 		- Fix NRE when trying to fire laser-guided missiles from a turret with no targeting cam.
 		- Single stage Modular Missiles now activate their engine on launch without needing an AG setup.
+		- GPS jamming functionality implemented.
+		- Missile Interception reworked, tied to PD logic. Missiles set to engage missiles will automatically launch to intercept incoming missiles (assuming viable launch geometry).
 - Competition:
 	- Include last-damaged-by tracking for bullet explosions that damage vessels, not just hits.
+	- GM kill when weaponless now looks for no weapons with ammo instead of no weapons.
 
 v1.6.7.0
 IMPROVEMENTS / FIXES

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -12,7 +12,7 @@
 - Weapons:
 	- Fix BurstFirelength and FireAngleOverride toggles not working in flight.
 	- Fix APS parts getting mixed in with global weapon shortnaming and overriding barrage settings.
-	- Anti-Ballistic APS no longer assigns multiple turrets to a single incoming shell.
+	- Anti-Ballistic APS no longer assigns multiple turrets to a single incoming shell, now respects reloading/overheated state of the weapon during target assignement
 	- Guns now properly respect crossfeed.
 	- Don't apply the unity integrator correction to the unsupported gravity component of the aiming (improves on-orbit aiming).
 	- Improve the estimate of the required OverlapSphere for Vessel-Relative Bullet Checks for hypervelocity craft.
@@ -26,7 +26,7 @@
 		- Craft without Radar/radarlock will now wait to fire radar LOAL missiles until target distance is close enough that radarTimeout < (tgtDist - activeRadarRange) / optimalAirspeed.
 		- Fix NRE when trying to fire laser-guided missiles from a turret with no targeting cam.
 		- Single stage Modular Missiles now activate their engine on launch without needing an AG setup.
-		- GPS jamming functionality implemented.
+		- Continuously-updating GPS-guided ordinance can now be jammed by a ECM jammer if within the jammer's garble radius.
 		- Missile Interception reworked, tied to PD logic. Missiles set to engage missiles will automatically launch to intercept incoming missiles (assuming viable launch geometry).
 - Competition:
 	- Include last-damaged-by tracking for bullet explosions that damage vessels, not just hits.

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -14,7 +14,7 @@
 - Weapons:
 	- Fix BurstFirelength and FireAngleOverride toggles not working in flight.
 	- Fix APS parts getting mixed in with global weapon shortnaming and overriding barrage settings.
-	- Anti-Ballistic APS no longer assigns multiple turrets to a single incoming shell, now respects reloading/overheated state of the weapon during target assignement
+	- Anti-Ballistic APS no longer assigns multiple turrets to a single incoming shell, now respects reloading/overheated state of the weapon during target assignment.
 	- Guns now properly respect crossfeed.
 	- Don't apply the unity integrator correction to the unsupported gravity component of the aiming (improves on-orbit aiming).
 	- Improve the estimate of the required OverlapSphere for Vessel-Relative Bullet Checks for hypervelocity craft.

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -16,6 +16,7 @@
 	- Guns now properly respect crossfeed.
 	- Don't apply the unity integrator correction to the unsupported gravity component of the aiming (improves on-orbit aiming).
 	- Improve the estimate of the required OverlapSphere for Vessel-Relative Bullet Checks for hypervelocity craft.
+	- Increased Abrams Turret Accuracy; Abrams can now hit a tank-sized target from 2km again.
 	- Missiles:
 		- Add new Inertial guidance mode.
 		  - Add new 'inertialDrift' missileLauncher field for INS drift, in meters/sec.

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,26 +1,28 @@
 ﻿IMPROVEMENTS / FIXES
+- General:
+	- Add tracking of 'named modules' (from non-dependency DLLs) to the VesselModuleRegistry.
+	- Optimise "Vector3.Distance(from, to) < dist" type checks.
+- UI
+	- rcsOverride enabled ECMJammers now properly affect RCs in the SPH/VAB RCS GUI.
+	- Fix Equivalent Armor Thickness readout in the Armor GUI
 - AI / WM
 	- AI GUI fixes for surface AI.
 	- Fix AI disengagement from launched nuclear/EMP ordinance if within projected blast radius.
+	- Expose the weave strength factor as a tunable parameter for the surface AI.
 - Weapons
 	- Fix BurstFirelength and FireAngleOverride toggles not working in flight.
 	- Fix APS parts getting mixed in with global weapon shortnaming and overriding barrage settings.
 	- Anti-Ballistic APS no longer assigns multiple turrets to a single incoming shell.
+	- Guns now properly respect crossfeed.
+	- Don't apply the unity integrator correction to the unsupported gravity component of the aiming (improves on-orbit aiming).
+	- Improve the estimate of the required OverlapSphere for Vessel-Relative Bullet Checks for hypervelocity craft.
 	- Missiles
 		- Have torpedoes head to last known contact point and start circling it, instead of current sink to bottom behavior.
 		- MultiMissileLauncher deploy anim toggle now affects symmetry twins.
 		- Fix various NullReferenceExceptions when trying to use Modular Missiles.
-
-v1.6.7.0
-IMPROVEMENTS / FIXES
-- General:
-	- Add tracking of 'named modules' (from non-dependency DLLs) to the VesselModuleRegistry.
-	- Optimise "Vector3.Distance(from, to) < dist" type checks.
-- AI:
-	- Expose the weave strength factor as a tunable parameter for the surface AI.
-- Weapons:
-	- Don't apply the unity integrator correction to the unsupported gravity component of the aiming (improves on-orbit aiming).
-	- Improve the estimate of the required OverlapSphere for Vessel-Relative Bullet Checks for hypervelocity craft.
+		- Antirad missiles using antiRadTypes = 9 now properly home in on active ECm jammers.
+		- Fix NRE when trying to fire laser-guided missiles from a turret with no targeting cam.
+		- Single stage Modular Missiles now activate their engine on launch without needing a AG setup.
 
 v1.6.7.0
 IMPROVEMENTS / FIXES

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -274,7 +274,14 @@ Localization
         #LOC_BDArmory_simple = Ammo Config: Simple
         #LOC_BDArmory_useBelt = Using Custom Loadout:
         #LOC_BDArmory_save = Save
+        #LOC_BDArmory_saveClose = Save & Close
         #LOC_BDArmory_reset = Reset
+        #LOC_BDArmory_applyTo = Apply To
+        #LOC_BDArmory_WeaponGroup = Weapon Group GUI
+        #LOC_BDArmory_AddToWpnGroup = Add to Weapon Group:
+        #LOC_BDArmory_thisWeapon = this weapon
+        #LOC_BDArmory_SymmetricWeapons = symmetric weapons
+
 
         // Vessel Spawner
         #LOC_BDArmory_BDAVesselSpawner_Title = BDA Vessel Spawner

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/m1Abrams/m1Abrams.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/m1Abrams/m1Abrams.cfg
@@ -78,7 +78,7 @@ MODULE
 	spinDownAnimation = false
 
 	roundsPerMinute = 10
-	maxDeviation = 0.2
+	maxDeviation = 0.1
 	maxTargetingRange = 8000
 	maxEffectiveDistance = 8000
 

--- a/BDArmory/UI/BDAEditorArmorWindow.cs
+++ b/BDArmory/UI/BDAEditorArmorWindow.cs
@@ -1039,7 +1039,7 @@ namespace BDArmory.UI
                 */
                 //armorValue = ProjectileUtils.CalculatePenetration(30, newCaliber, 0.388f, 1109, ArmorDuctility, ArmorDensity, ArmorStrength, 30, 0.8f, false);
                 armorValue = ProjectileUtils.CalculatePenetration(30, 1109, 0.388f, 0.8f, ArmorStrength, ArmorVfactor, ArmorMu1, ArmorMu2, ArmorMu3); //why is this hardcoded? it needs to be the selected armor mat's vars
-                BDAMath.RoundToUnit(steelValue / armorValue, 0.1f)
+                relValue = BDAMath.RoundToUnit(steelValue / armorValue, 0.1f);
                 exploValue = ArmorStrength * (1 + ArmorDuctility) * (ArmorDensity / 1000);
             }
         }

--- a/BDArmory/UI/BDAmmoSelector.cs
+++ b/BDArmory/UI/BDAmmoSelector.cs
@@ -205,7 +205,7 @@ namespace BDArmory.UI
             float line = 0.5f;
             string labelString = GUIstring.ToString() + countString.ToString();
             GUI.Label(new Rect(margin, 0.5f * buttonHeight, width - 2 * margin, buttonHeight), StringUtils.Localize("#LOC_BDArmory_Ammo_Setup"), titleStyle);
-            if (GUI.Button(new Rect(width - 26, 2, 24, 24), "X"))
+            if (GUI.Button(new Rect(width - 26, 2, 24, 24), "X", BDArmorySetup.CloseButtonStyle))
             {
                 open = false;
                 beltString = String.Empty;
@@ -232,7 +232,7 @@ namespace BDArmory.UI
             for (int i = 0; i < AList.Count; i++)
             {
                 string ammoname = String.IsNullOrEmpty(BulletInfo.bullets[AList[i]].DisplayName) ? BulletInfo.bullets[AList[i]].name : BulletInfo.bullets[AList[i]].DisplayName;
-                if (GUI.Button(new Rect(margin * 2, (line + labelLines + ammolines) * buttonHeight, (width - 4 * margin), buttonHeight), ammoname, BDArmorySetup.BDGuiSkin.button))
+                if (GUI.Button(new Rect(margin * 2, (line + labelLines + ammolines) * buttonHeight, (width - 4 * margin), buttonHeight), ammoname, BDArmorySetup.ButtonStyle))
                 {
                     beltString += BulletInfo.bullets[AList[i]].name;
                     beltString += "; ";
@@ -257,7 +257,7 @@ namespace BDArmory.UI
                     ammolines += 1.1f;
                 }
             }
-            if (GUI.Button(new Rect(margin * 5, (line + labelLines + ammolines) * buttonHeight, (width - (10 * margin)) / 2, buttonHeight), StringUtils.Localize("#LOC_BDArmory_reset")))
+            if (GUI.Button(new Rect(margin * 5, (line + labelLines + ammolines) * buttonHeight, (width - (10 * margin)) / 2, buttonHeight), StringUtils.Localize("#LOC_BDArmory_reset"), BDArmorySetup.ButtonStyle))
             {
                 beltString = String.Empty;
                 GUIstring = String.Empty;
@@ -266,17 +266,17 @@ namespace BDArmory.UI
                 labelLines = 1;
                 roundCounter = 1;
             }
-            if (GUI.Button(new Rect(((margin * 5) + ((width - (10 * margin)) / 2)), (line + labelLines + ammolines) * buttonHeight, (width - (10 * margin)) / 2, buttonHeight), StringUtils.Localize("#LOC_BDArmory_save")))
+            if (GUI.Button(new Rect((margin * 5) + ((width - (10 * margin)) / 2), (line + labelLines + ammolines) * buttonHeight, (width - (10 * margin)) / 2, buttonHeight), StringUtils.Localize("#LOC_BDArmory_save"), BDArmorySetup.ButtonStyle))
             {
                 save = true;
                 open = false;
             }
             line += 1.5f;
 
-            GUI.Label(new Rect(margin * 5, (line + labelLines + ammolines) * buttonHeight, width - (10 * margin) , buttonHeight), $"{StringUtils.Localize("#LOC_BDArmory_applyTo")} {_applyWeaponGroupTo}");
-            line += 1.1f;
-            if (_applyWeaponGroupToIndex != (_applyWeaponGroupToIndex = Mathf.RoundToInt(GUI.HorizontalSlider(new Rect(((margin * 5) + (width - (10 * margin))), (line + labelLines + ammolines) * buttonHeight, (width - (10 * margin)) / 2, buttonHeight),
-                _applyWeaponGroupToIndex, 0, 2)))) _applyWeaponGroupTo = applyWeaponGroupTo[_applyWeaponGroupToIndex];
+            GUI.Label(new Rect(margin * 5, (line + labelLines + ammolines) * buttonHeight, (width - (10 * margin)) / 2, buttonHeight), $"{StringUtils.Localize("#LOC_BDArmory_applyTo")} {_applyWeaponGroupTo}");
+            line += 0.2f;
+            if (_applyWeaponGroupToIndex != (_applyWeaponGroupToIndex = Mathf.RoundToInt(GUI.HorizontalSlider(new Rect((margin * 5) + (width - (10 * margin)) / 2, (line + labelLines + ammolines) * buttonHeight, (width - (10 * margin)) / 2, buttonHeight),
+                            _applyWeaponGroupToIndex, 0, 2)))) _applyWeaponGroupTo = applyWeaponGroupTo[_applyWeaponGroupToIndex];
             line += 1.5f;
             height = Mathf.Lerp(height, (line + labelLines + ammolines) * buttonHeight, 0.15f);
             windowRect.height = height;

--- a/BDArmory/WeaponMounts/MissileTurret.cs
+++ b/BDArmory/WeaponMounts/MissileTurret.cs
@@ -584,7 +584,7 @@ namespace BDArmory.WeaponMounts
 
                 ml.vessel.SetPosition(projPos);
                 //if (!ml.reloadableRail) ml.vessel.SetWorldVelocity(railVel + (forwardSpeed * ray.direction)); //this is still imparting veloctity on spawned missiles? Can function without, as long as missile turret is a static SAM site or similar
-                //Whiy is this a thing? MissileLauncher is already imparting forward vel from jettison. If we really need to impart some vel, setWorldvel is absolutely not the method to use.
+                //Why is this a thing? MissileLauncher is already imparting forward vel from jettison. If we really need to impart some vel, setWorldvel is absolutely not the method to use.
                 //else ml.reloadableRail.SpawnedMissile.vessel.SetWorldVelocity(railVel + (forwardSpeed * ray.direction));
                 yield return wait;
 

--- a/BDArmory/WeaponMounts/MissileTurret.cs
+++ b/BDArmory/WeaponMounts/MissileTurret.cs
@@ -583,7 +583,8 @@ namespace BDArmory.WeaponMounts
                 //Vector3 projVel = Vector3.Project(ml.vessel.Velocity-railVel, ray.direction);
 
                 ml.vessel.SetPosition(projPos);
-                if (!ml.reloadableRail) ml.vessel.SetWorldVelocity(railVel + (forwardSpeed * ray.direction)); //this is still imparting veloctity on spawned missiles? Can function without, as long as missile turret is a static SAM site or similar
+                //if (!ml.reloadableRail) ml.vessel.SetWorldVelocity(railVel + (forwardSpeed * ray.direction)); //this is still imparting veloctity on spawned missiles? Can function without, as long as missile turret is a static SAM site or similar
+                //Whiy is this a thing? MissileLauncher is already imparting forward vel from jettison. If we really need to impart some vel, setWorldvel is absolutely not the method to use.
                 //else ml.reloadableRail.SpawnedMissile.vessel.SetWorldVelocity(railVel + (forwardSpeed * ray.direction));
                 yield return wait;
 

--- a/BDArmory/Weapons/Missiles/BDModularGuidance.cs
+++ b/BDArmory/Weapons/Missiles/BDModularGuidance.cs
@@ -1035,7 +1035,7 @@ namespace BDArmory.Weapons.Missiles
             if (StagesNumber == 1)
             {
                 if (SpawnUtils.CountActiveEngines(vessel) < 1)
-                    SpawnUtils.ActivateAllEngines(vessel);
+                    SpawnUtils.ActivateAllEngines(vessel, true, false);
             }
 
             _nextStage++;

--- a/BDArmory/Weapons/Missiles/BDModularGuidance.cs
+++ b/BDArmory/Weapons/Missiles/BDModularGuidance.cs
@@ -1024,7 +1024,7 @@ namespace BDArmory.Weapons.Missiles
 
         /// <summary>
         ///     This method will execute the next ActionGroup. Due to StageManager is designed to work with an active vessel
-        ///     And a missile is not an active vessel. I had to use a different way to handle stages. And action groups works perfect!
+        ///     And a missile is not an active vessel. I had to use a different way to handle stages, and action groups work perfectly!
         /// </summary>
         public void ExecuteNextStage()
         {

--- a/BDArmory/Weapons/Missiles/BDModularGuidance.cs
+++ b/BDArmory/Weapons/Missiles/BDModularGuidance.cs
@@ -1024,7 +1024,7 @@ namespace BDArmory.Weapons.Missiles
 
         /// <summary>
         ///     This method will execute the next ActionGroup. Due to StageManager is designed to work with an active vessel
-        ///     And a missile is not an active vessel. I had to use a different way handle stages. And action groups works perfect!
+        ///     And a missile is not an active vessel. I had to use a different way to handle stages. And action groups works perfect!
         /// </summary>
         public void ExecuteNextStage()
         {

--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -624,7 +624,9 @@ namespace BDArmory.Weapons.Missiles
                         }
                     }
                     //else 
-                    // In theory if the jammer knew the GPS tranceiver channel, could transmit false coords using a more powerful signal to drown out the originals...
+                    // In theory if the jammer knew the GPS tranceiver channel/encryption, could transmit false coords using a more powerful signal to override out the originals...
+                    //currently just cuts off updates and ordinance heads to last valid coords. Instead have jammer Strength come into play and have it be a jStrength * 4prDist^2 check that slows update 
+                    //frequency/increases the RNG threshold to make the GPS update?
                 }
             }
 

--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -599,9 +599,9 @@ namespace BDArmory.Weapons.Missiles
                 gpsTargetCoords_ = targetGPSCoords;
                 if (targetVessel && HasFired && (gpsUpdates >= 0f))
                 {
-                    float distanceToTarget = (vessel.transform.position - gpsTargetCoords_).sqrMagnitude;
+                    float distanceToTargetSqr = (vessel.transform.position - gpsTargetCoords_).sqrMagnitude;
                     float jamDistance = RadarUtils.GetVesselECMJammingDistance(targetVessel.Vessel); //does the target have a jammer, and is the missile within the jammed AoE
-                    if (jamDistance * jamDistance < distanceToTarget) //outside/no area of interference, can receive GPS signal
+                    if (jamDistance * jamDistance < distanceToTargetSqr) //outside/no area of interference, can receive GPS signal
                     {
                         var weaponManager = VesselModuleRegistry.GetMissileFire(SourceVessel);
                         if (weaponManager != null && weaponManager.CanSeeTarget(targetVessel, false))
@@ -1176,7 +1176,8 @@ namespace BDArmory.Weapons.Missiles
             Vector3 TargetCoords_;
             if (!setInertialTarget)
             {
-                driftSeed = new Vector3(UnityEngine.Random.Range(-1, 1) * inertialDrift, UnityEngine.Random.Range(-1, 1) * inertialDrift, UnityEngine.Random.Range(-1, 1) * inertialDrift);
+                //driftSeed = new Vector3(UnityEngine.Random.Range(-1, 1) * inertialDrift, UnityEngine.Random.Range(-1, 1) * inertialDrift, UnityEngine.Random.Range(-1, 1) * inertialDrift);
+                driftSeed = UnityEngine.Random.insideUnitSphere * inertialDrift;
                 setInertialTarget = true;
             }
             TargetCoords_ = targetGPSCoords;

--- a/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
@@ -677,17 +677,11 @@ namespace BDArmory.Weapons.Missiles
             if (wpm != null)
             {
                 if (wpm.targetsAssigned.Count > 0) targetsAssigned.Clear();
-                /* //uncomment when missileInterception working
                 if (wpm.multiMissileTgtNum >= 2 || (missileLauncher.engageMissile && wpm.PDMslTgts.Count > 0))
                 {
                     if (missileLauncher.engageMissile && wpm.PDMslTgts.Count > 0) targetsAssigned.AddRange(wpm.PDMslTgts);
                     else if (wpm.targetsAssigned.Count > 0) targetsAssigned.AddRange(wpm.targetsAssigned);
-                    Debug.Log($"[BDArmory.MultiMissileLauncherDebug]: Num of targets: {targetsAssigned.Count}");
                 }
-                */
-                ///////////////////////////////////////////////// delete below when uncommenting above
-                    targetsAssigned.AddRange(wpm.targetsAssigned);
-                //////////////////////////////////////////////
                 //Debug.Log($"[BDArmory.MultiMissileLauncherDebug]: Num of targets: {targetsAssigned.Count - 1}");
                 if (targetsAssigned.Count < 1)
                     if (wpm.currentTarget != null) targetsAssigned.Add(wpm.currentTarget);

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -5069,7 +5069,7 @@ namespace BDArmory.Weapons
                         targetVelocity = visualTargetPart.vessel.rb_velocity;
                         targetPosition = visualTargetPart.transform.position;
                         visualTargetVessel = visualTargetPart.vessel;
-                        TargetInfo currentTarget = visualTargetVessel.gameObject.GetComponent<TargetInfo>();
+                        TargetInfo currentTarget = (visualTargetVessel != null ? visualTargetVessel.gameObject.GetComponent<TargetInfo>() : null);
                         targetRadius = currentTarget != null ? visualTargetVessel.GetRadius(fireTransforms[0].forward, currentTarget.bounds) : 0;
                     }
                     //targetVelocity -= BDKrakensbane.FrameVelocity;
@@ -6211,7 +6211,7 @@ namespace BDArmory.Weapons
             {
                 editor.Unlock("BD_MN_GUILock");
             }
-            guiWindowRect = GUILayout.Window(GUIUtility.GetControlID(FocusType.Passive), guiWindowRect, GUIWindow, "Weapon Group GUI", Styles.styleEditorPanel);
+            guiWindowRect = GUILayout.Window(GUIUtility.GetControlID(FocusType.Passive), guiWindowRect, GUIWindow, StringUtils.Localize("#LOC_BDArmory_WeaponGroup"), Styles.styleEditorPanel);
         }
 
         string[] applyWeaponGroupTo;
@@ -6226,11 +6226,11 @@ namespace BDArmory.Weapons
 
             GUILayout.BeginHorizontal();
 
-            GUILayout.Label("Add to Weapon Group: ");
+            GUILayout.Label($"{StringUtils.Localize("#LOC_BDArmory_WeaponGroup")} ");
 
             txtName = GUILayout.TextField(txtName);
 
-            if (GUILayout.Button("Save & Close"))
+            if (GUILayout.Button(StringUtils.Localize("#LOC_BDArmory_saveClose")))
             {
                 string newName = string.IsNullOrEmpty(txtName.Trim()) ? WPNmodule.OriginalShortName : txtName.Trim();
 
@@ -6292,7 +6292,7 @@ namespace BDArmory.Weapons
 
             GUILayout.EndHorizontal();
             GUILayout.BeginHorizontal();
-            GUILayout.Label($"Apply to {_applyWeaponGroupTo}");
+            GUILayout.Label($"{StringUtils.Localize("#LOC_BDArmory_applyTo")} {_applyWeaponGroupTo}");
             if (_applyWeaponGroupToIndex != (_applyWeaponGroupToIndex = Mathf.RoundToInt(GUILayout.HorizontalSlider(_applyWeaponGroupToIndex, 0, 4, GUILayout.Width(150))))) _applyWeaponGroupTo = applyWeaponGroupTo[_applyWeaponGroupToIndex];
             GUILayout.EndHorizontal();
 

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -5124,7 +5124,7 @@ namespace BDArmory.Weapons
                 delayTime = eWeaponType == WeaponTypes.Ballistic ? (targetDistance / (bulletVelocity + targetVelocity.magnitude)) : (eWeaponType == WeaponTypes.Rocket ? (targetDistance / ((targetDistance / predictedFlightTime) + targetVelocity.magnitude)) : -1);
                 if (delayTime < 0)
                 {
-                    delayTime = rocket != null ? 0.5f : (shell.bulletMass * (1 - Mathf.Clamp(shell.tntMass / shell.bulletMass, 0f, 0.95f) / 2)); //for shells, laser delay time is based on shell mass/HEratio. The heavier the shell, the mroe mass to burn through. Don't expect to stop sabots via laser APS
+                    delayTime = rocket != null ? 0.5f : (shell.bulletMass * (1 - Mathf.Clamp(shell.tntMass / shell.bulletMass, 0f, 0.95f) / 2)); //for shells, laser delay time is based on shell mass/HEratio. The heavier the shell, the more mass to burn through. Don't expect to stop sabots via laser APS
                     var angularSpread = tanAngle * targetDistance;
                     delayTime /= ((laserDamage / (1 + Mathf.PI * angularSpread * angularSpread) * 0.425f) / 100);
                     if (delayTime < TimeWarp.fixedDeltaTime) delayTime = 0;


### PR DESCRIPTION
...And some minor tank round stuff
-Tweak Abrams Turret accuracy
-GM 'no Weapon' kill now looks for no weapons with ammo, instead of no weapons
-Make Weave Strength editable for VTOL AI
-Add GPS jamming functionality for jamming continuously-updating GPS munitions
-AI will toggle/disable jammers if incoming GPS/Antirad ordinance
-Add Inertial Guidance mode for missiles
-Tweak AI launch behavior when launching radar missiles without a radar(lock) to wait until within missile's self lockon range
-Rework missile interception, missiles set to engageMissiles = true will now autolaunch against incoming missiles (launch geometry permitting)
-APS now accounts for if individual turrets are reloading/overheated when distributing targets.
-APS will only assign single interceptor turret to incoming shells; rapid fire APS relying on weight of fire instead of precision will still assign multiple turrets if there are more turrets than targets
-Fix Antirads set to home in on ECM jammers not homing.
-Single-stage Modular missiles now auto-ignite motor(s) on launch if no launch AG setup.
