### PR TITLE
Missile/Orbital Fixes/Improvements

### DIFF
--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -45,7 +45,7 @@ namespace BDArmory.Control
         private float maxAcceleration;
         private Vector3 maxAngularAcceleration;
         private Vector3 availableTorque;
-        private double minSafeAltitude = -1;
+        private double minSafeAltitude;
         private CelestialBody safeAltBody = null;
 
         // Evading
@@ -613,7 +613,7 @@ namespace BDArmory.Control
         void AddDebugMessages()
         {
             if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI)
-            { 
+            {
                 debugString.AppendLine($"Current Status: {currentStatus}");
                 debugString.AppendLine($"Has Propulsion: {hasPropulsion}");
                 debugString.AppendLine($"Has Weapons: {hasWeapons}");

--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -45,7 +45,8 @@ namespace BDArmory.Control
         private float maxAcceleration;
         private Vector3 maxAngularAcceleration;
         private Vector3 availableTorque;
-        private double minSafeAltitude;
+        private double minSafeAltitude = -1;
+        private CelestialBody safeAltBody = null;
 
         // Evading
         bool evadingGunfire = false;
@@ -106,6 +107,11 @@ namespace BDArmory.Control
             groupName = "pilotAI_EvadeExtend", groupDisplayName = "#LOC_BDArmory_PilotAI_EvadeExtend", groupStartCollapsed = true),
             UI_FloatRange(minValue = 0f, maxValue = 5f, stepIncrement = 0.1f, scene = UI_Scene.All)]
         public float evasionTimeThreshold = 0.1f;
+
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_EvasionErraticness", advancedTweakable = true, // Evasion Erraticness
+            groupName = "pilotAI_EvadeExtend", groupDisplayName = "#LOC_BDArmory_PilotAI_EvadeExtend", groupStartCollapsed = true),
+            UI_FloatRange(minValue = 0f, maxValue = 1f, stepIncrement = 0.01f, scene = UI_Scene.All)]
+        public float evasionErraticness = 0.1f;
 
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_EvasionMinRangeThreshold", advancedTweakable = true, // Evasion Min Range Threshold
             groupName = "pilotAI_EvadeExtend", groupDisplayName = "#LOC_BDArmory_PilotAI_EvadeExtend", groupStartCollapsed = true),
@@ -387,7 +393,7 @@ namespace BDArmory.Control
                                 if (o.altitude < gravTurnAlt * minSafeAltitude || descending || wasDescendingUnsafe) // At low alts or when descending, burn straight up
                                 {
                                     turn = 1f;
-                                    fc.alignmentToleranceforBurn = 45f; // Use a wide tolerance as aero forces could make it difficult to align otherwise. // FIXME Josue Thoughts on this?
+                                    fc.alignmentToleranceforBurn = 45f; // Use a wide tolerance as aero forces could make it difficult to align otherwise.
                                     wasDescendingUnsafe = descending || o.timeToAp < 10; // Hysteresis for upwards vs gravity turn burns.
                                 }
                                 else // At higher alts, gravity turn towards horizontal orbit vector
@@ -401,27 +407,6 @@ namespace BDArmory.Control
                                 fc.attitude = Vector3.Lerp(o.Horizontal(UT), upDir, turn);
                                 fc.throttle = 1;
                             }
-                            // else if (o.ApA < minSafeAltitude * 1.1) // FIXME Josue This is a duplicate of the above. It should be the o.altitude < minSafeAltitude ("Falling inside atmo") section. I've added that in below, but you should check that I've done it right. I've also adjusted the above 
-                            // {
-                            //     // Entirety of orbit is inside atmosphere, perform gravity turn burn until apoapsis is outside atmosphere by a 10% margin.
-
-                            //     SetStatus("Correcting Orbit (Apoapsis too low)");
-
-                            //     double gravTurnAlt = 0.1;
-                            //     float turn;
-
-                            //     if (o.altitude < gravTurnAlt * minSafeAltitude) // At low alts, burn straight up
-                            //         turn = 1f;
-                            //     else // At higher alts, gravity turn towards horizontal orbit vector
-                            //     {
-                            //         turn = Mathf.Clamp((float)((1.1 * minSafeAltitude - o.ApA) / (minSafeAltitude * (1.1 - gravTurnAlt))), 0.1f, 1f);
-                            //         turn = Mathf.Clamp(Mathf.Log10(turn) + 1f, 0.33f, 1f);
-                            //     }
-
-                            //     fc.attitude = Vector3.Lerp(o.Horizontal(UT), upDir, turn);
-                            //     fc.alignmentToleranceforBurn = Mathf.Clamp(15f * turn, 5f, 15f);
-                            //     fc.throttle = 1;
-                            // }
                             else if (o.altitude < minSafeAltitude * 1.1 && descending)
                             {
                                 // Our apoapsis is outside the atmosphere but we are inside the atmosphere and descending.
@@ -430,7 +415,7 @@ namespace BDArmory.Control
                                 SetStatus("Correcting Orbit (Falling inside atmo)");
 
                                 fc.attitude = o.Radial(UT);
-                                fc.alignmentToleranceforBurn = 45f; // Use a wide tolerance as aero forces could make it difficult to align otherwise. // FIXME Josue Thoughts on this?
+                                fc.alignmentToleranceforBurn = 45f; // Use a wide tolerance as aero forces could make it difficult to align otherwise.
                                 fc.throttle = 1;
                             }
                             else
