### PR TITLE
Fix calculation of RCS for FAR wing parts

### DIFF
--- a/BDArmory/Utils/FARUtils.cs
+++ b/BDArmory/Utils/FARUtils.cs
@@ -136,15 +136,21 @@ namespace BDArmory.Utils
             {
                 if (module.GetType() == FARWingModule)
                 {
-                    var sweep = (float)FARWingModule.GetField("MidChordSweep", BindingFlags.Public | BindingFlags.Instance).GetValue(module); //leading + trailing angle / 2
+                    var sweep = FARWingModule.GetField("MidChordSweep", BindingFlags.Public | BindingFlags.Instance).GetValue(module); //leading + trailing angle / 2
                     if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.FARUtils]: Found mid chord sweep of {sweep} for {part.name}.");
-                    return sweep;
+                    if (float.TryParse(sweep.ToString(), out float f))
+                    {
+                        return f;
+                    }
                 }
                 if (module.GetType() == FARControllableSurfaceModule)
                 {
-                    var sweep = (float)FARControllableSurfaceModule.GetField("MidChordSweep", BindingFlags.Public | BindingFlags.Instance).GetValue(module);
+                    var sweep = FARControllableSurfaceModule.GetField("MidChordSweep", BindingFlags.Public | BindingFlags.Instance).GetValue(module);
                     if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.FARUtils]: Found ctrl. srf. mid chord sweep of {sweep} for {part.name}.");
-                    return sweep;
+                    if (float.TryParse(sweep.ToString(), out float f))
+                    {
+                        return f;
+                    }
                 }
             }
             return 0;


### PR DESCRIPTION
Casting to the MidChordSweep field to a float causes an InvalidCastException. This results in FAR wings not having any radar return at all, at least according to the RCS analysis tool.

<img width="1273" alt="far-wing-bug" src="https://github.com/BrettRyland/BDArmory/assets/2476811/8914ecec-9c23-433b-94da-e22fb940b47a">

By fixing this, the RCS is calculated properly.

<img width="1037" alt="far-wing-fix" src="https://github.com/BrettRyland/BDArmory/assets/2476811/172e1793-8db1-4ddb-b5fe-0316063d5091">

IIRC, this was a regression in the 1.6.10.0 release.

P.S. I am not a C# or Unity coder, so I'd appreciate a more performant fix.