### PR TITLE
Orbital AI Update

### DIFF
--- a/BDArmory/Competition/BDACompetitionMode.cs
+++ b/BDArmory/Competition/BDACompetitionMode.cs
@@ -587,7 +587,7 @@ namespace BDArmory.Competition
                             {
                                 ModuleCommand MC;
                                 MC = part.Current.GetComponent<ModuleCommand>();
-                                if (part.Current.CrewCapacity == 0 && MC.minimumCrew == 0) //Drone core, nuke it
+                                if (part.Current.CrewCapacity == 0 && MC.minimumCrew == 0 && !SpawnUtils.IsModularMissilePart(part.Current)) //Non-MMG drone core, nuke it
                                     part.Current.RemoveModule(MC);
                             }
                             if (BDArmorySettings.RUNWAY_PROJECT_ROUND == 59)

--- a/BDArmory/Competition/BDACompetitionMode.cs
+++ b/BDArmory/Competition/BDACompetitionMode.cs
@@ -745,7 +745,10 @@ namespace BDArmory.Competition
             {
                 var pilotAI = VesselModuleRegistry.GetBDModulePilotAI(leaders[i].vessel, true); // Adjust initial fly-to point for terrain and default altitudes.
                 var startPosition = center + startDirection + (pilotAI != null ? (pilotAI.defaultAltitude - BodyUtils.GetRadarAltitudeAtPos(center + startDirection, false)) * VectorUtils.GetUpDirection(center + startDirection) : Vector3.zero);
-                leaders[i].CommandFlyTo(VectorUtils.WorldPositionToGeoCoords(startPosition, FlightGlobals.currentMainBody));
+                if (VesselModuleRegistry.GetModule<BDModuleOrbitalAI>(leaders[i].vessel, true))
+                    leaders[i].CommandFlyTo(leaders[i].vessel.CoM + (leaders[i].vessel.CoM - center));
+                else
+                    leaders[i].CommandFlyTo(VectorUtils.WorldPositionToGeoCoords(startPosition, FlightGlobals.currentMainBody));
                 startDirection = directionStep * startDirection;
             }
 

--- a/BDArmory/Control/BDAirspeedControl.cs
+++ b/BDArmory/Control/BDAirspeedControl.cs
@@ -513,7 +513,7 @@ namespace BDArmory.Control
             float rcsLerpT = rcsLerpRate * Time.fixedDeltaTime * Mathf.Clamp01(rcsLerpMag / RCSPower);
 
             if (rcsRotate) // Quickly rotate RCS thrust towards commanded RCSVector
-                RCSVectorLerped = Vector3.RotateTowards(RCSVectorLerped, RCSVector, rcsLerpT, rcsLerpT);
+                RCSVectorLerped = Vector3.Slerp(RCSVectorLerped, RCSVector, rcsLerpT);
             else // Gradually lerp RCS thrust towards commanded RCSVector
                 RCSVectorLerped = Vector3.Lerp(RCSVectorLerped, RCSVector, rcsLerpT);
             RCSThrottle = Mathf.Lerp(0, 1.732f, Mathf.InverseLerp(0, RCSPower, rcsLerpMag));

--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -234,7 +234,6 @@ namespace BDArmory.Control
             while (true)
             {
                 lastUpdate = Time.time;
-                UpdateStatus();
                 yield return PilotLogic();
                 if (!vessel) yield break; // Abort if the vessel died.
             }
@@ -259,9 +258,13 @@ namespace BDArmory.Control
         #region Actual AI Pilot
         protected override void AutoPilot(FlightCtrlState s)
         {
-
+            // TO-DO: re-work logic of ShipController and PilotLogic to be run from AutoPilot
             upDir = VectorUtils.GetUpDirection(vesselTransform.position);
+            UpdateStatus();
+        }
 
+        void AddDebugMessages()
+        {
             if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI)
             {
                 debugString.AppendLine($"Current Status: {currentStatus}");

--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -237,6 +237,7 @@ namespace BDArmory.Control
             GUIUtils.DrawLineBetweenWorldPositions(vesselTransform.position, debugPosition, 5, Color.red); // Target intercept position
             GUIUtils.DrawLineBetweenWorldPositions(vesselTransform.position, fc.attitude * 100, 5, Color.green); // Attitude command
             GUIUtils.DrawLineBetweenWorldPositions(vesselTransform.position, fc.RCSVector * 100, 5, Color.cyan); // RCS command
+            GUIUtils.DrawLineBetweenWorldPositions(vesselTransform.position, fc.RCSVectorLerped * 100, 5, Color.blue); // RCS lerped command
 
             GUIUtils.DrawLineBetweenWorldPositions(vesselTransform.position, vesselTransform.position + vesselTransform.up * 1000, 3, Color.white);
         }
@@ -850,8 +851,19 @@ namespace BDArmory.Control
 
         private void UpdateRCSVector(Vector3 inputVec = default(Vector3))
         {
-            // Sets RCS vector on flight controller
-            fc.RCSVector = evadingGunfire ? Vector3.ProjectOnPlane(evasionNonLinearityDirection, threatRelativePosition) : inputVec;
+            if (evadingGunfire) // Quickly move RCS vector
+            {
+                inputVec = Vector3.ProjectOnPlane(evasionNonLinearityDirection, threatRelativePosition);
+                fc.rcsLerpRate = 15f;
+                fc.rcsRotate = true;
+            }
+            else // Slowly lerp RCS vector
+            {
+                fc.rcsLerpRate = 5f;
+                fc.rcsRotate = false;
+            }
+            
+            fc.RCSVector = inputVec;
         }
 
         private Vector3 ToClosestApproach(Vector3 toTarget, Vector3 relVel, float minRange)

--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -658,6 +658,8 @@ namespace BDArmory.Control
                 currentStatusMode = StatusMode.Firing; // Guns
             else if (weaponManager && targetVessel != null && weaponManager.CurrentMissile && !weaponManager.GetLaunchAuthorization(targetVessel, weaponManager, weaponManager.CurrentMissile))
                 currentStatusMode = StatusMode.Firing; // Missiles
+            else if (weaponManager && targetVessel != null && weaponManager.CurrentMissile && weaponManager.guardFiringMissile && currentStatusMode == StatusMode.Firing)
+                currentStatusMode = StatusMode.Firing; // Post-launch authorization missile firing underway, don't change status from Firing
             else if (weaponManager && targetVessel != null && hasWeapons)
                 if (hasPropulsion)
                     currentStatusMode = StatusMode.Maneuvering;

--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -338,7 +338,8 @@ namespace BDArmory.Control
                             threatRelativePosition = weaponManager.incomingThreatPosition - vesselTransform.position;
                     }
                 }
-                evadingGunfire = true;
+                // Evade gunfire if we are not evading a missile
+                evadingGunfire = !(weaponManager.missileIsIncoming && weaponManager.incomingMissileVessel && weaponManager.incomingMissileTime <= weaponManager.evadeThreshold);
                 evasiveTimer += Time.fixedDeltaTime;
 
                 if (evasiveTimer >= minEvasionTime)
@@ -884,13 +885,7 @@ namespace BDArmory.Control
         private void UpdateRCSVector(Vector3 inputVec = default(Vector3))
         {
             // Sets RCS vector on flight controller
-
-            // If we are evading gunfire, try to evade with RCS
-            if (!weaponManager.missileIsIncoming && evadingGunfire)
-                inputVec = Vector3.ProjectOnPlane(evasionNonLinearityDirection, threatRelativePosition);
-            //else use inputVec
-
-            fc.RCSVector = inputVec;
+            fc.RCSVector = evadingGunfire ? Vector3.ProjectOnPlane(evasionNonLinearityDirection, threatRelativePosition) : inputVec;
         }
 
         private Vector3 ToClosestApproach(Vector3 toTarget, Vector3 relVel, float minRange)

--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -11,10 +11,7 @@ using BDArmory.Settings;
 using BDArmory.UI;
 using BDArmory.Utils;
 using BDArmory.Weapons;
-using BDArmory.Weapons.Missiles;
 using BDArmory.Guidances;
-using static BDArmory.Control.BDModuleOrbitalAI;
-using System.Diagnostics.Eventing.Reader;
 
 namespace BDArmory.Control
 {

--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -163,7 +163,14 @@ namespace BDArmory.Control
             sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- RCS Active</color> - Use RCS during any maneuvers, or only in combat");
             sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Maneuver Speed</color> - Max speed relative to target during intercept maneuvers");
             sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Strafing Speed</color> - Max speed relative to target during gun firing");
-            sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Evasion</color> - Evade missiles, or not");
+            if (GameSettings.ADVANCED_TWEAKABLES)
+            {
+                sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Min Evasion Time</color> - Minimum seconds AI will evade for");
+                sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Evasion Distance Threshold</color> - How close incoming gunfire needs to come to trigger evasion");
+                sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Evasion Time Threshold</color> - How many seconds the AI needs to be under fire to begin evading");
+                sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Evasion Min Range Threshold</color> - Attacker needs to be beyond this range to trigger evasion");
+                sb.AppendLine($"<color={XKCDColors.HexFormat.Cyan}>- Don't Evade My Target</color> - Whether gunfire from the current target is ignored for evasion");
+            }
             return sb.ToString();
         }
 

--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -13,6 +13,8 @@ using BDArmory.Utils;
 using BDArmory.Weapons;
 using BDArmory.Weapons.Missiles;
 using BDArmory.Guidances;
+using static BDArmory.Control.BDModuleOrbitalAI;
+using System.Diagnostics.Eventing.Reader;
 
 namespace BDArmory.Control
 {
@@ -24,7 +26,6 @@ namespace BDArmory.Control
         #region Declarations
 
         // Orbiter AI variables.
-        public float commandedBurn = 10f;
         public float updateInterval;
         public float emergencyUpdateInterval = 0.5f;
         public float combatUpdateInterval = 2.5f;
@@ -32,12 +33,14 @@ namespace BDArmory.Control
         public float firingAngularVelocityLimit = 1; // degrees per second
 
         private BDOrbitalControl fc;
-        private Coroutine shipController;
-        private Coroutine maxAccelerationCR;
 
         public IBDWeapon currentWeapon;
 
-        private float lastUpdate;
+        private Vector3 withdrawDeltaV;
+        private float maneuverTime;
+        private float minManeuverTime;
+        private bool maneuverStateChanged = false;
+        private bool belowSafeAlt = false;
         private bool hasPropulsion;
         private bool hasWeapons;
         private float maxAcceleration;
@@ -133,7 +136,7 @@ namespace BDArmory.Control
         #endregion
 
         #region Status Mode
-        public enum StatusMode { Idle, Evading, CorrectingOrbit, Withdrawing, Firing, Maneuvering, Stranded, Custom }
+        public enum StatusMode { Idle, Evading, CorrectingOrbit, Withdrawing, Firing, Maneuvering, Stranded, Commanded, Custom }
         public StatusMode currentStatusMode = StatusMode.Idle;
         StatusMode lastStatusMode = StatusMode.Idle;
         protected override void SetStatus(string status)
@@ -149,6 +152,7 @@ namespace BDArmory.Control
             else if (status.StartsWith("Firing")) currentStatusMode = StatusMode.Firing;
             else if (status.StartsWith("Maneuvering")) currentStatusMode = StatusMode.Maneuvering;
             else if (status.StartsWith("Stranded")) currentStatusMode = StatusMode.Stranded;
+            else if (status.StartsWith("Commanded")) currentStatusMode = StatusMode.Commanded;
             else currentStatusMode = StatusMode.Custom;
         }
         #endregion