@@ -628,7 +613,7 @@ namespace BDArmory.Control
         void AddDebugMessages()
         {
             if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI)
-            {
+            { 
                 debugString.AppendLine($"Current Status: {currentStatus}");
                 debugString.AppendLine($"Has Propulsion: {hasPropulsion}");
                 debugString.AppendLine($"Has Weapons: {hasWeapons}");
@@ -762,24 +747,7 @@ namespace BDArmory.Control
                     }
                 }
                 evadingGunfire = true;
-                evasionNonLinearityDirection = (evasionNonLinearityDirection + 0.1f * UnityEngine.Random.onUnitSphere).normalized; // FIXME Josue This 0.1f factor should probably be configurable.
-                /* Example python code to show evolution of direction for 2s of evasion. Remove after considering the 0.1f factor.
-                import numpy, matplotlib.pyplot as plt
-                d = numpy.random.randn(3)
-                d/=numpy.linalg.norm(d)
-                D=[d]
-                for i in range(100): # 2s
-                    v = numpy.random.randn(3)
-                    v/=numpy.linalg.norm(v)
-                    d = d + 0.1 * v
-                    d/=numpy.linalg.norm(d)
-                    D.append(d)
-                D = numpy.stack(D)
-                fig = plt.figure()
-                ax = fig.add_subplot(111,projection='3d')
-                ax.scatter(D[:,0],D[:,1],D[:,2], c='b',marker='.')
-                plt.show()
-                */
+                evasionNonLinearityDirection = (evasionNonLinearityDirection + evasionErraticness * UnityEngine.Random.onUnitSphere).normalized;
                 evasiveTimer += Time.fixedDeltaTime;
 
                 if (evasiveTimer >= minEvasionTime)
@@ -801,14 +769,11 @@ namespace BDArmory.Control
         private bool CheckOrbitUnsafe()
         {
             Orbit o = vessel.orbit;
-            CelestialBody body = o.referenceBody;
-            double maxTerrainHeight = 200;
-            if (body.pqsController)
+            if (o.referenceBody != safeAltBody) // Body has been updated, update min safe alt
             {
-                PQS pqs = body.pqsController;
-                maxTerrainHeight = pqs.radiusMax - pqs.radius;
+                minSafeAltitude = o.referenceBody.MinSafeAltitude();
+                safeAltBody = o.referenceBody;
             }
-            minSafeAltitude = Math.Max(maxTerrainHeight, body.atmosphereDepth); // FIXME Josue Why not use body.minOrbitalDistance?
 
             return (o.PeA < minSafeAltitude && o.timeToPe < o.timeToAp) || (o.ApA < minSafeAltitude && (o.ApA >= 0 || o.timeToPe < -60)); // Match conditions in PilotLogic
         }

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -7,7 +7,9 @@
 - Weapons:
 	- Corrections to penetration and ricochet velocity changes and ricochet positions.
 	- Missiles:
-		-	Fix mass changes of missiles that decouple boosters and add missile mass debug telemetry.
+		- Fix mass changes of missiles that decouple boosters and add missile mass debug telemetry.
+		- Fix radar and heat targeting leading targets excessively (most apparent in orbit)
+		- Change spacing missiles with continous warhead from Detonation Distance / 3 to  Min(Blast Radius / 3, Detonation Distance / 3)
 
 v1.6.9.0
 IMPROVEMENTS / FIXES

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -682,6 +682,7 @@ Localization
         #LOC_BDArmory_MinEvasionTime = Min Evasion Time
         #LOC_BDArmory_EvasionNonlinearity = Evasion/Extension Nonlinearity
         #LOC_BDArmory_EvasionThreshold = Evasion Distance Threshold
