### PR TITLE
Missile/Chaff Adjustments

### DIFF
--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -125,25 +125,11 @@ namespace BDArmory.Control
             // does not update the info. :( No idea how to force an update.
             StringBuilder sb = new StringBuilder();
             sb.AppendLine("<b>Available settings</b>:");
-            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Vehicle type</color> - can this vessel operate on land/sea/both");
-            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Max slope angle</color> - what is the steepest slope this vessel can negotiate");
-            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Cruise speed</color> - the default speed at which it is safe to maneuver");
-            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Max speed</color> - the maximum combat speed");
-            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Max drift</color> - maximum allowed angle between facing and velocity vector");
-            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Moving pitch</color> - the pitch level to maintain when moving at cruise speed");
-            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Bank angle</color> - the limit on roll when turning, positive rolls into turns");
-            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Steer Factor</color> - higher will make the AI apply more control input for the same desired rotation");
-            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Steer Damping</color> - higher will make the AI apply more control input when it wants to stop rotation");
-            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Attack vector</color> - does the vessel attack from the front or the sides");
-            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Min engagement range</color> - AI will try to move away from oponents if closer than this range");
-            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Max engagement range</color> - AI will prioritize getting closer over attacking when beyond this range");
-            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- RCS active</color> - Use RCS during any maneuvers, or only in combat ");
-            if (GameSettings.ADVANCED_TWEAKABLES)
-            {
-                sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Min obstacle mass</color> - Obstacles of a lower mass than this will be ignored instead of avoided");
-                sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Goes up to</color> - Increases variable limits, no direct effect on behaviour");
-            }
-
+            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Min Engagement Range</color> - can this vessel operate on land/sea/both");
+            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- RCS Active</color> - Use RCS during any maneuvers, or only in combat");
+            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Maneuver Speed</color> - Max speed relative to target during intercept maneuvers");
+            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Strafing Speed</color> - Max speed relative to target during gun firing");
+            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Evasion</color> - Evade missiles, or not");
             return sb.ToString();
         }
 

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2467,8 +2467,8 @@ namespace BDArmory.Control
                         if (ml && targetVessel && GetLaunchAuthorization(targetVessel, this, ml))
                         {
                             FireCurrentMissile(ml, true);
-                            unguidedWeapon = false;
                         }
+                        unguidedWeapon = false;
                     }
                 }
                 guardFiringMissile = false;
@@ -7744,7 +7744,7 @@ namespace BDArmory.Control
                     float fTime = Mathf.Min(missile.dropTime, 2f);
                     Vector3 futurePos = target + (targetV.Velocity() * fTime);
                     Vector3 myFuturePos = vessel.ReferenceTransform.position + (vessel.Velocity() * fTime);
-                    launchAuthorized = launchAuthorized && (missile.maxOffBoresight >= 360 ? true : Vector3.Angle(missile.GetForwardTransform(), futurePos - myFuturePos) < (unguidedWeapon ? 5 : missile.maxOffBoresight * boresightFactor)); // Launch is likely also possible at fTime
+                    launchAuthorized = launchAuthorized && ((!unguidedWeapon && missile.maxOffBoresight >= 360) ? true : Vector3.Angle(missile.GetForwardTransform(), futurePos - myFuturePos) < (unguidedWeapon ? 5 : missile.maxOffBoresight * boresightFactor)); // Launch is likely also possible at fTime
                 }
             }
 

--- a/BDArmory/CounterMeasure/CMChaff.cs
+++ b/BDArmory/CounterMeasure/CMChaff.cs
@@ -36,7 +36,7 @@ namespace BDArmory.CounterMeasure
                 gameObject.SetActive(false);
                 return;
             }
-
+            pe.useWorldSpace = false; // Don't use worldspace, so that we can move the FX properly.
             StartCoroutine(LifeRoutine());
         }
 
