### PR TITLE
MML exhaustPrefab filtering tweak

### DIFF
--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -1319,12 +1319,11 @@ namespace BDArmory.Weapons.Missiles
                 part.explosionPotential = 0; // Minimise the default part explosion FX that sometimes gets offset from the main explosion.
                 rcsClearanceState = (GuidanceMode == GuidanceModes.Orbital && hasRCS && vacuumSteerable && (vessel.InVacuum()) ? RCSClearanceStates.Clearing : RCSClearanceStates.Cleared); // Set up clearance check if missile hasRCS, is vacuumSteerable, and is in space
 
-                var mml = part.GetComponent<MultiMissileLauncher>();
-                var isClusterMissile = mml && mml.isClusterMissile;
+                bool isClusterMissile = multiLauncher && multiLauncher.isClusterMissile;
                 if (!string.IsNullOrEmpty(exhaustPrefabPath))
                 {
-                    HashSet<Transform> dummyTransforms = isClusterMissile ? part.GetComponentsInChildren<MissileDummy>().SelectMany(md => md.transform.parent.GetComponentsInChildren<Transform>().Where(t => t.name == "exhaustTransform")).ToHashSet() : [];
-                    foreach (var t in part.FindModelTransforms("exhaustTransform"))
+                    HashSet<Transform> dummyTransforms = isClusterMissile ? part.GetComponentsInChildren<MissileDummy>().SelectMany(md => md.transform.parent.GetComponentsInChildren<Transform>().Where(t => t.name == multiLauncher.exhaustTransformName)).ToHashSet() : [];
+                    foreach (var t in part.FindModelTransforms(boostTransformName))
                     {
                         if (t == null) continue;
                         if (dummyTransforms.Contains(t)) continue; // Ignore exhausts for dummy transforms for MMLs, e.g., for submunitions of cluster missiles.
@@ -1336,7 +1335,7 @@ namespace BDArmory.Weapons.Missiles
 
                 if (!string.IsNullOrEmpty(boostExhaustPrefabPath) && !string.IsNullOrEmpty(boostExhaustTransformName))
                 {
-                    HashSet<Transform> dummyTransforms = isClusterMissile ? part.GetComponentsInChildren<MissileDummy>().SelectMany(md => md.transform.parent.GetComponentsInChildren<Transform>().Where(t => t.name == boostExhaustTransformName)).ToHashSet() : [];
+                    HashSet<Transform> dummyTransforms = isClusterMissile ? part.GetComponentsInChildren<MissileDummy>().SelectMany(md => md.transform.parent.GetComponentsInChildren<Transform>().Where(t => t.name == multiLauncher.boostTransformName)).ToHashSet() : [];
                     foreach (var t in part.FindModelTransforms(boostExhaustTransformName))
                     {
                         if (t == null) continue;

--- a/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
@@ -38,6 +38,8 @@ namespace BDArmory.Weapons.Missiles
         [KSPField(isPersistant = true)] public string subMunitionPath; //model path for missile
         public float missileMass = 0.1f;
         [KSPField] public string launchTransformName; //name of transform launcTransforms are parented to - see Rocketlauncher transform hierarchy
+        public string exhaustTransformName;
+        public string boostTransformName;
         //[KSPField] public int salvoSize = 1; //leave blank to have salvoSize = launchTransforms.count
         [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = false, guiName = "#LOC_BDArmory_WMWindow_rippleText2"), UI_FloatRange(minValue = 1, maxValue = 10, stepIncrement = 1, scene = UI_Scene.Editor, affectSymCounterparts = UI_Scene.All)]//Salvo
         public float salvoSize = 1;
@@ -251,6 +253,16 @@ namespace BDArmory.Weapons.Missiles
                                 if (ML != null) loadedMissileName = ML.GetShortName();
                                 else Debug.LogError("[BDArmory.MultiMissileLauncher] submunition MissileLauncher module null! Check subMunitionName is correct");
                             }
+                            try
+                            {
+                                boostTransformName = ConfigNodeUtils.FindPartModuleConfigNodeValue(parts.Current.partPrefab.partInfo.partConfig, "MissileLauncher", "boostTransformName");
+                            }
+                            catch { boostTransformName = string.Empty; }
+                            try
+                            {
+                                exhaustTransformName = ConfigNodeUtils.FindPartModuleConfigNodeValue(parts.Current.partPrefab.partInfo.partConfig, "MissileLauncher", "boostExhaustTransformName ");
+                            }
+                            catch { exhaustTransformName = string.Empty; }
                             break;
                         }
                     if (bRadius == 0)


### PR DESCRIPTION
Have missileDummy exhausts be filtered by name in their .cfgs instead of hardcoded string; have missile exhaust use .cfg string instead of hardcoded one