@@ -199,10 +203,6 @@ namespace BDArmory.Control
                 fc.throttleLerpRate = 3;
             }
             fc.Activate();
-            updateInterval = combatUpdateInterval;
-
-            if (maxAccelerationCR == null) maxAccelerationCR = StartCoroutine(CalculateMaxAcceleration());
-            if (shipController == null) shipController = StartCoroutine(ShipController());
         }
 
         public override void DeactivatePilot()
@@ -215,28 +215,7 @@ namespace BDArmory.Control
                 fc = null;
             }
 
-            if (maxAccelerationCR != null)
-            {
-                StopCoroutine(maxAccelerationCR);
-                maxAccelerationCR = null;
-            }
-            if (shipController != null)
-            {
-                StopCoroutine(shipController);
-                shipController = null;
-            }
-
             SetStatus("");
-        }
-
-        private IEnumerator ShipController()
-        {
-            while (true)
-            {
-                lastUpdate = Time.time;
-                yield return PilotLogic();
-                if (!vessel) yield break; // Abort if the vessel died.
-            }
         }
 
         protected override void OnGUI()
@@ -258,9 +237,349 @@ namespace BDArmory.Control
         #region Actual AI Pilot
         protected override void AutoPilot(FlightCtrlState s)
         {
-            // TO-DO: re-work logic of ShipController and PilotLogic to be run from AutoPilot
+            // Update vars
+            InitialFrameUpdates();
+
+            UpdateStatus(); // Combat decisions, evasion, maneuverStateChanged = true and set new statusMode, etc.
+            
+            maneuverTime += Time.fixedDeltaTime;
+            if (maneuverStateChanged || maneuverTime > minManeuverTime)
+            {
+                maneuverTime = 0;
+                evasionNonLinearityDirection = UnityEngine.Random.insideUnitSphere;
+                fc.lerpAttitude = true;
+                minManeuverTime = combatUpdateInterval;
+                UpdateRCSVector();
+                switch (currentStatusMode)
+                {
+                    case StatusMode.Evading:
+                        minManeuverTime = emergencyUpdateInterval;
+                        break;
+                    case StatusMode.CorrectingOrbit:
+                        break;
+                    case StatusMode.Withdrawing:
+                        {
+                            // Determine the direction.
+                            Vector3 averagePos = Vector3.zero;
+                            using (List<TargetInfo>.Enumerator target = BDATargetManager.TargetList(weaponManager.Team).GetEnumerator())
+                                while (target.MoveNext())
+                                {
+                                    if (target.Current == null) continue;
+                                    if (target.Current && target.Current.Vessel && weaponManager.CanSeeTarget(target.Current))
+                                    {
+                                        averagePos += FromTo(vessel, target.Current.Vessel).normalized;
+                                    }
+                                }
+
+                            Vector3 direction = -averagePos.normalized;
+                            Vector3 orbitNormal = vessel.orbit.Normal(Planetarium.GetUniversalTime());
+                            bool facingNorth = Vector3.Dot(direction, orbitNormal) > 0;
+                            withdrawDeltaV = orbitNormal * (facingNorth ? 1 : -1) * 200;
+                        }
+                        break;
+                    case StatusMode.Commanded:
+                        minManeuverTime = 30;
+                        break;
+                    case StatusMode.Firing:
+                        fc.lerpAttitude = false;
+                        break;
+                    case StatusMode.Maneuvering:
+                        break;
+                    case StatusMode.Stranded:
+                        break;
+                    default: // Idle
+                        break;
+                }
+            }
+            Maneuver(); // Set attitude, alignment tolerance, throttle, update RCS if needed
+
+            AddDebugMessages();
+        }
+
+        void InitialFrameUpdates()
+        {
             upDir = VectorUtils.GetUpDirection(vesselTransform.position);
-            UpdateStatus();
+            CalculateMaxAcceleration();
+            UpdateRCSVector();
+            maxAcceleration = GetMaxAcceleration(vessel);
+            debugPosition = Vector3.zero;
+            fc.alignmentToleranceforBurn = 5;
+            fc.throttle = 0;
+            vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, ManeuverRCS);
+        }
+
+        void Maneuver()
+        {
+            switch (currentStatusMode)
+            {
+                case StatusMode.Evading:
+                    {
+                        SetStatus("Evading Missile");
+                        vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, true);
+
+                        Vector3 incomingVector = FromTo(vessel, weaponManager.incomingMissileVessel);
+                        Vector3 dodgeVector = Vector3.ProjectOnPlane(vessel.ReferenceTransform.up, incomingVector.normalized);
+                        
+                        fc.attitude = dodgeVector;
+                        fc.alignmentToleranceforBurn = 45;
+                        fc.throttle = 1;
+                        UpdateRCSVector(dodgeVector * 2);
+                    }
+                    break;
+                case StatusMode.CorrectingOrbit:
+                    {
+                        Orbit o = vessel.orbit;
+                        double UT = Planetarium.GetUniversalTime();
+                        UpdateRCSVector();
+                        if (!belowSafeAlt && (o.ApA < 0 && o.timeToPe < -60))
+                        {
+                            // Vessel is on an escape orbit and has passed the periapsis by over 60s, burn retrograde
+                            SetStatus("Correcting Orbit (On escape trajectory)");
+                            fc.attitude = -o.Prograde(UT);
+                            fc.throttle = 1;
+                        }
+                        else if (!belowSafeAlt && (o.ApA >= minSafeAltitude) && (o.altitude >= minSafeAltitude))
+                        {
+                            // We are outside the atmosphere but our periapsis is inside the atmosphere.
+                            // Execute a burn to circularize our orbit at the current altitude.
+                            SetStatus("Correcting Orbit (Circularizing)");
+
+                            Vector3d fvel = Math.Sqrt(o.referenceBody.gravParameter / o.GetRadiusAtUT(UT)) * o.Horizontal(UT);
+                            Vector3d deltaV = fvel - vessel.GetObtVelocity();
+
+                            fc.attitude = deltaV.normalized;
+                            fc.throttle = Mathf.Lerp(0, 1, (float)(deltaV.sqrMagnitude / 100));
+                        }
+                        else
+                        {
+                            belowSafeAlt = true;
+                            if (o.ApA < minSafeAltitude * 1.1)
+                            {
+                                // Entirety of orbit is inside atmosphere, perform gravity turn burn until apoapsis is outside atmosphere by a 10% margin.
+
+                                SetStatus("Correcting Orbit (Apoapsis too low)");
+
+                                double gravTurnAlt = 0.1;
+                                float turn;
+
+                                if (o.altitude < gravTurnAlt * minSafeAltitude) // At low alts, burn straight up
+                                    turn = 1f;
+                                else // At higher alts, gravity turn towards horizontal orbit vector
+                                {
+                                    turn = Mathf.Clamp((float)((1.1 * minSafeAltitude - o.ApA) / (minSafeAltitude * (1.1 - gravTurnAlt))), 0.1f, 1f);
+                                    turn = Mathf.Clamp(Mathf.Log10(turn) + 1f, 0.33f, 1f);
+                                }
+
+                                fc.attitude = Vector3.Lerp(o.Horizontal(UT), upDir, turn);
+                                fc.alignmentToleranceforBurn = Mathf.Clamp(15f * turn, 5f, 15f);
+                                fc.throttle = 1;
+                            }
+                            else if (o.ApA < minSafeAltitude * 1.1)
+                            {
+                                // Entirety of orbit is inside atmosphere, perform gravity turn burn until apoapsis is outside atmosphere by a 10% margin.
+
+                                SetStatus("Correcting Orbit (Apoapsis too low)");
+
+                                double gravTurnAlt = 0.1;
+                                float turn;
+
+                                if (o.altitude < gravTurnAlt * minSafeAltitude) // At low alts, burn straight up
+                                    turn = 1f;
+                                else // At higher alts, gravity turn towards horizontal orbit vector
+                                {
+                                    turn = Mathf.Clamp((float)((1.1 * minSafeAltitude - o.ApA) / (minSafeAltitude * (1.1 - gravTurnAlt))), 0.1f, 1f);
+                                    turn = Mathf.Clamp(Mathf.Log10(turn) + 1f, 0.33f, 1f);
+                                }
+
+                                fc.attitude = Vector3.Lerp(o.Horizontal(UT), upDir, turn);
+                                fc.alignmentToleranceforBurn = Mathf.Clamp(15f * turn, 5f, 15f);
+                                fc.throttle = 1;
+                            }
+                            else
+                            {
+                                SetStatus("Correcting Orbit (Drifting)");
+                                belowSafeAlt = false;
+                            }   
+                        }
+                    }
+                    break;
+                case StatusMode.Commanded:
+                    {
+                        // We have been given a command from the WingCommander to fly/follow in a general direction
+                        // Burn for commandedBurn length, coast for 2x commandedBurn length
+                        SetStatus("Commanded to " + (currentCommand == PilotCommands.FlyTo ? "(Position)" : "(Follow Leader)"));
+                        
+                        if (currentCommand == PilotCommands.FlyTo)
+                            fc.attitude = (assignedPositionGeo - vessel.transform.position).normalized;
+                        else // Following
+                            fc.attitude = commandLeader.transform.up;
+                        UpdateRCSVector();
+                        fc.throttle = Mathf.Lerp(1, 0, Mathf.Clamp01(maneuverTime / (minManeuverTime / 3f)));
+
+                    }
+                    break;
+                case StatusMode.Withdrawing:
+                    {
+                        SetStatus("Withdrawing");
+
+                        // Withdraw sequence. Locks behaviour while burning 200 m/s of delta-v either north or south.
+                        withdrawDeltaV -= Vector3.Project(vessel.acceleration, withdrawDeltaV) * TimeWarp.fixedDeltaTime;
+                        
+                        fc.attitude = withdrawDeltaV.normalized;
+                        fc.throttle = (withdrawDeltaV.sqrMagnitude > 100) ? 1 : 0;
+                    }
+                    break;
+                case StatusMode.Firing:
+                    {
+                        // Aim at appropriate point to launch missiles that aren't able to launch now
+                        SetStatus("Firing Missiles");
+                        vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, true);
+                        
+                        fc.lerpAttitude = false;
+                        Vector3 firingSolution = FromTo(vessel, targetVessel).normalized;
+
+                        if (weaponManager.currentGun && GunReady(weaponManager.currentGun))
+                        {
+                            SetStatus("Firing Guns");
+                            firingSolution = (Vector3)weaponManager.currentGun.FiringSolutionVector;
+                        } 
+                        else if (weaponManager.CurrentMissile && !weaponManager.GetLaunchAuthorization(targetVessel, weaponManager, weaponManager.CurrentMissile))
+                        {
+                            SetStatus("Firing Missiles");
+                            firingSolution = MissileGuidance.GetAirToAirFireSolution(weaponManager.CurrentMissile, targetVessel);
+                        }
+                        else
+                            SetStatus("Firing");
+
+
+                        fc.attitude = firingSolution;
+                        fc.throttle = 0;
+                        UpdateRCSVector(-Vector3.ProjectOnPlane(RelVel(vessel, targetVessel), FromTo(vessel, targetVessel)));
+                    }
+                    break;
+                case StatusMode.Maneuvering:
+                    {
+                        // todo: implement for longer range movement.
+                        // https://github.com/MuMech/MechJeb2/blob/dev/MechJeb2/MechJebModuleRendezvousAutopilot.cs
+                        // https://github.com/MuMech/MechJeb2/blob/dev/MechJeb2/OrbitalManeuverCalculator.cs
+                        // https://github.com/MuMech/MechJeb2/blob/dev/MechJeb2/MechJebLib/Maths/Gooding.cs
+
+                        float minRange = Mathf.Max(MinEngagementRange, targetVessel.GetRadius() + vesselStandoffDistance);
+                        float maxRange = Mathf.Max(weaponManager.gunRange, minRange * 1.2f);
+
+                        float minRangeProjectile = minRange;
+                        bool complete = false;
+                        bool usingProjectile = true;
+
+                        vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, true);
+
+                        if (weaponManager != null && weaponManager.selectedWeapon != null)
+                        {
+                            currentWeapon = weaponManager.selectedWeapon;
+                            minRange = Mathf.Max((currentWeapon as EngageableWeapon).engageRangeMin, minRange);
+                            maxRange = Mathf.Min((currentWeapon as EngageableWeapon).engageRangeMax, maxRange);
+                            usingProjectile = weaponManager.selectedWeapon.GetWeaponClass() != WeaponClasses.Missile;
+                        }
+
+                        float currentRange = VesselDistance(vessel, targetVessel);
+                        bool nearInt = false;
+                        Vector3 relVel = RelVel(vessel, targetVessel);
+
+                        if (currentRange < (!usingProjectile ? minRange : minRangeProjectile) && AwayCheck(minRange))
+                        {
+                            SetStatus("Maneuvering (Away)");
+                            fc.throttle = 1;
+                            fc.alignmentToleranceforBurn = 135;
+                            fc.attitude = FromTo(targetVessel, vessel).normalized;
+                            UpdateRCSVector();
+                            fc.throttle = Vector3.Dot(RelVel(vessel, targetVessel), fc.attitude) < ManeuverSpeed ? 1 : 0;
+                        }
+                        // Reduce near intercept time by accounting for target acceleration
+                        // It should be such that "near intercept" is so close that you would go past them after you stop burning despite their acceleration
+                        // Also a chase timeout after which both parties should just use their weapons regardless of range.
+                        else if (hasPropulsion
+                            && currentRange > maxRange
+                            && !(nearInt = NearIntercept(relVel, minRange))
+                            && CanInterceptShip(targetVessel))
+                        {
+                            SetStatus("Maneuvering (Intercept Target)");
+                            Vector3 toTarget = FromTo(vessel, targetVessel);
+                            relVel = targetVessel.GetObtVelocity() - vessel.GetObtVelocity();
+
+                            toTarget = ToClosestApproach(toTarget, -relVel, minRange);
+                            debugPosition = toTarget;
+
+                            // Burn the difference between the target and current velocities.
+                            Vector3 desiredVel = toTarget.normalized * ManeuverSpeed;
+                            Vector3 burn = desiredVel + relVel;
+
+                            // Bias towards eliminating lateral velocity early on.
+                            Vector3 lateral = Vector3.ProjectOnPlane(burn, toTarget.normalized);
+                            burn = Vector3.Slerp(burn.normalized, lateral.normalized,
+                                Mathf.Clamp01(lateral.magnitude / (maxAcceleration * 10))) * burn.magnitude;
+
+                            lateralVelocity = lateral.magnitude;
+
+                            float throttle = Vector3.Dot(RelVel(vessel, targetVessel), toTarget.normalized) < ManeuverSpeed ? 1 : 0;
+                            if (burn.magnitude / maxAcceleration < 1 && fc.throttle == 0)
+                                throttle = 0;
+
+                            fc.throttle = throttle * Mathf.Clamp(burn.magnitude / maxAcceleration, 0.2f, 1);
+
+                            if (fc.throttle > 0)
+                                fc.attitude = burn.normalized;
+                            else
+                                fc.attitude = toTarget.normalized;
+                        }
+                        else
+                        {
+                            if (hasPropulsion && (relVel.sqrMagnitude > firingSpeed * firingSpeed || nearInt))
+                            {
+                                SetStatus("Maneuvering (Kill Velocity)");
+                                relVel = targetVessel.GetObtVelocity() - vessel.GetObtVelocity();
+                                complete = relVel.sqrMagnitude < firingSpeed * firingSpeed / 9;
+                                fc.attitude = (relVel + targetVessel.acceleration).normalized;
+                                fc.throttle = !complete ? 1 : 0;
+                            }
+                            else if (hasPropulsion && targetVessel != null && AngularVelocity(vessel, targetVessel) > firingAngularVelocityLimit)
+                            {
+                                SetStatus("Maneuvering (Kill Angular Velocity)");
+                                complete = AngularVelocity(vessel, targetVessel) < firingAngularVelocityLimit / 2;
+                                fc.attitude = -Vector3.ProjectOnPlane(RelVel(vessel, targetVessel), FromTo(vessel, targetVessel)).normalized;
+                                fc.throttle = !complete ? 1 : 0;
+                            }
+                            else // Drifting
+                            {
+                                fc.throttle = 0;
+                                fc.attitude = FromTo(vessel, targetVessel).normalized;
+                                if (currentRange < minRange)
+                                    SetStatus("Maneuvering (Drift Away)");
+                                else
+                                    SetStatus("Maneuvering (Drift)");
+                            }
+                        }
+                    }
+                    break;
+                case StatusMode.Stranded:
+                    {
+                        SetStatus("Stranded");
+
+                        fc.attitude = FromTo(vessel, targetVessel).normalized;
+                        fc.throttle = 0;  
+                    }
+                    break;
+                default: // Idle
+                    {
+                        if (hasWeapons)
+                            SetStatus("Idle");
+                        else
+                            SetStatus("Idle (Unarmed)");
+
+                        fc.attitude = Vector3.zero;
+                        fc.throttle = 0;
+                    }
+                    break;
+            }
         }
 
         void AddDebugMessages()
