### PR TITLE
Heater selection tweak

### DIFF
--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -5253,7 +5253,7 @@ namespace BDArmory.Control
                                     candidateTDPS += candidateDetDist; // weight selection towards misiles with proximity warheads
                                 }
                                 if (heat && heatTarget.exists && heatTarget.signalStrength *
-                                        ((BDArmorySettings.ASPECTED_IR_SEEKERS && Vector3.Dot(guardTarget.vesselTransform.up, vessel.vesselTransform.up) > 0.25f) ?
+                                        ((BDArmorySettings.ASPECTED_IR_SEEKERS && Vector3.Dot(guardTarget.vesselTransform.up, mlauncher.transform.forward) > 0.25f) ?
                                         mlauncher.frontAspectHeatModifier : 1) < heatThresh)
                                 {
                                     candidateTDPS *= 0.001f; //Heatseeker, but IR sig is below missile threshold, skip to something else unless nothing else available

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -5252,9 +5252,11 @@ namespace BDArmory.Control
                                 {
                                     candidateTDPS += candidateDetDist; // weight selection towards misiles with proximity warheads
                                 }
-                                if (heat && heatTarget.exists && heatTarget.signalStrength < heatThresh)
+                                if (heat && heatTarget.exists && heatTarget.signalStrength *
+                                        ((BDArmorySettings.ASPECTED_IR_SEEKERS && Vector3.Dot(guardTarget.vesselTransform.up, vessel.vesselTransform.up) < 0.65f) ?
+                                        mlauncher.frontAspectHeatModifier : 1) < heatThresh)
                                 {
-                                    candidateTDPS *= 0.001f; //Heatseeker, but IR sig is below missile threshold, skip to something else unless nutohine else available
+                                    candidateTDPS *= 0.001f; //Heatseeker, but IR sig is below missile threshold, skip to something else unless nothing else available
                                 }
                                 if (radar)
                                 {

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -5253,7 +5253,7 @@ namespace BDArmory.Control
                                     candidateTDPS += candidateDetDist; // weight selection towards misiles with proximity warheads
                                 }
                                 if (heat && heatTarget.exists && heatTarget.signalStrength *
-                                        ((BDArmorySettings.ASPECTED_IR_SEEKERS && Vector3.Dot(guardTarget.vesselTransform.up, vessel.vesselTransform.up) < 0.65f) ?
+                                        ((BDArmorySettings.ASPECTED_IR_SEEKERS && Vector3.Dot(guardTarget.vesselTransform.up, vessel.vesselTransform.up) > 0.25f) ?
                                         mlauncher.frontAspectHeatModifier : 1) < heatThresh)
                                 {
                                     candidateTDPS *= 0.001f; //Heatseeker, but IR sig is below missile threshold, skip to something else unless nothing else available

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -35,6 +35,7 @@
 		- Fix GPS missiles fired from a cargo/custom bay losing lock immediately on firing.
 		- Fix typo in Dynamic Launch Zone calculation that was preventing some missiles from launching.
 		- Remove global toggle to use Dynamic or Static launch range for missiles and replace it with a per-missile toggle. When toggled on, the missile will launch missiles at their max engagement range without taking into account craft velocities.
+		- Incorporate missile frontAspectHeatModifier value into missile selection logic so rear-aspect missiles are not selected if they cannot be fired.
 - Competition:
 	- Include last-damaged-by tracking for bullet explosions that damage vessels, not just hits.
 	- GM kill when weaponless now looks for no weapons with ammo instead of no weapons.


### PR DESCRIPTION
- Incorporate missile frontAspectHeatModifier value into missile selection logic so rear-aspect missiles are not selected if they cannot be fired.