+        #LOC_BDArmory_EvasionErraticness = RCS Evasion Erraticness
         #LOC_BDArmory_EvasionTimeThreshold = Evasion Time Threshold	
         #LOC_BDArmory_EvasionMinRangeThreshold = Evasion Min Range Threshold
         #LOC_BDArmory_EvasionIgnoreMyTargetTargetingMe = Don't Evade My Target

--- a/BDArmory/Extensions/BodyExtensions.cs
+++ b/BDArmory/Extensions/BodyExtensions.cs
@@ -67,10 +67,5 @@ namespace BDArmory.Extensions
             }
             return Math.Max(maxTerrainHeight, body.atmosphereDepth);
         }
-
-        public static double MinOrbitalDistance(this CelestialBody body)
-        {
-            return body.MinSafeAltitude() + body.Radius;
-        }
     }
 }

--- a/BDArmory/Extensions/BodyExtensions.cs
+++ b/BDArmory/Extensions/BodyExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using System;
 
 namespace BDArmory.Extensions
 {
@@ -54,6 +55,22 @@ namespace BDArmory.Extensions
             longitude = iLng + dLng;
 
             return k < maxIterations;
+        }
+
+        public static double MinSafeAltitude(this CelestialBody body)
+        {
+            double maxTerrainHeight = 200;
+            if (body.pqsController)
+            {
+                PQS pqs = body.pqsController;
+                maxTerrainHeight = pqs.radiusMax - pqs.radius;
+            }
+            return Math.Max(maxTerrainHeight, body.atmosphereDepth);
+        }
+
+        public static double MinOrbitalDistance(this CelestialBody body)
+        {
+            return body.MinSafeAltitude() + body.Radius;
         }
     }
 }

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -1136,12 +1136,12 @@ namespace BDArmory.UI
                 if (activeVessel != null && activeVessel.loaded && !activeVessel.packed && activeVessel.IsMissile())
                 {
                     var mb = VesselModuleRegistry.GetMissileBase(activeVessel);
-                    // Don't switch away from an active missile until it misses or is off-target, or if it is within 1 km of its source vessel or target position
+                    // Don't switch away from an active missile until it misses or is off-target, or if it is within 1 km of its target position
+                    Vector3 targetPosition = mb.targetVessel ? mb.targetVessel.transform.position : mb.TargetPosition;
                     bool stayOnMissile = mb != null &&
                         !mb.HasMissed &&
-                        Vector3.Dot((mb.TargetPosition - mb.vessel.transform.position).normalized, mb.vessel.transform.up) < 0.5f &&
-                        ((mb.SourceVessel && (mb.vessel.transform.position - mb.SourceVessel.transform.position).sqrMagnitude < 1e6) || // FIXME Josue Why the source vessel, wouldn't the target vessel make more sense?
-                        (mb.vessel.transform.position - mb.TargetPosition).sqrMagnitude < 1e6);
+                        Vector3.Dot((targetPosition - mb.vessel.transform.position).normalized, mb.vessel.transform.up) < 0.5f &&
+                        ((mb.vessel.transform.position - targetPosition).sqrMagnitude < 1e6);
                     if (stayOnMissile) return;
                 }
                 bool foundActiveVessel = false;

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -1137,11 +1137,10 @@ namespace BDArmory.UI
                 {
                     var mb = VesselModuleRegistry.GetMissileBase(activeVessel);
                     // Don't switch away from an active missile until it misses or is off-target, or if it is within 1 km of its target position
-                    Vector3 targetPosition = mb.targetVessel ? mb.targetVessel.transform.position : mb.TargetPosition;
                     bool stayOnMissile = mb != null &&
                         !mb.HasMissed &&
-                        Vector3.Dot((targetPosition - mb.vessel.transform.position).normalized, mb.vessel.transform.up) < 0.5f &&
-                        ((mb.vessel.transform.position - targetPosition).sqrMagnitude < 1e6);
+                        Vector3.Dot((mb.TargetPosition - mb.vessel.transform.position).normalized, mb.vessel.transform.up) < 0.5f &&
+                        ((mb.vessel.transform.position - mb.TargetPosition).sqrMagnitude < 1e6);
                     if (stayOnMissile) return;
                 }
                 bool foundActiveVessel = false;