@@ -284,14 +603,6 @@ namespace BDArmory.Control
                 debugString.AppendLine($"Evasive {evasiveTimer}s");
                 debugString.AppendLine($"Threat Sqr Distance: {weaponManager.incomingThreatDistanceSqr}");
             }
-            if (BDArmorySettings.DEBUG_AI)
-            {
-                if (lastStatusMode != currentStatusMode)
-                {
-                    Debug.Log("[BDArmory.BDModuleOrbitalAI]: Status of " + vessel.vesselName + " changed from " + lastStatusMode + " to " + currentStatus);
-                }
-                lastStatusMode = currentStatusMode;
-            }
         }
 
         void UpdateStatus()
@@ -301,22 +612,44 @@ namespace BDArmory.Control
             hasPropulsion = hasRCSFore || VesselModuleRegistry.GetModuleEngines(vessel).Any(e => (e.EngineIgnited && e.isOperational));
             hasWeapons = weaponManager.HasWeaponsAndAmmo();
 
-            // Update intervals
-            if (weaponManager.incomingMissileVessel != null && updateInterval != emergencyUpdateInterval)
-                updateInterval = emergencyUpdateInterval;
-            else if (weaponManager.incomingMissileVessel == null && updateInterval == emergencyUpdateInterval)
-                updateInterval = combatUpdateInterval;
+            // Check for incoming gunfire
+            EvasionStatus(); 
 
-            // Set evasion status
-            EvasionStatus();
+            // Update status mode
+            if (weaponManager.missileIsIncoming && weaponManager.incomingMissileVessel && weaponManager.incomingMissileTime <= weaponManager.evadeThreshold) // Needs to start evading an incoming missile.
+                currentStatusMode = StatusMode.Evading;
+            else if (CheckOrbitUnsafe() || belowSafeAlt)
+                currentStatusMode = StatusMode.CorrectingOrbit;
+            else if (hasPropulsion && (currentCommand == PilotCommands.FlyTo || currentCommand == PilotCommands.Follow))
+                currentStatusMode = StatusMode.Commanded;
+            else if (allowWithdrawal && hasPropulsion && !hasWeapons && CheckWithdraw())
+                currentStatusMode = StatusMode.Withdrawing;
+            else if (targetVessel != null && weaponManager.currentGun && GunReady(weaponManager.currentGun))
+                currentStatusMode = StatusMode.Firing; // Guns
+            else if (targetVessel != null && weaponManager.CurrentMissile && !weaponManager.GetLaunchAuthorization(targetVessel, weaponManager, weaponManager.CurrentMissile))
+                currentStatusMode = StatusMode.Firing; // Missiles
+            else if (targetVessel != null && hasWeapons)
+                if (hasPropulsion)
+                    currentStatusMode = StatusMode.Maneuvering;
+                else
+                    currentStatusMode = StatusMode.Stranded;
+            else
+                currentStatusMode = StatusMode.Idle;
+
+            // Flag changed status if necessary
+            if (lastStatusMode != currentStatusMode)
+            {
+                maneuverStateChanged = true;
+                lastStatusMode = currentStatusMode;
+                if (BDArmorySettings.DEBUG_AI)
+                    Debug.Log("[BDArmory.BDModuleOrbitalAI]: Status of " + vessel.vesselName + " changed from " + lastStatusMode + " to " + currentStatus);
+            }
 
             // Set target as UI target
             if (vessel.isActiveVessel && targetVessel && !targetVessel.IsMissile() && (vessel.targetObject == null || vessel.targetObject.GetVessel() != targetVessel))
             {
                 FlightGlobals.fetch.SetVesselTarget(targetVessel, true);
             }
-
-            return;
         }
 
         void EvasionStatus()
@@ -349,430 +682,6 @@ namespace BDArmory.Control
                     evasiveTimer = 0;
             }
         }