@@ -57,7 +57,7 @@ namespace BDArmory.CounterMeasure
             while (Time.time - startTime < pe.maxEnergy)
             {
                 position = body.GetWorldSurfacePosition(geoPos.x, geoPos.y, geoPos.z);
-                velocity += FlightGlobals.getGeeForceAtPosition(position) * Time.fixedDeltaTime;
+                velocity += FlightGlobals.getGeeForceAtPosition(position, body) * Time.fixedDeltaTime;
                 Vector3 dragForce = (0.008f) * drag * 0.5f * velocity.sqrMagnitude *
                                     (float)
                                     FlightGlobals.getAtmDensity(FlightGlobals.getStaticPressure(position),

--- a/BDArmory/CounterMeasure/CMDropper.cs
+++ b/BDArmory/CounterMeasure/CMDropper.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 using BDArmory.Settings;
 using BDArmory.UI;
 using BDArmory.Utils;
+using BDArmory.Extensions;
 
 namespace BDArmory.CounterMeasure
 {
@@ -308,7 +309,7 @@ namespace BDArmory.CounterMeasure
 
             GameObject cm = chaffPool.GetPooledObject();
             CMChaff chaff = cm.GetComponent<CMChaff>();
-            chaff.Emit(ejectTransform.position, ejectVelocity * ejectTransform.forward);
+            chaff.Emit(ejectTransform.position, ejectVelocity * ejectTransform.forward + vessel.Velocity());
 
             FireParticleEffects();
             return true;

--- a/BDArmory/CounterMeasure/VesselChaffInfo.cs
+++ b/BDArmory/CounterMeasure/VesselChaffInfo.cs
@@ -48,8 +48,9 @@ namespace BDArmory.CounterMeasure
 
         void FixedUpdate()
         {
+            float speedOrAccel = (vessel.atmDensity > 0.05) ? (float)vessel.srfSpeed : Mathf.Abs((float)vessel.acceleration_immediate.magnitude);
             chaffScalar = Mathf.MoveTowards(chaffScalar, chaffMax,
-                Mathf.Clamp(speedRegenMult * (float)vessel.srfSpeed, minRegen, maxRegen) * Time.fixedDeltaTime);
+                Mathf.Clamp(speedRegenMult * speedOrAccel, minRegen, maxRegen) * Time.fixedDeltaTime);
         }
     }
 }

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -14,6 +14,10 @@
 		  - Add new Orbital guidance option for Modular Missiles
 		    - Missile will attempt to intercept orbital target at the user-set Max Speed value
       - Fix clustermissiles launching copies of themselves instead of submunitions.
+	  - Fix for HEKV launching unguided in non-ideal situations.
+- Countermeasures
+	- Add vessel's velocity to chaff ejection particles.
+	- Use vessel acceleration instead of velocity for chaff decoy factor calculation when in space.
 - Vessel Mover:
 	- Check for outdated loadMeta files when refreshing the craft list in the vessel selection window and update them since KSP doesn't update them when you save your craft!
 	- Fix the spawn point selection sometimes not registering.

--- a/BDArmory/Targeting/TargetSignatureData.cs
+++ b/BDArmory/Targeting/TargetSignatureData.cs
@@ -164,6 +164,7 @@ namespace BDArmory.Targeting
             {
                 // chaff check
                 decoyFactor = (1f - RadarUtils.GetVesselChaffFactor(vessel));
+                Vector3 velOrAccel = (vessel.atmDensity > 0.05) ? vessel.Velocity() : vessel.acceleration_immediate;
 
                 if (decoyFactor > 0f)
                 {
@@ -177,10 +178,10 @@ namespace BDArmory.Targeting
                     float distortionFactor = decoyFactor * UnityEngine.Random.Range(16f, 256f);
 
                     // Convert Float jammingFactor position bias and signatureFactor scaling to Vector3 position
-                    Vector3 signatureDistortion = distortionFactor * (UnityEngine.Random.insideUnitSphere - jammingFactor * vessel.Velocity().normalized);
+                    Vector3 signatureDistortion = distortionFactor * (UnityEngine.Random.insideUnitSphere - jammingFactor * velOrAccel.normalized);
 
                     // Higher speed -> missile decoyed further "behind" where the chaff drops (also means that chaff is least effective for head-on engagements)
-                    posDistortion = signatureDistortion - Mathf.Clamp(decoyFactor * decoyFactor, 0f, 0.5f) * vessel.Velocity();
+                    posDistortion = signatureDistortion - Mathf.Clamp(decoyFactor * decoyFactor, 0f, 0.5f) * velOrAccel;
 
                     // Apply effects from global settings and individual missile chaffEffectivity
                     posDistortion *= Mathf.Max(BDArmorySettings.CHAFF_FACTOR, 0f) * chaffEffectivity;


### PR DESCRIPTION
- Add vessel's velocity to chaff ejection particles.
- Use vessel acceleration instead of velocity for chaff decoy factor calculation when in space.
- Fix for HEKV launching unguided in non-ideal situations.