--- a/BDArmory/VesselSpawning/CircularSpawning.cs
+++ b/BDArmory/VesselSpawning/CircularSpawning.cs
@@ -182,7 +182,7 @@ namespace BDArmory.VesselSpawning
             int spawnedVesselCount = 0; // Reset our spawned vessel count.
             var spawnAirborne = spawnConfig.altitude > 10;
             var spawnBody = FlightGlobals.Bodies[spawnConfig.worldIndex];
-            var spawnInOrbit = spawnConfig.altitude + spawnBody.Radius >= spawnBody.minOrbitalDistance; // Min safe orbital distance
+            var spawnInOrbit = spawnConfig.altitude + spawnBody.Radius >= spawnBody.MinOrbitalDistance(); // Min safe orbital distance
             var withInitialVelocity = spawnAirborne && BDArmorySettings.VESSEL_SPAWN_INITIAL_VELOCITY;
             var spawnPitch = (withInitialVelocity || spawnInOrbit) ? 0f : -80f;
             bool PinataMode = false;

--- a/BDArmory/VesselSpawning/CircularSpawning.cs
+++ b/BDArmory/VesselSpawning/CircularSpawning.cs
@@ -182,7 +182,7 @@ namespace BDArmory.VesselSpawning
             int spawnedVesselCount = 0; // Reset our spawned vessel count.
             var spawnAirborne = spawnConfig.altitude > 10;
             var spawnBody = FlightGlobals.Bodies[spawnConfig.worldIndex];
-            var spawnInOrbit = spawnConfig.altitude + spawnBody.Radius >= spawnBody.MinOrbitalDistance(); // Min safe orbital distance
+            var spawnInOrbit = spawnConfig.altitude >= spawnBody.MinSafeAltitude(); // Min safe orbital altitude
             var withInitialVelocity = spawnAirborne && BDArmorySettings.VESSEL_SPAWN_INITIAL_VELOCITY;
             var spawnPitch = (withInitialVelocity || spawnInOrbit) ? 0f : -80f;
             bool PinataMode = false;

--- a/BDArmory/VesselSpawning/ContinuousSpawning.cs
+++ b/BDArmory/VesselSpawning/ContinuousSpawning.cs
@@ -119,7 +119,7 @@ namespace BDArmory.VesselSpawning
             spawnConfig.craftFiles.Shuffle(); // Randomise the spawn order.
             spawnConfig.altitude = Math.Max(100, spawnConfig.altitude); // Don't spawn too low.
             var spawnBody = FlightGlobals.Bodies[spawnConfig.worldIndex];
-            var spawnInOrbit = spawnConfig.altitude + spawnBody.Radius >= spawnBody.minOrbitalDistance; // Min safe orbital distance
+            var spawnInOrbit = spawnConfig.altitude + spawnBody.Radius >= spawnBody.MinOrbitalDistance(); // Min safe orbital distance
             var spawnDistance = spawnConfig.craftFiles.Count > 1 ? (spawnConfig.absDistanceOrFactor ? spawnConfig.distance : spawnConfig.distance * (1 + (BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS > 0 ? Math.Min(spawnConfig.craftFiles.Count, BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS) : spawnConfig.craftFiles.Count))) : 0f; // If it's a single craft, spawn it at the spawn point.
             if (BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS == 0)
                 LogMessage("Spawning " + spawnConfig.craftFiles.Count + " vessels at an altitude of " + spawnConfig.altitude.ToString("G0") + (spawnConfig.craftFiles.Count > 8 ? "m, this may take some time..." : "m."));

--- a/BDArmory/VesselSpawning/ContinuousSpawning.cs
+++ b/BDArmory/VesselSpawning/ContinuousSpawning.cs
@@ -119,7 +119,7 @@ namespace BDArmory.VesselSpawning
             spawnConfig.craftFiles.Shuffle(); // Randomise the spawn order.
             spawnConfig.altitude = Math.Max(100, spawnConfig.altitude); // Don't spawn too low.
             var spawnBody = FlightGlobals.Bodies[spawnConfig.worldIndex];