-
-        private IEnumerator PilotLogic()
-        {
-            maxAcceleration = GetMaxAcceleration(vessel);
-            debugPosition = Vector3.zero;
-            evasionNonLinearityDirection = UnityEngine.Random.insideUnitSphere;
-            fc.alignmentToleranceforBurn = 5;
-            fc.throttle = 0;
-            vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, ManeuverRCS);
-            var wait = new WaitForFixedUpdate(); 
-
-            // Movement.
-            if (weaponManager.missileIsIncoming && weaponManager.incomingMissileVessel && weaponManager.incomingMissileTime <= weaponManager.evadeThreshold) // Needs to start evading an incoming missile.
-            {
-
-                SetStatus("Evading Missile");
-                vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, true);
-
-                float previousTolerance = fc.alignmentToleranceforBurn;
-                fc.alignmentToleranceforBurn = 45;
-                fc.throttle = 1;
-
-                Vessel incoming = weaponManager.incomingMissileVessel;
-                Vector3 incomingVector = FromTo(vessel, incoming);
-                Vector3 dodgeVector;
-
-                bool complete = false;
-
-                while (UnderTimeLimit() && incoming != null && !complete)
-                {
-                    incomingVector = FromTo(vessel, incoming);
-                    dodgeVector = Vector3.ProjectOnPlane(vessel.ReferenceTransform.up, incomingVector.normalized);
-                    fc.attitude = dodgeVector;
-                    UpdateRCSVector(dodgeVector * 2);
-
-                    yield return wait;
-                    if (!vessel) yield break; // Abort if the vessel died.
-                    complete = Vector3.Dot(RelVel(vessel, incoming), incomingVector) < 0;
-                }
-
-                fc.throttle = 0;
-                fc.alignmentToleranceforBurn = previousTolerance;
-            }
-            else if (CheckOrbitUnsafe())
-            {
-                Orbit o = vessel.orbit;
-                double UT;
-
-                if (o.ApA < 0 && o.timeToPe < -60)
-                {
-                    // Vessel is on an escape orbit and has passed the periapsis by over 60s, burn retrograde
-
-                    SetStatus("Correcting Orbit (On escape trajectory)");
-
-                    fc.throttle = 1;
-                    while (UnderTimeLimit())
-                    {
-                        yield return wait;
-                        if (!vessel) yield break; // Abort if the vessel died.
-
-                        UT = Planetarium.GetUniversalTime();
-
-                        fc.attitude = -o.Prograde(UT);
-                        UpdateRCSVector();
-                    }
-                }
-                else if (o.ApA < minSafeAltitude)
-                {
-                    // Entirety of orbit is inside atmosphere, perform gravity turn burn until apoapsis is outside atmosphere by a 10% margin.
-
-                    SetStatus("Correcting Orbit (Apoapsis too low)");
-                    fc.throttle = 1;
-                    float previousTolerance = fc.alignmentToleranceforBurn;
-                    double gravTurnAlt = 0.1;
-                    float turn;
-
-                    while (UnderTimeLimit() && o.ApA < minSafeAltitude * 1.1)
-                    {
-                        UT = Planetarium.GetUniversalTime();
-                        if (o.altitude < gravTurnAlt * minSafeAltitude) // At low alts, burn straight up
-                            turn = 1f;
-                        else // At higher alts, gravity turn towards horizontal orbit vector
-                        {
-                            turn = Mathf.Clamp((float)((1.1 * minSafeAltitude - o.ApA) / (minSafeAltitude * (1.1 - gravTurnAlt))), 0.1f, 1f);
-                            turn = Mathf.Clamp(Mathf.Log10(turn) + 1f, 0.33f, 1f);
-                        }
-                        fc.attitude = Vector3.Lerp(o.Horizontal(UT), upDir, turn);
-                        UpdateRCSVector();
-                        fc.alignmentToleranceforBurn = Mathf.Clamp(15f * turn, 5f, 15f);
-                        yield return wait;
-                        if (!vessel) yield break; // Abort if the vessel died.
-                    }
-                    fc.alignmentToleranceforBurn = previousTolerance;
-                }
-                else if (o.altitude < minSafeAltitude)
-                {
-                    // Our apoapsis is outside the atmosphere but we are inside the atmosphere and descending.
-                    // Burn up until we are ascending and our apoapsis is outside the atmosphere by a 10% margin.
-
-                    SetStatus("Correcting Orbit (Falling inside atmo)");
-                    fc.throttle = 1;
-
-                    while (UnderTimeLimit() && (o.ApA < minSafeAltitude * 1.1 || o.timeToPe < o.timeToAp))
-                    {
-                        UT = Planetarium.GetUniversalTime();
-                        fc.attitude = o.Radial(UT);
-                        UpdateRCSVector();
-                        yield return wait;
-                        if (!vessel) yield break; // Abort if the vessel died.
-                    }
-                }
-                else
-                {
-                    // We are outside the atmosphere but our periapsis is inside the atmosphere.
-                    // Execute a burn to circularize our orbit at the current altitude.
-
-                    SetStatus("Correcting Orbit (Circularizing)");
-
-                    Vector3d fvel, deltaV = Vector3d.up * 100;
-                    fc.throttle = 1;
-
-                    while (UnderTimeLimit() && deltaV.sqrMagnitude > 4)
-                    {
-                        yield return wait;
-                        if (!vessel) yield break; // Abort if the vessel died.
-
-                        UT = Planetarium.GetUniversalTime();
-                        fvel = Math.Sqrt(o.referenceBody.gravParameter / o.GetRadiusAtUT(UT)) * o.Horizontal(UT);
-                        deltaV = fvel - vessel.GetObtVelocity();
-
-                        fc.attitude = deltaV.normalized;
-                        UpdateRCSVector();
-                        fc.throttle = Mathf.Lerp(0, 1, (float)(deltaV.sqrMagnitude / 100));
-                    }
-                }
-            }
-            else if (hasPropulsion && (currentCommand == PilotCommands.FlyTo || currentCommand == PilotCommands.Follow))
-            {
-                // We have been given a command from the WingCommander to fly/follow in a general direction
-                // Burn for commandedBurn length, coast for 2x commandedBurn length
-                SetStatus("Maneuvering " + (currentCommand == PilotCommands.FlyTo ? "(Commanded Position)" : "(Following)"));
-                float timer = 0;
-
-                while (UnderTimeLimit(commandedBurn * 3f) && (currentCommand == PilotCommands.FlyTo || currentCommand == PilotCommands.Follow))
-                {
-                    if (currentCommand == PilotCommands.FlyTo)
-                        fc.attitude = (assignedPositionWorld - vessel.transform.position).normalized;
-                    else // Following
-                        fc.attitude = commandLeader.transform.up;
-                    UpdateRCSVector();
-                    fc.throttle = Mathf.Lerp(1, 0, Mathf.Clamp01(timer / commandedBurn));
-                    timer += Time.fixedDeltaTime;
-                    yield return wait;
-                    if (!vessel) yield break; // Abort if the vessel died.
-                }
-            }
-            else if (allowWithdrawal && hasPropulsion && !hasWeapons && CheckWithdraw())
-            {
-                SetStatus("Withdrawing");
-
-
-                // Determine the direction.
-                Vector3 averagePos = Vector3.zero;
-                using (List<TargetInfo>.Enumerator target = BDATargetManager.TargetList(weaponManager.Team).GetEnumerator())
-                    while (target.MoveNext())
-                    {
-                        if (target.Current == null) continue;
-                        if (target.Current && target.Current.Vessel && weaponManager.CanSeeTarget(target.Current))
-                        {
-                            averagePos += FromTo(vessel, target.Current.Vessel).normalized;
-                        }
-                    }
-
-                Vector3 direction = -averagePos.normalized;
-                Vector3 orbitNormal = vessel.orbit.Normal(Planetarium.GetUniversalTime());
-                bool facingNorth = Vector3.Dot(direction, orbitNormal) > 0;
-
-                // Withdraw sequence. Locks behaviour while burning 200 m/s of delta-v either north or south.
-
-                Vector3 deltav = orbitNormal * (facingNorth ? 1 : -1) * 200;
-                fc.throttle = 1;
-
-                while (deltav.sqrMagnitude > 100)
-                {
-                    if (!hasPropulsion) break;
-
-                    deltav -= Vector3.Project(vessel.acceleration, deltav) * TimeWarp.fixedDeltaTime;
-                    fc.attitude = deltav.normalized;
-                    UpdateRCSVector();
-                    yield return wait;
-                    if (!vessel) yield break; // Abort if the vessel died.
-                }
-
-                fc.throttle = 0;
-            }
-            else if (targetVessel != null && weaponManager.currentGun && GunReady(weaponManager.currentGun))
-            {
-                // Aim at target using current non-missile weapon.
-
-                SetStatus("Firing Guns");
-                vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, true);
-                fc.throttle = 0;
-                fc.lerpAttitude = false;
-                Vector3 firingSolution = FromTo(vessel, targetVessel).normalized;
-
-                while (UnderTimeLimit() && targetVessel != null && weaponManager.currentGun && GunReady(weaponManager.currentGun))
-                {
-                    if (weaponManager.currentGun.FiringSolutionVector != null)
-                        firingSolution = (Vector3)weaponManager.currentGun.FiringSolutionVector;
-
-                    fc.attitude = firingSolution;
-                    UpdateRCSVector(-Vector3.ProjectOnPlane(RelVel(vessel, targetVessel), FromTo(vessel, targetVessel)));
-
-                    yield return wait;
-                    if (!vessel) yield break; // Abort if the vessel died.
-                }
-
-                fc.lerpAttitude = true;
-            }
-            else if (targetVessel != null && weaponManager.CurrentMissile && !weaponManager.GetLaunchAuthorization(targetVessel, weaponManager, weaponManager.CurrentMissile))
-            {
-                // Aim at appropriate point to launch missiles that aren't able to launch now
-                
-                SetStatus("Firing Missiles");
-                vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, true);
-                fc.throttle = 0;
-                fc.lerpAttitude = false;
-                Vector3 firingSolution = FromTo(vessel, targetVessel).normalized;
-
-                while (UnderTimeLimit() && targetVessel != null && weaponManager.CurrentMissile && !weaponManager.GetLaunchAuthorization(targetVessel, weaponManager, weaponManager.CurrentMissile))
-                {
-                    firingSolution = MissileGuidance.GetAirToAirFireSolution(weaponManager.CurrentMissile, targetVessel);
-
-                    fc.attitude = firingSolution;
-                    UpdateRCSVector(-Vector3.ProjectOnPlane(RelVel(vessel, targetVessel), FromTo(vessel, targetVessel)));
-
-                    yield return wait;
-                    if (!vessel) yield break; // Abort if the vessel died.
-                }
-
-                fc.lerpAttitude = true;
-            }
-            else if (targetVessel != null && hasWeapons)
-            {
-
-                // todo: implement for longer range movement.
-                // https://github.com/MuMech/MechJeb2/blob/dev/MechJeb2/MechJebModuleRendezvousAutopilot.cs
-                // https://github.com/MuMech/MechJeb2/blob/dev/MechJeb2/OrbitalManeuverCalculator.cs
-                // https://github.com/MuMech/MechJeb2/blob/dev/MechJeb2/MechJebLib/Maths/Gooding.cs
-
-                float minRange = Mathf.Max(MinEngagementRange, targetVessel.GetRadius() + vesselStandoffDistance);
-                float maxRange = Mathf.Max(weaponManager.gunRange, minRange * 1.2f);
-
-                float minRangeProjectile = minRange;
-                bool complete = false;
-                bool usingProjectile = true;
-
-                vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, true);
-
-                if (weaponManager != null && weaponManager.selectedWeapon != null)
-                {
-                    currentWeapon = weaponManager.selectedWeapon;
-                    minRange = Mathf.Max((currentWeapon as EngageableWeapon).engageRangeMin, minRange);
-                    maxRange = Mathf.Min((currentWeapon as EngageableWeapon).engageRangeMax, maxRange);
-                    usingProjectile = weaponManager.selectedWeapon.GetWeaponClass() != WeaponClasses.Missile;
-                }
-
-                float currentRange = VesselDistance(vessel, targetVessel);
-                bool nearInt = false;
-                Vector3 relVel = RelVel(vessel, targetVessel);
-
-                if (currentRange < (!usingProjectile ? minRange : minRangeProjectile) && AwayCheck(minRange))
-                {
-                    SetStatus("Maneuvering (Away)");
-                    fc.throttle = 1;
-                    fc.alignmentToleranceforBurn = 135;
-
-                    while (UnderTimeLimit() && targetVessel != null && !complete)
-                    {
-                        fc.attitude = FromTo(targetVessel, vessel).normalized;
-                        UpdateRCSVector();
-                        fc.throttle = Vector3.Dot(RelVel(vessel, targetVessel), fc.attitude) < ManeuverSpeed ? 1 : 0;
-                        complete = FromTo(vessel, targetVessel).sqrMagnitude > minRange * minRange || !AwayCheck(minRange);
-
-                        yield return wait;
-                        if (!vessel) yield break; // Abort if the vessel died.
-                    }
-                }
-                // Reduce near intercept time by accounting for target acceleration
-                // It should be such that "near intercept" is so close that you would go past them after you stop burning despite their acceleration
-                // Also a chase timeout after which both parties should just use their weapons regardless of range.
-                else if (hasPropulsion
-                    && currentRange > maxRange
-                    && !(nearInt = NearIntercept(relVel, minRange))
-                    && CanInterceptShip(targetVessel))
-                {
-                    SetStatus("Maneuvering (Intercept Target)");
-                    complete = FromTo(vessel, targetVessel).sqrMagnitude < maxRange * maxRange || NearIntercept(relVel, minRange);
-                    while (UnderTimeLimit() && targetVessel != null && !complete)
-                    {
-                        Vector3 toTarget = FromTo(vessel, targetVessel);
-                        relVel = targetVessel.GetObtVelocity() - vessel.GetObtVelocity();
-
-                        toTarget = ToClosestApproach(toTarget, -relVel, minRange);
-                        debugPosition = toTarget;
-
-                        // Burn the difference between the target and current velocities.
-                        Vector3 desiredVel = toTarget.normalized * ManeuverSpeed;
-                        Vector3 burn = desiredVel + relVel;
-
-                        // Bias towards eliminating lateral velocity early on.
-                        Vector3 lateral = Vector3.ProjectOnPlane(burn, toTarget.normalized);
-                        burn = Vector3.Slerp(burn.normalized, lateral.normalized,
-                            Mathf.Clamp01(lateral.magnitude / (maxAcceleration * 10))) * burn.magnitude;
-
-                        lateralVelocity = lateral.magnitude;
-
-                        float throttle = Vector3.Dot(RelVel(vessel, targetVessel), toTarget.normalized) < ManeuverSpeed ? 1 : 0;
-                        if (burn.magnitude / maxAcceleration < 1 && fc.throttle == 0)
-                            throttle = 0;
-
-                        fc.throttle = throttle * Mathf.Clamp(burn.magnitude / maxAcceleration, 0.2f, 1);
-
-                        if (fc.throttle > 0)
-                            fc.attitude = burn.normalized;
-                        else
-                            fc.attitude = toTarget.normalized;
-
-                        UpdateRCSVector();
-                        complete = FromTo(vessel, targetVessel).sqrMagnitude < maxRange * maxRange || NearIntercept(relVel, minRange);
-
-                        yield return wait;
-                        if (!vessel) yield break; // Abort if the vessel died.
-                    }
-                }
-                else
-                {
-                    if (hasPropulsion && (relVel.sqrMagnitude > firingSpeed * firingSpeed || nearInt))
-                    {
-                        SetStatus("Maneuvering (Kill Velocity)");
-                        while (UnderTimeLimit() && targetVessel != null && !complete)
-                        {
-                            relVel = targetVessel.GetObtVelocity() - vessel.GetObtVelocity();
-                            fc.attitude = (relVel + targetVessel.acceleration).normalized;
-                            UpdateRCSVector();
-                            complete = relVel.sqrMagnitude < firingSpeed * firingSpeed / 9;
-                            fc.throttle = !complete ? 1 : 0;
-
-                            yield return wait;
-                            if (!vessel) yield break; // Abort if the vessel died.
-                        }
-                    }
-                    else if (hasPropulsion && targetVessel != null && AngularVelocity(vessel, targetVessel) > firingAngularVelocityLimit)
-                    {
-                        SetStatus("Maneuvering (Kill Angular Velocity)");
-
-                        while (UnderTimeLimit() && targetVessel != null && !complete)
-                        {
-                            complete = AngularVelocity(vessel, targetVessel) < firingAngularVelocityLimit / 2;
-                            fc.attitude = -Vector3.ProjectOnPlane(RelVel(vessel, targetVessel), FromTo(vessel, targetVessel)).normalized;
-                            UpdateRCSVector();
-                            fc.throttle = !complete ? 1 : 0;
-
-                            yield return wait;
-                            if (!vessel) yield break; // Abort if the vessel died.
-                        }
-                    }
-                    else
-                    {
-                        if (hasPropulsion)
-                        {
-                            if (currentRange < minRange)
-                            {
-                                SetStatus("Maneuvering (Drift Away)");
-
-                                Vector3 toTarget;
-                                fc.throttle = 0;
-
-                                while (UnderTimeLimit() && targetVessel != null && !complete)
-                                {
-                                    toTarget = FromTo(vessel, targetVessel);
-                                    complete = toTarget.sqrMagnitude > minRange * minRange;
-                                    fc.attitude = toTarget.normalized;
-                                    UpdateRCSVector();
-                                    yield return wait;
-                                    if (!vessel) yield break; // Abort if the vessel died.
-                                }
-                            }
-                            else
-                            {
-                                SetStatus("Maneuvering (Drift)");
-                                fc.throttle = 0;
-                                fc.attitude = FromTo(vessel, targetVessel).normalized;
-                                UpdateRCSVector();
-                            }
-                        }
-                        else
-                        {
-                            SetStatus("Stranded");
-                            fc.throttle = 0;
-                            fc.attitude = FromTo(vessel, targetVessel).normalized;
-                            UpdateRCSVector();
-                        }
-
-                        yield return new WaitForSecondsFixed(updateInterval);
-                    }
-                }
-            }
-            else
-            {
-                // Idle
-
-                if (hasWeapons)
-                    SetStatus("Idle");
-                else
-                    SetStatus("Idle (Unarmed)");
-
-                fc.throttle = 0;
-                fc.attitude = Vector3.zero;
-                UpdateRCSVector();
-                yield return new WaitForSecondsFixed(updateInterval);
-            }
-        }
-
         #endregion Actual AI Pilot
 
         #region Utility Functions
