### PR TITLE
Team Icons / Fuel Leak / Missile Fix Update

### DIFF
--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -6415,7 +6415,7 @@ namespace BDArmory.Control
                 MissileBase ml = CurrentMissile;
                 MissileBase pMl = PreviousMissile;
                 if (!ml && pMl) ml = PreviousMissile; //if fired missile, then switched to guns or something
-                if (ml && ml.TargetingMode == MissileBase.TargetingModes.Radar && vesselRadarData != null && (!vesselRadarData.locked || vesselRadarData.lockedTargetData.vessel != guardTarget))
+                if (vesselRadarData != null && (!vesselRadarData.locked || vesselRadarData.lockedTargetData.vessel != guardTarget))
                 {
                     if (!vesselRadarData.locked)
                     {

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -4,6 +4,9 @@
 	- Fix Krakensbane adjustments when the active vessel dies.
 	- Fix tracer visuals when the active vessel dies.
 	- Adjust timing and conditions for auto-camera switching to and away from missiles.
+	- Battle damage fuel leak rates now scale by (bullet caliber)^2, instead of (bullet caliber). Fuel leak rates for 20mm caliber remain the same, calibers higher and lower than 20mm will now have higher and lower leak rates, respectively.
+- UI:
+	- New Opacity option in BDA Team Icons to set icon opacity.
 - AI / WM:
 	- Invert the roll target when the fly-to direction is below and behind the craft within the Immelmann turn angle.
 	- Fix automatic gun range adjustments in the WM again.

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -20,6 +20,8 @@
 		- Change spacing missiles with continous warhead from Detonation Distance / 3 to  Min(Blast Radius / 3, Detonation Distance / 3).
 		- Fix missile RCS FX constantly displaying.
 		- Missiles with RCS/Orbital homing types (i.e. HEKV) in vacuum now perform turn maneuver after launch to face target and only throttle up once facing target.
+		- Fix missile drag curve having negative drag at ~25 deg AoA
+		- Fix AI occasionally not firing radar missiles; Git Issue #573
 
 v1.6.9.0
 IMPROVEMENTS / FIXES

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -18,15 +18,16 @@ v1.6.9.0
   	- 'subProjectileCount' has been deprecated and replaced with 'projectileCount'; this specifies number of pellets per shot (for shotguns, etc) to make it more intuitive. Existing shotgun-type weapons will need to update their bulletDefs.
  	  - The subMunitionType field for beehive ammo now uses the syntax of "ammotype; quantity" (e.g. subMunitionType = 35x228AHEADPellet; 30) with number of projectiles released on detonation set here instead of the subMunition's bulletDef.
   	- Missiles:
-    		- Fix issue with Rotary Rails trying to use missiles that have previously been blown off from combat damage.
-    		- Fix issue with MultiMissilelauncher Turrets throwing an NRE when AI firing.
-       	- Fix mass changes of missiles that decouple boosters and add missile mass debug telemetry.
-		    - Fix radar and heat targeting leading targets excessively (most apparent in orbit)
+		- Fix issue with Rotary Rails trying to use missiles that have previously been blown off from combat damage.
+		- Fix issue with MultiMissilelauncher Turrets throwing an NRE when AI firing.
+		- Fix mass changes of missiles that decouple boosters and add missile mass debug telemetry.
+		- Fix radar and heat targeting leading targets excessively (most apparent in orbit)
         - Fix missile drag curve having negative drag at ~25 deg AoA
-		    - Fix AI occasionally not firing radar missiles; Git Issue #573
-	    	- Change spacing missiles with continous rod warheads from Detonation Distance / 3 to  Min(Blast Radius / 3, Detonation Distance / 3)
+		- Fix AI occasionally not firing radar missiles; Git Issue #573
+		- Change spacing missiles with continous rod warheads from Detonation Distance / 3 to  Min(Blast Radius / 3, Detonation Distance / 3)
         - Fix missile RCS FX constantly displaying.
-		    - Missiles with RCS/Orbital homing types (i.e. HEKV) in vacuum now perform turn maneuver after launch to face target and only throttle up once facing target.
+		- Missiles with RCS/Orbital homing types (i.e. HEKV) in vacuum now perform turn maneuver after launch to face target and only throttle up once facing target.
+		- Add new dragArea configuration variable for missiles to set reference area for drag independently from the lift area. If not set, this defaults to the liftArea setting in the missile configuration file.
 
 IMPROVEMENTS / FIXES
 - UI:

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -1144,6 +1144,7 @@ Localization
         #LOC_BDArmory_Icon_threats = Vessel Threat Indicators
         #LOC_BDArmory_Icon_pointers = Offscreen Icon Pointers
         #LOC_BDArmory_Icon_scale = Icon Scale:
+        #LOC_BDArmory_Icon_opacity = Opacity:
         #LOC_BDArmory_Icon_distance_threshold = Distance Threshold:
         #LOC_BDArmory_Icon_max_distance_threshold = Max Distance Threshold:
         #LOC_BDArmory_Icon_telemetry = Enable Telemetry;

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -1139,6 +1139,7 @@ Localization
         #LOC_BDArmory_Icon_score = Enable Score
         #LOC_BDArmory_Icon_healthbars = Enable Healthbars
         #LOC_BDArmory_Icon_missiles = Missile Icons
+        #LOC_BDArmory_Icon_missile_text = Missile Labels
         #LOC_BDArmory_Icon_debris = Debris Icons
         #LOC_BDArmory_Icon_persist = Do not hide with UI
         #LOC_BDArmory_Icon_threats = Vessel Threat Indicators

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/aim-120/amraam.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/aim-120/amraam.cfg
@@ -73,6 +73,7 @@ PART
 
 		aero = true //Missile has aerodynamics
 		liftArea = 0.0020 //increases lift which helps with manuevering and turning, but also increases drag
+		// dragArea = 0.0020 // Option to set reference area for drag independently from the lift area, otherwise defaults to liftArea
 		steerMult = 8 //big number = steer harder...
 		maxTorque = 60 //ammount of torque that will be applied to the missile for turning
 		maxAoA = 30 //max AoA missile can turn at, will limit missile's turn radius below what is possible with maxTorque if set too low

--- a/BDArmory/FX/BulletHitFX.cs
+++ b/BDArmory/FX/BulletHitFX.cs
@@ -476,8 +476,8 @@ namespace BDArmory.FX
                     if (!hitPart.isEngine())
                     {
                         leakFX.AttachAt(hitPart, hit, new Vector3(0.25f, 0f, 0f));
-                        leakFX.transform.localScale = Vector3.one * (caliber / 10);
-                        leakFX.drainRate = ((caliber / 10) * BDArmorySettings.BD_TANK_LEAK_RATE);
+                        leakFX.transform.localScale = Vector3.one * (caliber * caliber / 200f);
+                        leakFX.drainRate = ((caliber * caliber / 200f) * BDArmorySettings.BD_TANK_LEAK_RATE);
                         leakFX.lifeTime = (BDArmorySettings.BD_TANK_LEAK_TIME);
                         if (BDArmorySettings.BD_FIRES_ENABLED && !inertTank)
                         {
@@ -509,8 +509,8 @@ namespace BDArmory.FX
                 else
                 {
                     leakFX.AttachAt(hitPart, hit, new Vector3(0.25f, 0f, 0f));
-                    leakFX.transform.localScale = Vector3.one * (caliber / 10);
-                    leakFX.drainRate = ((caliber / 10) * BDArmorySettings.BD_TANK_LEAK_RATE);
+                    leakFX.transform.localScale = Vector3.one * (caliber * caliber / 200f);
+                    leakFX.drainRate = ((caliber * caliber / 200f) * BDArmorySettings.BD_TANK_LEAK_RATE);
                     leakFX.lifeTime = (BDArmorySettings.BD_TANK_LEAK_TIME);
 
                     if (hitPart.isEngine())

--- a/BDArmory/GameModes/Mutators/BDAMutator.cs
+++ b/BDArmory/GameModes/Mutators/BDAMutator.cs
@@ -362,7 +362,7 @@ namespace BDArmory.GameModes
                             iconPath = MutatorInfo.mutators[mutators[i]].icon;
                             iconcolor = MutatorInfo.mutators[mutators[i]].iconColor;
                             iconColor = GUIUtils.ParseColor255(iconcolor);
-                            iconColor.a = BDTISettings.OPACITY * BDTISetup.localToGlobalOpacity * BDTISetup.iconOpacity;
+                            iconColor.a = BDTISettings.OPACITY * BDTISetup.iconOpacity;
                             switch (iconPath)
                             {
                                 case "IconAccuracy":

--- a/BDArmory/GameModes/Mutators/BDAMutator.cs
+++ b/BDArmory/GameModes/Mutators/BDAMutator.cs
@@ -362,6 +362,7 @@ namespace BDArmory.GameModes
                             iconPath = MutatorInfo.mutators[mutators[i]].icon;
                             iconcolor = MutatorInfo.mutators[mutators[i]].iconColor;
                             iconColor = GUIUtils.ParseColor255(iconcolor);
+                            iconColor.a = BDTISettings.OPACITY * BDTISetup.localToGlobalOpacity * BDTISetup.iconOpacity;
                             switch (iconPath)
                             {
                                 case "IconAccuracy":

--- a/BDArmory/Guidances/MissileGuidance.cs
+++ b/BDArmory/Guidances/MissileGuidance.cs
@@ -626,12 +626,12 @@ namespace BDArmory.Guidances
             if (DefaultDragCurve == null)
             {
                 DefaultDragCurve = new FloatCurve();
-                DefaultDragCurve.Add(0, 0.00215f);
-                DefaultDragCurve.Add(5, .00285f);
-                DefaultDragCurve.Add(15, .007f);
-                DefaultDragCurve.Add(29, .01f);
-                DefaultDragCurve.Add(55, .3f);
-                DefaultDragCurve.Add(90, .5f);
+                DefaultDragCurve.Add(0, 0.00215f, 0.00014f, 0.00014f);
+                DefaultDragCurve.Add(5, .00285f, 0.0002775f, 0.0002775f);
+                DefaultDragCurve.Add(15, .007f, 0.0003146428f, 0.0003146428f);
+                DefaultDragCurve.Add(29, .01f, 0.0002142857f, 0.01115385f);
+                DefaultDragCurve.Add(55, .3f, 0.008434067f, 0.008434067f);
+                DefaultDragCurve.Add(90, .5f, 0.005714285f, 0.005714285f);
             }
 
             FloatCurve liftCurve = DefaultLiftCurve;
@@ -659,7 +659,7 @@ namespace BDArmory.Guidances
             float AoA = Mathf.Clamp(Vector3.Angle(ml.transform.forward, velocity.normalized), 0, 90);
             if (AoA > 0)
             {
-                double liftForce = 0.5 * airDensity * airSpeed * airSpeed * liftArea * liftMultiplier * liftCurve.Evaluate(AoA);
+                double liftForce = 0.5 * airDensity * airSpeed * airSpeed * liftArea * liftMultiplier * Mathf.Max(liftCurve.Evaluate(AoA), 0f);
                 Vector3 forceDirection = -velocity.ProjectOnPlanePreNormalized(ml.transform.forward).normalized;
                 rb.AddForceAtPosition((float)liftForce * forceDirection,
                     ml.transform.TransformPoint(ml.part.CoMOffset + CoL));
@@ -668,7 +668,7 @@ namespace BDArmory.Guidances
             //drag
             if (airSpeed > 0)
             {
-                double dragForce = 0.5 * airDensity * airSpeed * airSpeed * liftArea * dragMultiplier * dragCurve.Evaluate(AoA);
+                double dragForce = 0.5 * airDensity * airSpeed * airSpeed * liftArea * dragMultiplier * Mathf.Max(dragCurve.Evaluate(AoA), 0f);
                 rb.AddForceAtPosition((float)dragForce * -velocity.normalized,
                     ml.transform.TransformPoint(ml.part.CoMOffset + CoL));
             }

--- a/BDArmory/Guidances/MissileGuidance.cs
+++ b/BDArmory/Guidances/MissileGuidance.cs
@@ -608,7 +608,7 @@ namespace BDArmory.Guidances
         public static FloatCurve DefaultLiftCurve = null;
         public static FloatCurve DefaultDragCurve = null;
 
-        public static Vector3 DoAeroForces(MissileLauncher ml, Vector3 targetPosition, float liftArea, float steerMult,
+        public static Vector3 DoAeroForces(MissileLauncher ml, Vector3 targetPosition, float liftArea, float dragArea, float steerMult,
             Vector3 previousTorque, float maxTorque, float maxAoA)
         {
             if (DefaultLiftCurve == null)
@@ -637,11 +637,11 @@ namespace BDArmory.Guidances
             FloatCurve liftCurve = DefaultLiftCurve;
             FloatCurve dragCurve = DefaultDragCurve;
 
-            return DoAeroForces(ml, targetPosition, liftArea, steerMult, previousTorque, maxTorque, maxAoA, liftCurve,
+            return DoAeroForces(ml, targetPosition, liftArea, dragArea, steerMult, previousTorque, maxTorque, maxAoA, liftCurve,
                 dragCurve);
         }
 
-        public static Vector3 DoAeroForces(MissileLauncher ml, Vector3 targetPosition, float liftArea, float steerMult,
+        public static Vector3 DoAeroForces(MissileLauncher ml, Vector3 targetPosition, float liftArea, float dragArea, float steerMult,
             Vector3 previousTorque, float maxTorque, float maxAoA, FloatCurve liftCurve, FloatCurve dragCurve)
         {
             Rigidbody rb = ml.part.rb;
@@ -668,7 +668,7 @@ namespace BDArmory.Guidances
             //drag
             if (airSpeed > 0)
             {
-                double dragForce = 0.5 * airDensity * airSpeed * airSpeed * liftArea * dragMultiplier * Mathf.Max(dragCurve.Evaluate(AoA), 0f);
+                double dragForce = 0.5 * airDensity * airSpeed * airSpeed * dragArea * dragMultiplier * Mathf.Max(dragCurve.Evaluate(AoA), 0f);
                 rb.AddForceAtPosition((float)dragForce * -velocity.normalized,
                     ml.transform.TransformPoint(ml.part.CoMOffset + CoL));
             }

--- a/BDArmory/Settings/BDTISettings.cs
+++ b/BDArmory/Settings/BDTISettings.cs
@@ -18,8 +18,9 @@ namespace BDArmory.Settings
 		[SettingsDataField] public static bool PERSISTANT = true;
 		[SettingsDataField] public static bool POINTERS = true;
 		[SettingsDataField] public static bool TELEMETRY = false;
-		[SettingsDataField] public static float ICONSCALE = 1.0f;
-		[SettingsDataField] public static float DISTANCE_THRESHOLD = 100f;
+        [SettingsDataField] public static float ICONSCALE = 1.0f;
+        [SettingsDataField] public static float OPACITY = 50f;
+        [SettingsDataField] public static float DISTANCE_THRESHOLD = 100f;
 		[SettingsDataField] public static float MAX_DISTANCE_THRESHOLD = 0f;
 	}
 }

--- a/BDArmory/Settings/BDTISettings.cs
+++ b/BDArmory/Settings/BDTISettings.cs
@@ -14,7 +14,8 @@ namespace BDArmory.Settings
 		[SettingsDataField] public static bool HEALTHBAR = false;
 		[SettingsDataField] public static bool THREATICON = false;
 		[SettingsDataField] public static bool MISSILES = false;
-		[SettingsDataField] public static bool DEBRIS = true;
+        [SettingsDataField] public static bool MISSILE_TEXT = true;
+        [SettingsDataField] public static bool DEBRIS = true;
 		[SettingsDataField] public static bool PERSISTANT = true;
 		[SettingsDataField] public static bool POINTERS = true;
 		[SettingsDataField] public static bool TELEMETRY = false;

--- a/BDArmory/UI/BDATeamIcons.cs
+++ b/BDArmory/UI/BDATeamIcons.cs
@@ -478,9 +478,9 @@ namespace BDArmory.UI
         {
             // Update opacity for DropshadowStyle, mIStyle, Missilecolor. IconUIStyle opacity
             // is updated in OnGUI().
-            if (forceUpdate || Opacity != BDTISettings.OPACITY * BDTISetup.localToGlobalOpacity)
+            if (forceUpdate || Opacity != BDTISettings.OPACITY)
             {
-                Opacity = BDTISettings.OPACITY * BDTISetup.localToGlobalOpacity;
+                Opacity = BDTISettings.OPACITY;
 
                 Teamcolor.a = Opacity;
                 Color temp;

--- a/BDArmory/UI/BDATeamIcons.cs
+++ b/BDArmory/UI/BDATeamIcons.cs
@@ -244,7 +244,7 @@ namespace BDArmory.UI
                                                 Rect distRect = new Rect((guiPos.x - 12), (guiPos.y + 10), 100, 32);
                                                 GUI.Label(distRect, UIdist + UoM, mIStyle);
                                             }
-                                            if (BDTISettings.VESSELNAMES)
+                                            if (BDTISettings.MISSILE_TEXT)
                                             {
                                                 if (GUIUtils.WorldToGUIPos(ml.Current.vessel.CoM, out guiPos))
                                                 {

--- a/BDArmory/UI/BDATeamIcons.cs
+++ b/BDArmory/UI/BDATeamIcons.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
-
 using BDArmory.Competition;
 using BDArmory.Settings;
 using BDArmory.Utils;

--- a/BDArmory/UI/BDATeamIcons.cs
+++ b/BDArmory/UI/BDATeamIcons.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System;
 using UnityEngine;
 
 using BDArmory.Competition;
@@ -30,6 +29,8 @@ namespace BDArmory.UI
         GUIStyle DropshadowStyle;
         GUIStyle mIStyle;
         Color Teamcolor;
+        Color Missilecolor;
+        float Opacity;
 
         private void Start()
         {
@@ -47,12 +48,16 @@ namespace BDArmory.UI
             mIStyle.fontStyle = FontStyle.Normal;
             mIStyle.fontSize = 10;
             mIStyle.normal.textColor = XKCDColors.Yellow;
+            Missilecolor = XKCDColors.Yellow;
 
             IconMat = new Material(Shader.Find("KSP/Particles/Alpha Blended"));
+
+            UpdateStyles(true);
         }
 
         private void DrawOnScreenIcon(Vector3 worldPos, Texture texture, Vector2 size, Color Teamcolor, bool ShowPointer)
         {
+            Teamcolor.a *= BDTISetup.iconOpacity;
             if (Event.current.type.Equals(EventType.Repaint))
             {
                 bool offscreen = false;
@@ -110,6 +115,7 @@ namespace BDArmory.UI
         }
         private void DrawThreatIndicator(Vector3 vesselPos, Vector3 targetPos, Color Teamcolor)
         {
+            Teamcolor.a *= BDTISetup.iconOpacity;
             if (Event.current.type.Equals(EventType.Repaint))
             {
                 Vector3 screenPos = GUIUtils.GetMainCamera().WorldToViewportPoint(vesselPos);
@@ -194,7 +200,7 @@ namespace BDArmory.UI
             {
                 Texture icon;
                 float size = 40;
-
+                UpdateStyles();
                 using (List<Vessel>.Enumerator v = FlightGlobals.Vessels.GetEnumerator())
                     while (v.MoveNext())
                     {
@@ -233,7 +239,7 @@ namespace BDArmory.UI
                                                 UoM = "m";
                                                 UIdist = Dist.ToString("0.0");
                                             }
-                                            GUIUtils.DrawTextureOnWorldPos(v.Current.CoM, BDTISetup.Instance.TextureIconMissile, new Vector2(20, 20), 0);
+                                            DrawOnScreenIcon(v.Current.CoM, BDTISetup.Instance.TextureIconMissile, new Vector2(20, 20), Missilecolor, true);
                                             if (GUIUtils.WorldToGUIPos(ml.Current.vessel.CoM, out guiPos))
                                             {
                                                 Rect distRect = new Rect((guiPos.x - 12), (guiPos.y + 10), 100, 32);
@@ -243,7 +249,9 @@ namespace BDArmory.UI
                                             {
                                                 if (GUIUtils.WorldToGUIPos(ml.Current.vessel.CoM, out guiPos))
                                                 {
-                                                    IconUIStyle.normal.textColor = BDTISetup.Instance.ColorAssignments.ContainsKey(ml.Current.Team.Name) ? BDTISetup.Instance.ColorAssignments[ml.Current.Team.Name] : Color.gray;
+                                                    Color iconUI = BDTISetup.Instance.ColorAssignments.ContainsKey(ml.Current.Team.Name) ? BDTISetup.Instance.ColorAssignments[ml.Current.Team.Name] : Color.gray;
+                                                    iconUI.a = Opacity * BDTISetup.textOpacity;
+                                                    IconUIStyle.normal.textColor = iconUI;
                                                     Rect nameRect = new Rect((guiPos.x + (24 * BDTISettings.ICONSCALE)), guiPos.y - 4, 100, 32);
                                                     Rect shadowRect = new Rect((nameRect.x + 1), nameRect.y + 1, 100, 32);
                                                     GUI.Label(shadowRect, ml.Current.vessel.vesselName, DropshadowStyle);
@@ -279,8 +287,11 @@ namespace BDArmory.UI
                             {
                                 if (wm.Current == null) continue;
                                 if (!BDTISetup.Instance.ColorAssignments.ContainsKey(wm.Current.Team.Name)) continue; // Ignore entries that haven't been updated yet.
-                                Teamcolor = BDTISetup.Instance.ColorAssignments[wm.Current.Team.Name];
-                                IconUIStyle.normal.textColor = Teamcolor;
+                                Color teamcolor = BDTISetup.Instance.ColorAssignments[wm.Current.Team.Name];
+                                teamcolor.a = Opacity;
+                                Teamcolor = teamcolor;
+                                teamcolor.a *= BDTISetup.textOpacity;
+                                IconUIStyle.normal.textColor = teamcolor;
                                 size = wm.Current.vessel.vesselType == VesselType.Debris ? 20 : 40;
                                 if (wm.Current.vessel.isActiveVessel)
                                 {
@@ -399,9 +410,12 @@ namespace BDArmory.UI
                                                 {
                                                     Rect barRect = new Rect((guiPos.x - (32 * BDTISettings.ICONSCALE)), (guiPos.y + (30 * BDTISettings.ICONSCALE)), (64 * BDTISettings.ICONSCALE), 12);
                                                     Rect healthRect = new Rect((guiPos.x - (30 * BDTISettings.ICONSCALE)), (guiPos.y + (32 * BDTISettings.ICONSCALE)), (60 * (float)hpPercent * BDTISettings.ICONSCALE), 8);
-                                                    //GUI.Label(healthRect, "Team: " + $"{wm.Current.Team.Name}", IconUIStyle);
-                                                    GUIUtils.DrawRectangle(barRect, XKCDColors.Grey);
-                                                    GUIUtils.DrawRectangle(healthRect, Color.HSVToRGB((85f * (float)hpPercent) / 255, 1f, 1f));
+                                                    Color temp = XKCDColors.Grey;
+                                                    temp.a = Opacity * BDTISetup.iconOpacity;
+                                                    GUIUtils.DrawRectangle(barRect, temp);
+                                                    temp = Color.HSVToRGB((85f * (float)hpPercent) / 255, 1f, 1f);
+                                                    temp.a = Opacity * BDTISetup.iconOpacity;
+                                                    GUIUtils.DrawRectangle(healthRect, temp);
 
                                                 }
                                                 Rect distRect = new Rect((guiPos.x - 12), (guiPos.y + (45 * BDTISettings.ICONSCALE)), 100, 32);
@@ -460,6 +474,26 @@ namespace BDArmory.UI
             }
         }
 
+        void UpdateStyles(bool forceUpdate = false)
+        {
+            // Update opacity for DropshadowStyle, mIStyle, Missilecolor. IconUIStyle opacity
+            // is updated in OnGUI().
+            if (forceUpdate || Opacity != BDTISettings.OPACITY * BDTISetup.localToGlobalOpacity)
+            {
+                Opacity = BDTISettings.OPACITY * BDTISetup.localToGlobalOpacity;
+
+                Teamcolor.a = Opacity;
+                Color temp;
+                temp = DropshadowStyle.normal.textColor;
+                temp.a = Opacity * BDTISetup.textOpacity;
+                DropshadowStyle.normal.textColor = temp;
+                temp = mIStyle.normal.textColor;
+                temp.a = Opacity * BDTISetup.textOpacity;
+                mIStyle.normal.textColor = temp;
+                Missilecolor.a = Opacity;
+            }
+        }
+
         Texture2D GetIconForVessel(Vessel v)
         {
             Texture2D icon;
@@ -490,8 +524,11 @@ namespace BDArmory.UI
             else if (v.vesselType == VesselType.Debris)
             {
                 icon = BDTISetup.Instance.TextureIconDebris;
-                IconUIStyle.normal.textColor = XKCDColors.Grey;
-                Teamcolor = XKCDColors.Grey;
+                Color temp = XKCDColors.Grey;
+                temp.a = Opacity;
+                Teamcolor = temp;
+                temp.a *= BDTISetup.textOpacity;
+                IconUIStyle.normal.textColor = temp;
             }
             else
             {

--- a/BDArmory/UI/BDTISetup.cs
+++ b/BDArmory/UI/BDTISetup.cs
@@ -403,6 +403,7 @@ namespace BDArmory.UI
                 BDTISettings.HEALTHBAR = GUI.Toggle(new Rect(15, line++ * 25, toolWindowWidth - 20, 20), BDTISettings.HEALTHBAR, StringUtils.Localize("#LOC_BDArmory_Icon_healthbars"), BDArmorySetup.BDGuiSkin.toggle);
                 BDTISettings.SHOW_SELF = GUI.Toggle(new Rect(15, line++ * 25, toolWindowWidth - 20, 20), BDTISettings.SHOW_SELF, StringUtils.Localize("#LOC_BDArmory_Icon_show_self"), BDArmorySetup.BDGuiSkin.toggle);
                 BDTISettings.MISSILES = GUI.Toggle(new Rect(15, line++ * 25, toolWindowWidth - 20, 20), BDTISettings.MISSILES, StringUtils.Localize("#LOC_BDArmory_Icon_missiles"), BDArmorySetup.BDGuiSkin.toggle);
+                if (BDTISettings.MISSILES) BDTISettings.MISSILE_TEXT = GUI.Toggle(new Rect(15, line++ * 25, toolWindowWidth - 20, 20), BDTISettings.MISSILE_TEXT, StringUtils.Localize("#LOC_BDArmory_Icon_missile_text"), BDArmorySetup.BDGuiSkin.toggle);
                 BDTISettings.DEBRIS = GUI.Toggle(new Rect(15, line++ * 25, toolWindowWidth - 20, 20), BDTISettings.DEBRIS, StringUtils.Localize("#LOC_BDArmory_Icon_debris"), BDArmorySetup.BDGuiSkin.toggle);
                 BDTISettings.PERSISTANT = GUI.Toggle(new Rect(15, line++ * 25, toolWindowWidth - 20, 20), BDTISettings.PERSISTANT, StringUtils.Localize("#LOC_BDArmory_Icon_persist"), BDArmorySetup.BDGuiSkin.toggle);
                 BDTISettings.THREATICON = GUI.Toggle(new Rect(15, line++ * 25, toolWindowWidth - 20, 20), BDTISettings.THREATICON, StringUtils.Localize("#LOC_BDArmory_Icon_threats"), BDArmorySetup.BDGuiSkin.toggle);

--- a/BDArmory/UI/BDTISetup.cs
+++ b/BDArmory/UI/BDTISetup.cs
@@ -35,6 +35,11 @@ namespace BDArmory.UI
         private float updateList = 0;
         private bool maySavethisInstance = false;
 
+        // Opacity Settings
+        internal const float textOpacity = 1f;
+        internal const float iconOpacity = 0.5f;
+        internal const float localToGlobalOpacity = 0.02f; // Conversion between BDATeamIcons.Opacity and BDTISettings.OPACITY
+
         public SortedList<string, List<MissileFire>> weaponManagers = new SortedList<string, List<MissileFire>>();
 
         public static string textureDir = "BDArmory/Textures/";
@@ -409,6 +414,8 @@ namespace BDArmory.UI
                 line -= 0.15f;
                 GUI.Label(new Rect(15, line++ * 25, toolWindowWidth - 20, 20), $"{StringUtils.Localize("#LOC_BDArmory_Icon_distance_threshold")} {BDTISettings.DISTANCE_THRESHOLD:0}m");
                 BDTISettings.DISTANCE_THRESHOLD = BDAMath.RoundToUnit(GUI.HorizontalSlider(new Rect(10, line++ * 25, toolWindowWidth - 40, 20), BDTISettings.DISTANCE_THRESHOLD, 10f, 250f), 10f);
+                GUI.Label(new Rect(15, line++ * 25, toolWindowWidth - 20, 20), $"{StringUtils.Localize("#LOC_BDArmory_Icon_opacity")} {BDTISettings.OPACITY:0}%");
+                BDTISettings.OPACITY = BDAMath.RoundToUnit(GUI.HorizontalSlider(new Rect(10, line++ * 25, toolWindowWidth - 40, 20), BDTISettings.OPACITY, 0f, 100f), 1f);
                 GUI.Label(new Rect(15, line++ * 25, toolWindowWidth - 20, 20), $"{StringUtils.Localize("#LOC_BDArmory_Icon_max_distance_threshold")} {(BDTISettings.MAX_DISTANCE_THRESHOLD < BDArmorySettings.MAX_GUARD_VISUAL_RANGE ? $"{BDTISettings.MAX_DISTANCE_THRESHOLD / 1000f:0}km" : "Unlimited")}");
                 BDTISettings.MAX_DISTANCE_THRESHOLD = UI_FloatSemiLogRange.ToSemiLogValue(Mathf.Round(GUI.HorizontalSlider(new Rect(10, line++ * 25, toolWindowWidth - 40, 20), UI_FloatSemiLogRange.FromSemiLogValue(BDTISettings.MAX_DISTANCE_THRESHOLD / 1000f, 1f), 1f, UI_FloatSemiLogRange.FromSemiLogValue(BDArmorySettings.MAX_GUARD_VISUAL_RANGE / 1000f, 1f))), 1f, 1) * 1000f;
                 GUI.EndGroup();

--- a/BDArmory/UI/BDTISetup.cs
+++ b/BDArmory/UI/BDTISetup.cs
@@ -36,8 +36,8 @@ namespace BDArmory.UI
         private bool maySavethisInstance = false;
 
         // Opacity Settings
-        internal const float textOpacity = 1f;
-        internal const float iconOpacity = 0.5f;
+        internal const float textOpacity = 2f;
+        internal const float iconOpacity = 1f;
         internal const float localToGlobalOpacity = 0.02f; // Conversion between BDATeamIcons.Opacity and BDTISettings.OPACITY
 
         public SortedList<string, List<MissileFire>> weaponManagers = new SortedList<string, List<MissileFire>>();
@@ -414,8 +414,8 @@ namespace BDArmory.UI
                 line -= 0.15f;
                 GUI.Label(new Rect(15, line++ * 25, toolWindowWidth - 20, 20), $"{StringUtils.Localize("#LOC_BDArmory_Icon_distance_threshold")} {BDTISettings.DISTANCE_THRESHOLD:0}m");
                 BDTISettings.DISTANCE_THRESHOLD = BDAMath.RoundToUnit(GUI.HorizontalSlider(new Rect(10, line++ * 25, toolWindowWidth - 40, 20), BDTISettings.DISTANCE_THRESHOLD, 10f, 250f), 10f);
-                GUI.Label(new Rect(15, line++ * 25, toolWindowWidth - 20, 20), $"{StringUtils.Localize("#LOC_BDArmory_Icon_opacity")} {BDTISettings.OPACITY:0}%");
-                BDTISettings.OPACITY = BDAMath.RoundToUnit(GUI.HorizontalSlider(new Rect(10, line++ * 25, toolWindowWidth - 40, 20), BDTISettings.OPACITY, 0f, 100f), 1f);
+                GUI.Label(new Rect(15, line++ * 25, toolWindowWidth - 20, 20), $"{StringUtils.Localize("#LOC_BDArmory_Icon_opacity")} {BDTISettings.OPACITY * 100f:0}%");
+                BDTISettings.OPACITY = BDAMath.RoundToUnit(GUI.HorizontalSlider(new Rect(10, line++ * 25, toolWindowWidth - 40, 20), BDTISettings.OPACITY * 100f, 0f, 100f) / 100f, 0.01f);
                 GUI.Label(new Rect(15, line++ * 25, toolWindowWidth - 20, 20), $"{StringUtils.Localize("#LOC_BDArmory_Icon_max_distance_threshold")} {(BDTISettings.MAX_DISTANCE_THRESHOLD < BDArmorySettings.MAX_GUARD_VISUAL_RANGE ? $"{BDTISettings.MAX_DISTANCE_THRESHOLD / 1000f:0}km" : "Unlimited")}");
                 BDTISettings.MAX_DISTANCE_THRESHOLD = UI_FloatSemiLogRange.ToSemiLogValue(Mathf.Round(GUI.HorizontalSlider(new Rect(10, line++ * 25, toolWindowWidth - 40, 20), UI_FloatSemiLogRange.FromSemiLogValue(BDTISettings.MAX_DISTANCE_THRESHOLD / 1000f, 1f), 1f, UI_FloatSemiLogRange.FromSemiLogValue(BDArmorySettings.MAX_GUARD_VISUAL_RANGE / 1000f, 1f))), 1f, 1) * 1000f;
                 GUI.EndGroup();

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -67,6 +67,9 @@ namespace BDArmory.Weapons.Missiles
         public float liftArea = 0.015f;
 
         [KSPField]
+        public float dragArea = -1f; // Optional parameter to specify separate drag reference area, otherwise defaults to liftArea
+
+        [KSPField]
         public float steerMult = 0.5f;
 
         [KSPField]
@@ -471,6 +474,12 @@ namespace BDArmory.Weapons.Missiles
             Fields["maxStaticLaunchRange"].guiActiveEditor = false;
             Fields["minStaticLaunchRange"].guiActive = false;
             Fields["minStaticLaunchRange"].guiActiveEditor = false;
+
+            if (dragArea < 0)
+            {
+                if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileLauncher]: OnStart missile {shortName}: setting default dragArea to liftArea {liftArea}:");
+                dragArea = liftArea;
+            }
 
             loftState = 0;
             TimeToImpact = float.PositiveInfinity;
@@ -1773,7 +1782,7 @@ namespace BDArmory.Weapons.Missiles
                     TargetMf = null;
                     if (aero)
                     {
-                        aeroTorque = MissileGuidance.DoAeroForces(this, TargetPosition, liftArea, .25f, aeroTorque, maxTorque, maxAoA);
+                        aeroTorque = MissileGuidance.DoAeroForces(this, TargetPosition, liftArea, dragArea, .25f, aeroTorque, maxTorque, maxAoA);
                     }
                 }
 
@@ -2593,7 +2602,7 @@ namespace BDArmory.Weapons.Missiles
 
         void DoAero(Vector3 targetPosition)
         {
-            aeroTorque = MissileGuidance.DoAeroForces(this, targetPosition, liftArea, controlAuthority * steerMult, aeroTorque, finalMaxTorque, maxAoA);
+            aeroTorque = MissileGuidance.DoAeroForces(this, targetPosition, liftArea, dragArea, controlAuthority * steerMult, aeroTorque, finalMaxTorque, maxAoA);
         }
 
         void AGMBallisticGuidance()


### PR DESCRIPTION
- Add opacity option to BDA Team Icons
- Add missile label toggling option to BDA Team Icons
- Scale fuel leak rates by bullet caliber^2 instead of caliber
- Fix missile drag curve having negative drag at ~25 deg AoA
- Fix AI occasionally not firing radar missiles; Git Issue #573
- Add new dragArea configuration variable for missiles to set reference area for drag independently from the lift area. If not set, this defaults to the liftArea setting in the missile configuration file.