-            var spawnInOrbit = spawnConfig.altitude + spawnBody.Radius >= spawnBody.MinOrbitalDistance(); // Min safe orbital distance
+            var spawnInOrbit = spawnConfig.altitude >= spawnBody.MinSafeAltitude(); // Min safe orbital altitude
             var spawnDistance = spawnConfig.craftFiles.Count > 1 ? (spawnConfig.absDistanceOrFactor ? spawnConfig.distance : spawnConfig.distance * (1 + (BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS > 0 ? Math.Min(spawnConfig.craftFiles.Count, BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS) : spawnConfig.craftFiles.Count))) : 0f; // If it's a single craft, spawn it at the spawn point.
             if (BDArmorySettings.VESSEL_SPAWN_CONCURRENT_VESSELS == 0)
                 LogMessage("Spawning " + spawnConfig.craftFiles.Count + " vessels at an altitude of " + spawnConfig.altitude.ToString("G0") + (spawnConfig.craftFiles.Count > 8 ? "m, this may take some time..." : "m."));

--- a/BDArmory/VesselSpawning/CustomSpawnTemplate.cs
+++ b/BDArmory/VesselSpawning/CustomSpawnTemplate.cs
@@ -120,7 +120,7 @@ namespace BDArmory.VesselSpawning
             spawnConfig.craftFiles = spawnConfig.customVesselSpawnConfigs.SelectMany(team => team).Select(config => config.craftURL).Where(craftURL => !string.IsNullOrEmpty(craftURL)).ToList();
             var spawnAirborne = spawnConfig.altitude > 10f;
             var spawnBody = FlightGlobals.Bodies[spawnConfig.worldIndex];
-            var spawnInOrbit = spawnConfig.altitude + spawnBody.Radius >= spawnBody.MinOrbitalDistance(); // Min safe orbital distance
+            var spawnInOrbit = spawnConfig.altitude >= spawnBody.MinSafeAltitude(); // Min safe orbital altitude
             var withInitialVelocity = spawnAirborne && BDArmorySettings.VESSEL_SPAWN_INITIAL_VELOCITY;
             var spawnPitch = withInitialVelocity ? 0f : -80f;
             LogMessage($"Spawning {spawnConfig.craftFiles.Count} vessels at an altitude of {spawnConfig.altitude.ToString("G0")}m ({(spawnInOrbit ? "in orbit" : spawnAirborne ? "airborne" : "landed")}).");

--- a/BDArmory/VesselSpawning/CustomSpawnTemplate.cs
+++ b/BDArmory/VesselSpawning/CustomSpawnTemplate.cs
@@ -120,7 +120,7 @@ namespace BDArmory.VesselSpawning
             spawnConfig.craftFiles = spawnConfig.customVesselSpawnConfigs.SelectMany(team => team).Select(config => config.craftURL).Where(craftURL => !string.IsNullOrEmpty(craftURL)).ToList();
             var spawnAirborne = spawnConfig.altitude > 10f;
             var spawnBody = FlightGlobals.Bodies[spawnConfig.worldIndex];
-            var spawnInOrbit = spawnConfig.altitude + spawnBody.Radius >= spawnBody.minOrbitalDistance; // Min safe orbital distance
+            var spawnInOrbit = spawnConfig.altitude + spawnBody.Radius >= spawnBody.MinOrbitalDistance(); // Min safe orbital distance
             var withInitialVelocity = spawnAirborne && BDArmorySettings.VESSEL_SPAWN_INITIAL_VELOCITY;
             var spawnPitch = withInitialVelocity ? 0f : -80f;
             LogMessage($"Spawning {spawnConfig.craftFiles.Count} vessels at an altitude of {spawnConfig.altitude.ToString("G0")}m ({(spawnInOrbit ? "in orbit" : spawnAirborne ? "airborne" : "landed")}).");

--- a/BDArmory/VesselSpawning/SingleVesselSpawning.cs
+++ b/BDArmory/VesselSpawning/SingleVesselSpawning.cs
@@ -62,7 +62,7 @@ namespace BDArmory.VesselSpawning
             var north = VectorUtils.GetNorthVector(spawnPoint, spawnBody);
             var direction = (Quaternion.AngleAxis(initialHeading, radialUnitVector) * north).ProjectOnPlanePreNormalized(radialUnitVector).normalized;
             var airborne = altitude > 10;