@@ -798,14 +707,6 @@ namespace BDArmory.Control
             minSafeAltitude = Math.Max(maxTerrainHeight, body.atmosphereDepth);
 
             return (o.PeA < minSafeAltitude && o.timeToPe < o.timeToAp) || (o.ApA < minSafeAltitude && (o.ApA >= 0 || o.timeToPe < -60)); // Match conditions in PilotLogic
-        }
-
-        private bool UnderTimeLimit(float timeLimit = 0)
-        {
-            if (timeLimit == 0)
-                timeLimit = updateInterval;
-
-            return Time.time - lastUpdate < timeLimit;
         }
 
         private bool NearIntercept(Vector3 relVel, float minRange)
@@ -954,14 +855,8 @@ namespace BDArmory.Control
             return velocity * time + 0.5f * acceleration * time * time;
         }
 
-        private IEnumerator CalculateMaxAcceleration()
+        private void CalculateMaxAcceleration()
         {
-            while (vessel.MOI == Vector3.zero)
-            {
-                yield return new WaitForSecondsFixed(1);
-                if (!vessel) yield break; // Abort if the vessel died.
-            }
-
             Vector3 availableTorque = Vector3.zero;
             var reactionWheels = VesselModuleRegistry.GetModules<ModuleReactionWheel>(vessel);
             foreach (var wheel in reactionWheels)

--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -248,7 +248,7 @@ namespace BDArmory.Control
 
         void UpdateStatus()
         {
-            bool hasRCSFore = VesselModuleRegistry.GetModules<ModuleRCSFX>(vessel).Any(e => e.rcsEnabled && !e.flameout && e.useThrottle);
+            bool hasRCSFore = VesselModuleRegistry.GetModules<ModuleRCS>(vessel).Any(e => e.rcsEnabled && !e.flameout && e.useThrottle);
             hasPropulsion = hasRCSFore || VesselModuleRegistry.GetModuleEngines(vessel).Any(e => (e.EngineIgnited && e.isOperational));
             hasWeapons = weaponManager.HasWeaponsAndAmmo();
 
@@ -823,18 +823,9 @@ namespace BDArmory.Control
 
         public static float GetMaxThrust(Vessel v)
         {
-            List<ModuleEngines> engines = VesselModuleRegistry.GetModules<ModuleEngines>(v).ToList();
-            engines.RemoveAll(e => !e.EngineIgnited || !e.isOperational);
-            float thrust = engines.Sum(e => e.MaxThrustOutputVac(true));
-
-            List<ModuleRCSFX> RCS = VesselModuleRegistry.GetModules<ModuleRCSFX>(v).ToList();
-            foreach (ModuleRCS thruster in RCS)
-            {
-                if (thruster.useThrottle)
-                    thrust += thruster.thrusterPower;
-            }
-
-            return engines.Sum(e => e.MaxThrustOutputVac(true));
+            float thrust = VesselModuleRegistry.GetModuleEngines(v).Where(e => e != null && e.EngineIgnited && e.isOperational).Sum(e => e.MaxThrustOutputVac(true));
+            thrust += VesselModuleRegistry.GetModules<ModuleRCS>(v).Where(rcs => rcs != null && rcs.useThrottle).Sum(rcs => rcs.thrusterPower);
+            return thrust;
         }
         #endregion
 

--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -194,7 +194,7 @@ namespace BDArmory.Control
 
         protected override void OnDestroy()
         {
-            GameEvents.onVesselPartCountChanged.Add(CalculateAvailableTorque);
+            GameEvents.onVesselPartCountChanged.Remove(CalculateAvailableTorque);
             base.OnDestroy();
         }
 

--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -412,6 +412,7 @@ namespace BDArmory.Control
                     fc.throttle = Mathf.Lerp(1, 0, Mathf.Clamp01(timer / commandedBurn));
                     timer += Time.fixedDeltaTime;
                     yield return wait;
+                    if (!vessel) yield break; // Abort if the vessel died.
                 }
             }
             else if (allowWithdrawal && hasPropulsion && !hasWeapons && CheckWithdraw())

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -7762,14 +7762,14 @@ namespace BDArmory.Control
                 }
 
                 // Check that target is within maxOffBoresight now and in future time fTime
-                launchAuthorized = missile.maxOffBoresight >= 360 ? true : Vector3.Angle(missile.GetForwardTransform(), target - missile.transform.position) < boresightAngle; // Launch is possible now
+                launchAuthorized = missile.maxOffBoresight >= 360 || Vector3.Angle(missile.GetForwardTransform(), target - missile.transform.position) < boresightAngle; // Launch is possible now
                 if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileFire]: {vessel.vesselName} final boresight check {(launchAuthorized ? "passed" : "failed")}.");
                 if (launchAuthorized)
                 {
                     float fTime = Mathf.Min(missile.dropTime, 2f);
                     Vector3 futurePos = target + (targetV.Velocity() * fTime);
                     Vector3 myFuturePos = vessel.ReferenceTransform.position + (vessel.Velocity() * fTime);
-                    launchAuthorized = launchAuthorized && ((!unguidedWeapon && missile.maxOffBoresight >= 360) ? true : Vector3.Angle(missile.GetForwardTransform(), futurePos - myFuturePos) < boresightAngle); // Launch is likely also possible at fTime
+                    launchAuthorized = launchAuthorized && ((!unguidedWeapon && missile.maxOffBoresight >= 360) || Vector3.Angle(missile.GetForwardTransform(), futurePos - myFuturePos) < boresightAngle); // Launch is likely also possible at fTime
                 }
             }
 

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -7732,7 +7732,7 @@ namespace BDArmory.Control
                 {
                     target = MissileGuidance.GetAirToAirFireSolution(missile, targetV);
                 }
-                
+
                 float boresightFactor = (mf.vessel.LandedOrSplashed || targetV.LandedOrSplashed || missile.uncagedLock) ? 0.75f : 0.35f; // Allow launch at close to maxOffBoresight for ground targets or missiles with allAspect = true
 
                 //if(missile.TargetingMode == MissileBase.TargetingModes.Gps) maxOffBoresight = 45;

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -7754,7 +7754,10 @@ namespace BDArmory.Control
                 float boresightAngle = missile.maxOffBoresight * ((mf.vessel.LandedOrSplashed || targetV.LandedOrSplashed || missile.uncagedLock) ? 0.75f : 0.35f); // Allow launch at close to maxOffBoresight for ground targets or missiles with allAspect = true
                 if (unguidedWeapon) // Override boresightAngle based on blast radius for unguidedWeapons
                 {
-                    boresightAngle = Mathf.Max(Mathf.Rad2Deg * Mathf.Atan(missile.GetBlastRadius() / (target - missile.transform.position).magnitude) / 3, 1f); // 1deg - within 1/3 of blast radius
+                    if (((MissileLauncher)missile).missileTurret)
+                        boresightAngle = 1f;
+                    else
+                        boresightAngle = Mathf.Max(Mathf.Rad2Deg * Mathf.Atan(missile.GetBlastRadius() / (target - missile.transform.position).magnitude) / 3, 1f); // 1deg - within 1/3 of blast radius
                     if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileFire]: {vessel.vesselName} boresight angle for unguided {missile.shortName} is {boresightAngle}.");
                 }
 

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -7730,7 +7730,10 @@ namespace BDArmory.Control
                 //if (!targetV.LandedOrSplashed) //no leading for moving surface targets? two use condtions come to mind - leading torps and unguided AtG missiles. Latter can use A2AFS, torps slightly complicated in that there's a ~2.5s drop time where theyr'e moving at parent speed
                 if (targetV.speed > 1) //target is moving
                 {
-                    target = MissileGuidance.GetAirToAirFireSolution(missile, targetV);
+                    if (VesselModuleRegistry.GetModule<BDModuleOrbitalAI>(vessel, true) == null)
+                        target = MissileGuidance.GetAirToAirFireSolution(missile, targetV);
+                    else // Orbital AI condition
+                        target = MissileGuidance.GetAirToAirFireSolution(missile, targetV.transform.position, targetV.Velocity());
                 }
 
                 float boresightFactor = (mf.vessel.LandedOrSplashed || targetV.LandedOrSplashed || missile.uncagedLock) ? 0.75f : 0.35f; // Allow launch at close to maxOffBoresight for ground targets or missiles with allAspect = true

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -7730,12 +7730,9 @@ namespace BDArmory.Control
                 //if (!targetV.LandedOrSplashed) //no leading for moving surface targets? two use condtions come to mind - leading torps and unguided AtG missiles. Latter can use A2AFS, torps slightly complicated in that there's a ~2.5s drop time where theyr'e moving at parent speed
                 if (targetV.speed > 1) //target is moving
                 {
-                    if (VesselModuleRegistry.GetModule<BDModuleOrbitalAI>(vessel, true) == null)
-                        target = MissileGuidance.GetAirToAirFireSolution(missile, targetV);
-                    else // Orbital AI condition
-                        target = MissileGuidance.GetAirToAirFireSolution(missile, targetV.transform.position, targetV.Velocity());
+                    target = MissileGuidance.GetAirToAirFireSolution(missile, targetV);
                 }
-
+                
                 float boresightFactor = (mf.vessel.LandedOrSplashed || targetV.LandedOrSplashed || missile.uncagedLock) ? 0.75f : 0.35f; // Allow launch at close to maxOffBoresight for ground targets or missiles with allAspect = true
 
                 //if(missile.TargetingMode == MissileBase.TargetingModes.Gps) maxOffBoresight = 45;

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -24,7 +24,8 @@
 		- Add new Orbital guidance option for Modular Missiles
 			- Missile will attempt to intercept orbital target at the user-set Max Speed value
 		- Fix clustermissiles launching copies of themselves instead of submunitions.
-	  - Fix for HEKV launching unguided in non-ideal situations.
+		- Improvements to AAM guidance types so that they work in orbit
+		- Fix for HEKV launching unguided in non-ideal situations.
 - Countermeasures
 	- Add vessel's velocity to chaff ejection particle effect.
 	- Use vessel acceleration instead of velocity for chaff decoy factor calculation when in space.

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -5,8 +5,9 @@
 - AI / WM:
 	- Add new Orbital AI part for spacecraft in orbit:
 		- The Orbital AI will use orbital maneuvers to close within gun range of the target to fire weapons. It will also automatically fire missiles when able.
-		- The AI will maneuver at the Maneuver Speed setting and once within gun range try to fire guns while at the Strafe Speed setting. If evasion is enabled, it will attempt to dodge vacuum missiles (i.e. HEKVs) or Modular Missiles with Orbital guidance (see Weapons section of changelog).
+		- The AI will maneuver at the Maneuver Speed setting and once within gun range try to fire guns while at the Strafe Speed setting. It will evade missiles based on the countermeasure settings on the Weapons Manager and evade gunfire using AI settings similar to those on the Pilot AI.
 		- When spawned at orbital altitudes using the BDA Vessel Spawner, craft with the Orbital AI will be automatically spawned into orbit (other options for orbital spawning are cheat menu and HyperEdit mod).
+		- Orbital AI is adapted from the StockCombatAI (KCS) mod, check it out here https://github.com/Halbann/StockCombatAI/releases!
 	- Base the Immelmann turn pitch direction on the local pitch angular velocity (i.e., pitch down if already rotating that way — fixes the pitch oscillation behaviour when targeting an opponent behind the craft while inverted near terrain).
 	- Don't summon the NaN-Kraken when the post-terrain avoidance cool-down is 0.
 	- Perform banked turns when the target is behind us at long range and extending is allowed instead of Immelmann turns or turning directly to target. Threshold is clamp(8 * max speed, 1000, 4000).

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -27,9 +27,8 @@
 		- Add new Orbital guidance option for Modular Missiles
 			- Missile will attempt to intercept orbital target at the user-set Max Speed value
 		- homingType = orbital replaces homingType = RCS in missile configuration files (BDA is still backwards-compatible with homingType = RCS)
-		- Orbital/RCS homing types now lead the target
 		- Fix clustermissiles launching copies of themselves instead of submunitions.
-		- Improvements to AAM guidance types so that they work in orbit
+		- Improvements to modular missile AAM guidance types so that they work in orbit
 		- Fix for HEKV launching unguided in non-ideal situations.
 - Countermeasures
 	- Add vessel's velocity to chaff ejection particle effect.

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -2,6 +2,7 @@
 - UI:
 	- Fix the alternate (hidden UI) window locations (for scores and vessel switcher) not being saved correctly.
 	- Add a max distance threshold setting to Team Icons.
+	- Fix "Camera Switch: Incl. Missiles" not switching to missiles about to hit their target.
 - AI / WM:
 	- Add new Orbital AI part for spacecraft in orbit:
 		- The Orbital AI will use orbital maneuvers to close within gun range of the target to fire weapons. It will also automatically fire missiles when able.
@@ -25,6 +26,8 @@
 	- Missiles:
 		- Add new Orbital guidance option for Modular Missiles
 			- Missile will attempt to intercept orbital target at the user-set Max Speed value
+		- homingType = orbital replaces homingType = RCS in missile configuration files (BDA is still backwards-compatible with homingType = RCS)
+		- Orbital/RCS homing types now lead the target
 		- Fix clustermissiles launching copies of themselves instead of submunitions.
 		- Improvements to AAM guidance types so that they work in orbit
 		- Fix for HEKV launching unguided in non-ideal situations.

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/hekv1/hekv1.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/hekv1/hekv1.cfg
@@ -63,7 +63,7 @@ MODULE
 
 	audioClipPath = BDArmory/Sounds/jet
 	guidanceActive = true //missile has guidanceActive
-	homingType = RCS
+	homingType = orbital  // Replaces homingType = RCS
 	targetingType = radar
 	missileType = missile
 	DetonationDistance = 1

--- a/BDArmory/Guidances/MissileGuidance.cs
+++ b/BDArmory/Guidances/MissileGuidance.cs
@@ -5,7 +5,6 @@ using BDArmory.Extensions;
 using BDArmory.Settings;
 using BDArmory.Utils;
 using BDArmory.Weapons.Missiles;