-            var spawnInOrbit = altitude + spawnBody.Radius >= spawnBody.minOrbitalDistance; // Min safe orbital distance
+            var spawnInOrbit = altitude + spawnBody.Radius >= spawnBody.MinOrbitalDistance(); // Min safe orbital distance
             var withInitialVelocity = airborne && BDArmorySettings.VESSEL_SPAWN_INITIAL_VELOCITY;
             VesselSpawnConfig vesselSpawnConfig = new VesselSpawnConfig(craftUrl, spawnPoint, direction, (float)altitude, initialPitch, airborne, spawnInOrbit);
 

--- a/BDArmory/VesselSpawning/SingleVesselSpawning.cs
+++ b/BDArmory/VesselSpawning/SingleVesselSpawning.cs
@@ -62,7 +62,7 @@ namespace BDArmory.VesselSpawning
             var north = VectorUtils.GetNorthVector(spawnPoint, spawnBody);
             var direction = (Quaternion.AngleAxis(initialHeading, radialUnitVector) * north).ProjectOnPlanePreNormalized(radialUnitVector).normalized;
             var airborne = altitude > 10;
-            var spawnInOrbit = altitude + spawnBody.Radius >= spawnBody.MinOrbitalDistance(); // Min safe orbital distance
+            var spawnInOrbit = altitude >= spawnBody.MinSafeAltitude(); // Min safe orbital altitude
             var withInitialVelocity = airborne && BDArmorySettings.VESSEL_SPAWN_INITIAL_VELOCITY;
             VesselSpawnConfig vesselSpawnConfig = new VesselSpawnConfig(craftUrl, spawnPoint, direction, (float)altitude, initialPitch, airborne, spawnInOrbit);
 

--- a/BDArmory/VesselSpawning/VesselSpawnerBase.cs
+++ b/BDArmory/VesselSpawning/VesselSpawnerBase.cs
@@ -336,7 +336,7 @@ namespace BDArmory.VesselSpawning
             RaycastHit hit;
             var distanceToCoMainBody = (ray.origin - spawnBody.transform.position).magnitude;
             float distance;
-            var spawnInOrbit = vesselSpawnConfig.altitude + spawnBody.Radius >= spawnBody.minOrbitalDistance; // Min safe orbital distance
+            var spawnInOrbit = vesselSpawnConfig.altitude + spawnBody.Radius >= spawnBody.MinOrbitalDistance(); // Min safe orbital distance
             Vector3 localSurfaceNormal = -ray.direction;
             var localTerrainAltitude = BodyUtils.GetTerrainAltitudeAtPos(ray.origin);
             if (localTerrainAltitude > 0 && Physics.Raycast(ray, out hit, distanceToCoMainBody, (int)LayerMasks.Scenery))
@@ -792,7 +792,7 @@ namespace BDArmory.VesselSpawning
                         if (pilot != null) { vessel.SetWorldVelocity(pilot.idleSpeed * vessel.transform.up); }
                     }
                     var orbitalAI = weaponManager.AI as BDModuleOrbitalAI;
-                    if (orbitalAI && vessel.altitude + vessel.mainBody.Radius > vessel.mainBody.minOrbitalDistance) // In space with an orbital AI. Set it in a circular orbit.
+                    if (orbitalAI && vessel.altitude + vessel.mainBody.Radius > vessel.mainBody.MinOrbitalDistance()) // In space with an orbital AI. Set it in a circular orbit.
                     {
                         Vector3d orbitVelocity = Math.Sqrt(FlightGlobals.getGeeForceAtPosition(vessel.CoM, vessel.mainBody).magnitude * (vessel.mainBody.Radius + vessel.altitude)) * FlightGlobals.currentMainBody.getRFrmVel(vessel.CoM).normalized;
                         vessel.SetWorldVelocity(orbitVelocity);

--- a/BDArmory/VesselSpawning/VesselSpawnerBase.cs
+++ b/BDArmory/VesselSpawning/VesselSpawnerBase.cs
@@ -336,7 +336,7 @@ namespace BDArmory.VesselSpawning
             RaycastHit hit;
             var distanceToCoMainBody = (ray.origin - spawnBody.transform.position).magnitude;
             float distance;
-            var spawnInOrbit = vesselSpawnConfig.altitude + spawnBody.Radius >= spawnBody.MinOrbitalDistance(); // Min safe orbital distance
+            var spawnInOrbit = vesselSpawnConfig.altitude >= spawnBody.MinSafeAltitude(); // Min safe orbital altitude
             Vector3 localSurfaceNormal = -ray.direction;
             var localTerrainAltitude = BodyUtils.GetTerrainAltitudeAtPos(ray.origin);
             if (localTerrainAltitude > 0 && Physics.Raycast(ray, out hit, distanceToCoMainBody, (int)LayerMasks.Scenery))
@@ -792,7 +792,7 @@ namespace BDArmory.VesselSpawning
                         if (pilot != null) { vessel.SetWorldVelocity(pilot.idleSpeed * vessel.transform.up); }
                     }
                     var orbitalAI = weaponManager.AI as BDModuleOrbitalAI;