-using static UnityEngine.GraphicsBuffer;
 
 namespace BDArmory.Guidances
 {

--- a/BDArmory/Guidances/MissileGuidance.cs
+++ b/BDArmory/Guidances/MissileGuidance.cs
@@ -403,7 +403,7 @@ namespace BDArmory.Guidances
             float targetDistance = Vector3.Distance(targetPosition, missileVessel.CoM);
 
             //Basic lead time calculation
-            Vector3 currVel = ((float)missileVessel.srfSpeed * missileVessel.Velocity().normalized);
+            Vector3 currVel = missileVessel.Velocity();
             timeToImpact = targetDistance / (targetVelocity - currVel).magnitude;
 
             // Calculate time to CPA to determine target position
@@ -417,7 +417,7 @@ namespace BDArmory.Guidances
 
         public static Vector3 GetPNTarget(Vector3 targetPosition, Vector3 targetVelocity, Vessel missileVessel, float N, out float timeToGo)
         {
-            Vector3 missileVel = (float)missileVessel.srfSpeed * missileVessel.Velocity().normalized;
+            Vector3 missileVel = missileVessel.Velocity();
             Vector3 relVelocity = targetVelocity - missileVel;
             Vector3 relRange = targetPosition - missileVessel.CoM;
             Vector3 RotVector = Vector3.Cross(relRange, relVelocity) / Vector3.Dot(relRange, relRange);
@@ -429,7 +429,7 @@ namespace BDArmory.Guidances
 
         public static Vector3 GetAPNTarget(Vector3 targetPosition, Vector3 targetVelocity, Vector3 targetAcceleration, Vessel missileVessel, float N, out float timeToGo)
         {
-            Vector3 missileVel = (float)missileVessel.srfSpeed * missileVessel.Velocity().normalized;
+            Vector3 missileVel = missileVessel.Velocity();
             Vector3 relVelocity = targetVelocity - missileVel;
             Vector3 relRange = targetPosition - missileVessel.CoM;
             Vector3 RotVector = Vector3.Cross(relRange, relVelocity) / Vector3.Dot(relRange, relRange);
@@ -444,54 +444,12 @@ namespace BDArmory.Guidances
         }
         public static float GetLOSRate(Vector3 targetPosition, Vector3 targetVelocity, Vessel missileVessel)
         {
-            Vector3 missileVel = (float)missileVessel.srfSpeed * missileVessel.Velocity().normalized;
+            Vector3 missileVel = missileVessel.Velocity();
             Vector3 relVelocity = targetVelocity - missileVel;
             Vector3 relRange = targetPosition - missileVessel.CoM;
             Vector3 RotVector = Vector3.Cross(relRange, relVelocity) / Vector3.Dot(relRange, relRange);
             Vector3 LOSRate = Mathf.Rad2Deg * RotVector;
             return LOSRate.magnitude;
-        }
-
-        /// <summary>
-        /// Calculate a very accurate time to impact, use the out timeToimpact property if the method returned true. DEPRECATED, use TimeToCPA.
-        /// </summary>
-        /// <param name="targetVelocity"></param>
-        /// <param name="missileVessel"></param>
-        /// <param name="effectiveMissileAcceleration"></param>
-        /// <param name="effectiveTargetAcceleration"></param>
-        /// <param name="targetDistance"></param>
-        /// <param name="timeToImpact"></param>
-        /// <returns> true if it was possible to reach the target, false otherwise</returns>
-        private static bool CalculateAccurateTimeToImpact(float targetDistance, Vector3 targetVelocity, Vessel missileVessel,
-            Vector3d effectiveMissileAcceleration, Vector3 effectiveTargetAcceleration, out float timeToImpact)
-        {
-            int iterations = 0;
-            Vector3d relativeAcceleration = effectiveMissileAcceleration - effectiveTargetAcceleration;
-            Vector3d relativeVelocity = (float)missileVessel.srfSpeed * missileVessel.Velocity().normalized -
-                                   targetVelocity;
-            Vector3 missileFinalPosition = missileVessel.CoM;
-            float previousDistanceSqr = 0f;
-            float currentDistanceSqr;
-            do
-            {
-                missileFinalPosition += relativeVelocity * Time.fixedDeltaTime;
-                relativeVelocity += relativeAcceleration;
-                currentDistanceSqr = (missileFinalPosition - missileVessel.CoM).sqrMagnitude;
-
-                if (currentDistanceSqr <= previousDistanceSqr)
-                {
-                    Debug.Log("[BDArmory.MissileGuidance]: Accurate time to impact failed");
-
-                    timeToImpact = 0;
-                    return false;
-                }
-
-                previousDistanceSqr = currentDistanceSqr;
-                iterations++;
-            } while (currentDistanceSqr < targetDistance * targetDistance);
-
-            timeToImpact = Time.fixedDeltaTime * iterations;
-            return true;
         }
 
         /// <summary>

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -1818,7 +1818,9 @@ namespace BDArmory.Radar
             Vector3 upVector = referenceTransform.up;
             Vector3 lookDirection = -forwardVector;
             var pilotAI = VesselModuleRegistry.GetBDModulePilotAI(myWpnManager.vessel, true);
-            var ignoreMyTargetTargetingMe = pilotAI != null && pilotAI.evasionIgnoreMyTargetTargetingMe;
+            var orbitalAI = VesselModuleRegistry.GetModule<BDModuleOrbitalAI>(myWpnManager.vessel, true);
+            var ignoreMyTargetTargetingMe = (pilotAI != null && pilotAI.evasionIgnoreMyTargetTargetingMe) ||
+                (orbitalAI != null && orbitalAI.evasionIgnoreMyTargetTargetingMe);
             float maxRWRDistance = RWR != null ? RWR.rwrDisplayRange : maxViewDistance;
             using (var loadedvessels = BDATargetManager.LoadedVessels.GetEnumerator())
                 while (loadedvessels.MoveNext())

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -1258,6 +1258,7 @@ namespace BDArmory.UI
                                     float HP = 0;
                                     float WreckFactor = 0;
                                     var AI = VesselModuleRegistry.GetBDModulePilotAI(wm.Current.vessel, true);
+                                    var OAI = VesselModuleRegistry.GetModule<BDModuleOrbitalAI>(wm.Current.vessel, true);
 
                                     // If we're running a waypoints competition, only focus on vessels still running waypoints.
                                     if (BDACompetitionMode.Instance.competitionType == CompetitionType.WAYPOINTS)
@@ -1322,6 +1323,18 @@ namespace BDArmory.UI
                                             }
                                         }
                                         //else got weapons and engaging
+                                    }
+                                    if (OAI) // Maneuvering is interesting, other statuses are not
+                                    {
+                                        if (OAI.currentStatusMode == BDModuleOrbitalAI.StatusMode.Maneuvering)
+                                            vesselScore *= 0.5f;
+                                        else if (OAI.currentStatusMode == BDModuleOrbitalAI.StatusMode.CorrectingOrbit)
+                                            vesselScore *= 1.5f;
+                                        else if (OAI.currentStatusMode == BDModuleOrbitalAI.StatusMode.Idle)
+                                            vesselScore *= 2f;
+                                        else if (OAI.currentStatusMode == BDModuleOrbitalAI.StatusMode.Stranded)
+                                            vesselScore *= 3f;
+                                        // else -- Firing, Evading covered by weapon manager checks
                                     }
                                     vesselScore *= 0.031623f * BDAMath.Sqrt(targetDistance); // Equal to 1 at 1000m
                                     if (wm.Current.recentlyFiring) // Firing guns or missiles at stuff is more interesting. (Uses 1/2 the camera switch frequency on all guns.)

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -1160,14 +1160,14 @@ namespace BDArmory.UI
                     }
                     centroid /= (float)count;
                 }
-                if (BDArmorySettings.CAMERA_SWITCH_INCLUDE_MISSILES) // Prioritise active missiles. // FIXME Not sure this bit is actually doing much.
+                if (BDArmorySettings.CAMERA_SWITCH_INCLUDE_MISSILES) // Prioritise active missiles.
                 {
                     foreach (MissileBase missile in BDATargetManager.FiredMissiles)
                     {
                         if (missile == null || missile.HasMissed) continue; // Ignore missed missiles.
                         var targetDirection = missile.TargetPosition - missile.transform.position;
                         var targetDistance = targetDirection.magnitude;
-                        if (Vector3.Dot(targetDirection, missile.GetForwardTransform()) < 0.5f * targetDistance) continue; // Ignore off-target missiles.
+                        if (Vector3.Dot(targetDirection.normalized, missile.GetForwardTransform()) < 0.7f) continue; // Ignore off-target missiles.
                         float missileScore = targetDistance < 1.1e3f ? 0.1f : (targetDistance - 1e3f) * (targetDistance - 1e3f) * 1e-5f; // Prioritise missiles that are within 1km from their targets.
                         if (missileScore < bestScore)
                         {

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -1167,8 +1167,8 @@ namespace BDArmory.UI
                         if (missile == null || missile.HasMissed) continue; // Ignore missed missiles.
                         var targetDirection = missile.TargetPosition - missile.transform.position;
                         var targetDistance = targetDirection.magnitude;
-                        if (Vector3.Dot(targetDirection.normalized, missile.GetForwardTransform()) < 0.7f) continue; // Ignore off-target missiles.
-                        float missileScore = targetDistance < 1.1e3f ? 0.1f : (targetDistance - 1e3f) * (targetDistance - 1e3f) * 1e-5f; // Prioritise missiles that are within 1km from their targets.
+                        if (Vector3.Dot(targetDirection, missile.GetForwardTransform()) < 0.5f * targetDistance) continue; // Ignore off-target missiles.
+                        float missileScore = targetDistance < 1e3f ? 0.1f : 0.1f + (targetDistance - 1e3f) * (targetDistance - 1e3f) * 2e-8f; // Prioritise missiles that are within 1km from their targets.
                         if (missileScore < bestScore)
                         {
                             bestScore = missileScore;

--- a/BDArmory/VesselSpawning/SpawnUtils.cs
+++ b/BDArmory/VesselSpawning/SpawnUtils.cs
@@ -127,7 +127,7 @@ namespace BDArmory.VesselSpawning
         {
             foreach (var engine in VesselModuleRegistry.GetModuleEngines(vessel))
             {
-                if (ignoreModularMissileEngines && IsModularMissileEngine(engine)) continue; // Ignore modular missile engines.
+                if (ignoreModularMissileEngines && IsModularMissilePart(engine.part)) continue; // Ignore modular missile engines.
                 if (BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.RUNWAY_PROJECT_ROUND == 55) engine.independentThrottle = false;
                 var mme = engine.part.FindModuleImplementing<MultiModeEngine>();
                 if (mme == null)
@@ -164,9 +164,8 @@ namespace BDArmory.VesselSpawning
             FireSpitter.ActivateFSEngines(vessel, activate);
         }
 
-        public static bool IsModularMissileEngine(ModuleEngines engine)
+        public static bool IsModularMissilePart(Part part)
         {
-            var part = engine.part;
             if (part is not null)
             {
                 var firstDecoupler = BDModularGuidance.FindFirstDecoupler(part.parent, null);

--- a/BDArmory/Weapons/Missiles/BDModularGuidance.cs
+++ b/BDArmory/Weapons/Missiles/BDModularGuidance.cs
@@ -113,7 +113,7 @@ namespace BDArmory.Weapons.Missiles
         private Vector3 rcsVector = Vector3.zero;
         private Vector3 rcsVectorLerped = Vector3.zero;
         private bool missileTarget = false;
-        private List<ModuleRCSFX> rcsThrusters;
+        private List<ModuleRCS> rcsThrusters;
         private List<ModuleEngines> engines;
 
         private bool _minSpeedAchieved = false;
@@ -889,13 +889,17 @@ namespace BDArmory.Weapons.Missiles
         {
             // Update list of engines/thrusters
             engines = VesselModuleRegistry.GetModuleEngines(vessel);
-            rcsThrusters = VesselModuleRegistry.GetModules<ModuleRCSFX>(vessel);
+            rcsThrusters = VesselModuleRegistry.GetModules<ModuleRCS>(vessel);
 
             // Get a probe core and align its reference transform with the propulsion vector.
             ModuleCommand commander = VesselModuleRegistry.GetModuleCommand(vessel);
-            commander.MakeReference();
-            Vector3 propulsionVector = -GetFireVector(engines, rcsThrusters, -vessel.ReferenceTransform.up);
-            AlignReference(commander, propulsionVector.normalized);
+            if (commander != null)
+            {
+                commander.MakeReference();
+                Vector3 propulsionVector = -GetFireVector(engines, rcsThrusters, -vessel.ReferenceTransform.up);
+                if (propulsionVector != null)
+                    AlignReference(commander, propulsionVector.normalized);
+            }
         }
 
         // Create and set a new control point for a command module (commander) pointing along a world space vector (direction).
@@ -929,7 +933,7 @@ namespace BDArmory.Weapons.Missiles
             dynamic.transform.rotation = Quaternion.LookRotation(perpendicular, direction.normalized); // VAB orientation.
         }
 
-        private static Vector3 GetFireVector(List<ModuleEngines> engines, List<ModuleRCSFX> RCS = null, Vector3 thrustVector = default(Vector3))
+        private static Vector3 GetFireVector(List<ModuleEngines> engines, List<ModuleRCS> RCS = null, Vector3 thrustVector = default(Vector3))
         {
             // Place linears first to establish a direction, not currently needed
             if (engines?.Any() == true)
@@ -943,7 +947,7 @@ namespace BDArmory.Weapons.Missiles
                 if (RCS?.Any() == true)
                 {
                     // If there are engines we can add RCS on top
-                    foreach (ModuleRCSFX thruster in RCS)
+                    foreach (ModuleRCS thruster in RCS)
                     {
                         thrustVector += GetRCSVector(thruster, thrustVector);
                     }
@@ -964,7 +968,7 @@ namespace BDArmory.Weapons.Missiles
             return thrustVector;
         }
 
-        private static Vector3 GetRCSVector(ModuleRCSFX thruster, Vector3 thrustVector)
+        private static Vector3 GetRCSVector(ModuleRCS thruster, Vector3 thrustVector)
         {
             //method to get the thrust vector of a specified rcs thruster
             Vector3 meanVector = Vector3.zero;

--- a/BDArmory/Weapons/Missiles/BDModularGuidance.cs
+++ b/BDArmory/Weapons/Missiles/BDModularGuidance.cs
@@ -888,8 +888,8 @@ namespace BDArmory.Weapons.Missiles
         private void UpdateOrbitalStage()
         {
             // Update list of engines/thrusters
-            engines = VesselModuleRegistry.GetModuleEngines(vessel).ToList();
-            rcsThrusters = VesselModuleRegistry.GetModules<ModuleRCS>(vessel).ToList();
+            engines = VesselModuleRegistry.GetModuleEngines(vessel);
+            rcsThrusters = VesselModuleRegistry.GetModules<ModuleRCS>(vessel);
 
             // Get a probe core and align its reference transform with the propulsion vector.
             ModuleCommand commander = VesselModuleRegistry.GetModuleCommand(vessel);

--- a/BDArmory/Weapons/Missiles/BDModularGuidance.cs
+++ b/BDArmory/Weapons/Missiles/BDModularGuidance.cs
@@ -777,7 +777,7 @@ namespace BDArmory.Weapons.Missiles
             }
             else
             {
-                aamTarget = vessel.CoM + (20 * vessel.srfSpeed * vessel.Velocity().normalized);
+                aamTarget = vessel.CoM + (20 * vessel.Velocity());
             }
 
             return aamTarget;

--- a/BDArmory/Weapons/Missiles/BDModularGuidance.cs
+++ b/BDArmory/Weapons/Missiles/BDModularGuidance.cs
@@ -888,8 +888,8 @@ namespace BDArmory.Weapons.Missiles
         private void UpdateOrbitalStage()
         {
             // Update list of engines/thrusters
-            engines = VesselModuleRegistry.GetModuleEngines(vessel);
-            rcsThrusters = VesselModuleRegistry.GetModules<ModuleRCS>(vessel);
+            engines = VesselModuleRegistry.GetModuleEngines(vessel).ToList();
+            rcsThrusters = VesselModuleRegistry.GetModules<ModuleRCS>(vessel).ToList();
 
             // Get a probe core and align its reference transform with the propulsion vector.
             ModuleCommand commander = VesselModuleRegistry.GetModuleCommand(vessel);

--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -717,7 +717,7 @@ namespace BDArmory.Weapons.Missiles
                 if (predictedHeatTarget.exists)
                 {
                     float currentFactor = (1400 * 1400) / Mathf.Clamp((predictedHeatTarget.position - transform.position).sqrMagnitude, 90000, 36000000);
-                    Vector3 currVel = (float)vessel.srfSpeed * vessel.Velocity().normalized;
+                    Vector3 currVel = vessel.Velocity();
                     predictedHeatTarget.position = predictedHeatTarget.position + predictedHeatTarget.velocity * Time.fixedDeltaTime;
                     predictedHeatTarget.velocity = predictedHeatTarget.velocity + predictedHeatTarget.acceleration * Time.fixedDeltaTime;
                     float futureFactor = (1400 * 1400) / Mathf.Clamp((predictedHeatTarget.position - (transform.position + (currVel * Time.fixedDeltaTime))).sqrMagnitude, 90000, 36000000);

--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -298,7 +298,7 @@ namespace BDArmory.Weapons.Missiles
 
         public DetonationDistanceStates DetonationDistanceState { get; set; } = DetonationDistanceStates.NotSafe;
 
-        public enum GuidanceModes { None, AAMLead, AAMPure, AGM, AGMBallistic, Cruise, STS, Bomb, RCS, BeamRiding, SLW, PN, APN, AAMLoft, Orbital }
+        public enum GuidanceModes { None, AAMLead, AAMPure, AGM, AGMBallistic, Cruise, STS, Bomb, Orbital, BeamRiding, SLW, PN, APN, AAMLoft }
 
         public GuidanceModes GuidanceMode;
 

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -1517,7 +1517,7 @@ namespace BDArmory.Weapons.Missiles
             if (!HasMissed && checkMiss)
             {
                 bool noProgress = MissileState == MissileStates.PostThrust && (Vector3.Dot(vessel.Velocity() - TargetVelocity, TargetPosition - vessel.transform.position) < 0);
-                bool pastGracePeriod = TimeIndex > ((vessel.LandedOrSplashed ? 0f : dropTime) + 180f / maxTurnRateDPS);
+                bool pastGracePeriod = TimeIndex > ((vessel.LandedOrSplashed ? 0f : dropTime) + Mathf.Clamp(maxTurnRateDPS / 15, 1, 8)); //180f / maxTurnRateDPS);
                 bool targetBehindMissile = !(MissileState != MissileStates.PostThrust && hasRCS) && Vector3.Dot(TargetPosition - transform.position, transform.forward) < 0f; // Allow thrusting RCS missiles to be behind the target
                 if ((pastGracePeriod && targetBehindMissile) || noProgress) // Check that we're not moving away from the target after a grace period
                 {
@@ -2563,11 +2563,14 @@ namespace BDArmory.Weapons.Missiles
             if (TargetAcquired)
             {
                 DrawDebugLine(transform.position + (part.rb.velocity * Time.fixedDeltaTime), TargetPosition);
-                Vector3 targetVector = TargetPosition - vessel.CoM;
+                // orbitalTarget = TargetPosition is more accurate than the below for the HEKV, TO-DO: investigate whether the below works for 
+                // multiple different missile configurations, or if a more generalized OrbitalGuidance method is needed
+                /*(Vector3 targetVector = TargetPosition - vessel.CoM;
                 Vector3 relVel = vessel.Velocity() - TargetVelocity;
                 Vector3 accel = currentThrust * Throttle / part.mass * Vector3.forward;
                 float timeToImpact = AIUtils.TimeToCPA(targetVector, relVel, TargetAcceleration - accel, 30f);
-                orbitalTarget = AIUtils.PredictPosition(targetVector, relVel, TargetAcceleration - 0.5f * accel, timeToImpact);
+                orbitalTarget = AIUtils.PredictPosition(targetVector, relVel, TargetAcceleration - 0.5f * accel, timeToImpact); */
+                orbitalTarget = TargetPosition;
             }
             else
             {

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -2686,7 +2686,7 @@ namespace BDArmory.Weapons.Missiles
         {
             try
             {
-                Vector3 relV = TargetVelocity - vessel.obt_velocity;
+                Vector3 relV = TargetVelocity - vessel.Velocity();
 
                 for (int i = 0; i < 4; i++)
                 {

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -1801,7 +1801,7 @@ namespace BDArmory.Weapons.Missiles
                             if (heatTarget.signalStrength > 0)
                             {
                                 float currentFactor = (1400 * 1400) / Mathf.Clamp((heatTarget.position - transform.position).sqrMagnitude, 90000, 36000000);
-                                Vector3 currVel = (float)vessel.srfSpeed * vessel.Velocity().normalized;
+                                Vector3 currVel = vessel.Velocity();
                                 heatTarget.position = heatTarget.position + heatTarget.velocity * Time.fixedDeltaTime;
                                 heatTarget.velocity = heatTarget.velocity + heatTarget.acceleration * Time.fixedDeltaTime;
                                 float futureFactor = (1400 * 1400) / Mathf.Clamp((heatTarget.position - (transform.position + (currVel * Time.fixedDeltaTime))).sqrMagnitude, 90000, 36000000);


### PR DESCRIPTION
- Re-factor of orbital AI to not use co-routines
- Logic for responding to WingCommander commands for Orbital AI
- Issue appropriate WingCommander command to Orbital AIs at start to have them fly away from center point
- Camera auto-switching logic for Orbital AI
- Missile firing logic for missiles with maxOffBoresight < 360
- Fix AI not being able to dumb-fire missiles on target when in orbit
- Fix RWP game mode removing command module from MMGs
- Fix NRE in MMG orbital guidance when command module is null