-                    if (orbitalAI && vessel.altitude + vessel.mainBody.Radius > vessel.mainBody.MinOrbitalDistance()) // In space with an orbital AI. Set it in a circular orbit.
+                    if (orbitalAI && vessel.altitude > vessel.mainBody.MinSafeAltitude()) // In space with an orbital AI. Set it in a circular orbit.
                     {
                         Vector3d orbitVelocity = Math.Sqrt(FlightGlobals.getGeeForceAtPosition(vessel.CoM, vessel.mainBody).magnitude * (vessel.mainBody.Radius + vessel.altitude)) * FlightGlobals.currentMainBody.getRFrmVel(vessel.CoM).normalized;
                         vessel.SetWorldVelocity(orbitVelocity);

--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -717,7 +717,7 @@ namespace BDArmory.Weapons.Missiles
                 if (heatTarget.exists)
                 {
                     TargetAcquired = true;
-                    TargetPosition = heatTarget.position + (2 * heatTarget.velocity * Time.fixedDeltaTime); // Not sure why this is 2*
+                    TargetPosition = heatTarget.position;
                     TargetVelocity = heatTarget.velocity;
                     TargetAcceleration = heatTarget.acceleration;
                     lockFailTimer = 0;
@@ -955,7 +955,7 @@ namespace BDArmory.Weapons.Missiles
                                         //if (weaponClass == WeaponClasses.SLW)
                                         //    TargetPosition = radarTarget.predictedPosition + (radarTarget.velocity * Time.fixedDeltaTime);
                                         //else
-                                        TargetPosition = radarTarget.predictedPositionWithChaffFactor(chaffEffectivity) + (radarTarget.velocity * Time.fixedDeltaTime);
+                                        TargetPosition = radarTarget.predictedPositionWithChaffFactor(chaffEffectivity);
 
                                         TargetVelocity = radarTarget.velocity;
                                         TargetAcceleration = radarTarget.acceleration;
@@ -995,7 +995,7 @@ namespace BDArmory.Weapons.Missiles
                             //if (weaponClass == WeaponClasses.SLW)
                             //    TargetPosition = radarTarget.predictedPosition + (radarTarget.velocity * Time.fixedDeltaTime);
                             //else
-                            TargetPosition = radarTarget.predictedPositionWithChaffFactor(chaffEffectivity) + (radarTarget.velocity * Time.fixedDeltaTime);
+                            TargetPosition = radarTarget.predictedPositionWithChaffFactor(chaffEffectivity);
 
                             TargetVelocity = radarTarget.velocity;
                             TargetAcceleration = Vector3.zero;
@@ -1071,7 +1071,7 @@ namespace BDArmory.Weapons.Missiles
                     //if (weaponClass == WeaponClasses.SLW)
                     //    TargetPosition = radarTarget.predictedPosition + (radarTarget.velocity * Time.fixedDeltaTime);
                     //else
-                    TargetPosition = radarTarget.predictedPositionWithChaffFactor(chaffEffectivity) + (radarTarget.velocity * Time.fixedDeltaTime);
+                    TargetPosition = radarTarget.predictedPositionWithChaffFactor(chaffEffectivity);
                     TargetVelocity = radarTarget.velocity;
                     TargetAcceleration = radarTarget.acceleration;
 
@@ -1474,7 +1474,7 @@ namespace BDArmory.Weapons.Missiles
                         else
                         {
                             float optimalDistance = (float)(Math.Max(DetonationDistance, relativeSpeed));
-                            Vector3 targetPoint = (warheadType == WarheadTypes.ContinuousRod ? vessel.CoM - VectorUtils.GetUpDirection(TargetPosition) * (GetBlastRadius() > 0 ? (DetonationDistance / 3) : 5) : vessel.CoM);
+                            Vector3 targetPoint = (warheadType == WarheadTypes.ContinuousRod ? vessel.CoM - VectorUtils.GetUpDirection(TargetPosition) * (GetBlastRadius() > 0f ? Mathf.Min(GetBlastRadius() / 3f, DetonationDistance / 3f) : 5f) : vessel.CoM);
                             var hitCount = Physics.OverlapSphereNonAlloc(targetPoint, optimalDistance, proximityHitColliders, layerMask);
                             if (hitCount == proximityHitColliders.Length)
                             {

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -2415,8 +2415,7 @@ namespace BDArmory.Weapons.Missiles
             {
                 if (warheadType == WarheadTypes.ContinuousRod) //Have CR missiles target slightly above target to ensure craft caught in planar blast AOE
                 {
-                    TargetPosition += VectorUtils.GetUpDirection(TargetPosition) * (blastRadius > 0 ? (DetonationDistance / 3) : 5);
-                    //TargetPosition += VectorUtils.GetUpDirection(TargetPosition) * (blastRadius < 10? (blastRadius / 2) : 10);
+                    TargetPosition += VectorUtils.GetUpDirection(TargetPosition) * (blastRadius > 0f ? Mathf.Min(blastRadius / 3f, DetonationDistance / 3f) : 5f);
                 }
                 DrawDebugLine(transform.position + (part.rb.velocity * Time.fixedDeltaTime), TargetPosition);
 

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -2389,7 +2389,7 @@ namespace BDArmory.Weapons
             WeaponFX();
             for (int i = 0; i < fireTransforms.Length; i++)
             {
-                if ((!useRippleFire || !pulseLaser || fireState.Length == 1) || (useRippleFire && i == barrelIndex))
+                if (!useRippleFire || !pulseLaser || fireState.Length == 1 || (useRippleFire && i == barrelIndex))
                 {
                     float damage = laserDamage;
                     float initialDamage = damage * 0.425f;
@@ -2416,10 +2416,11 @@ namespace BDArmory.Weapons
                     lr.useWorldSpace = false;
                     lr.SetPosition(0, Vector3.zero);
 
-                    var hitCount = Physics.RaycastNonAlloc(ray, laserHits, maxTargetingRange, layerMask1);
+                    var raycastDistance = isAPS ? (tgtShell != null ? (tgtShell.currentPosition - tf.position).magnitude : tgtRocket != null ? (tgtRocket.currentPosition - tf.position).magnitude : maxTargetingRange) : maxTargetingRange; // Only raycast to the incoming projectile if APS.
+                    var hitCount = Physics.RaycastNonAlloc(ray, laserHits, raycastDistance, layerMask1);
                     if (hitCount == laserHits.Length) // If there's a whole bunch of stuff in the way (unlikely), then we need to increase the size of our hits buffer.
                     {
-                        laserHits = Physics.RaycastAll(ray, maxTargetingRange, layerMask1);
+                        laserHits = Physics.RaycastAll(ray, raycastDistance, layerMask1);
                         hitCount = laserHits.Length;
                     }
                     //Debug.Log($"[LASER DEBUG] hitCount: {hitCount}");
@@ -2614,7 +2615,7 @@ namespace BDArmory.Weapons
                     else
                     {
                         if (isAPS && !pulseLaser)
-                            laserPoint = (tgtShell != null ? tgtShell.transform.position : (tgtRocket != null ? tgtRocket.transform.position : lr.transform.InverseTransformPoint((targetDirectionLR * maxTargetingRange) + tf.position)));
+                            laserPoint = lr.transform.InverseTransformPoint(tgtShell != null ? tgtShell.transform.position : tgtRocket != null ? tgtRocket.transform.position : (targetDirectionLR * maxTargetingRange) + tf.position);
                         else
                             laserPoint = lr.transform.InverseTransformPoint((targetDirectionLR * maxTargetingRange) + tf.position);
                         lr.SetPosition(1, laserPoint);


### PR DESCRIPTION
 - Change target spacing for missiles with continous warhead from DetonationDistance / 3 to Min(blastRadius / 3, DetonationDistance / 3)
- Remove unnecessary lead in heatTarget position update
- Remove unnecessary lead in radarTarget position update
- Add methods to BodyExtensions to calculate minimum safe orbit and altitude distances and use those with Orbital AI and spawning routines.
- Remove some fixed FixMe comments