### PR TITLE
Assorted fixes

### DIFF
--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -1467,6 +1467,7 @@ namespace BDArmory.Bullets
                 float incrementVelocity = 1000 / (bulletVelocity + sBullet.bulletVelocity); //using 1km/s as a reference Unit
                 float dispersionAngle = sBullet.subProjectileDispersion > 0 ? sBullet.subProjectileDispersion : BDAMath.Sqrt(count) / 2; //fewer fragments/pellets are going to be larger-> move slower, less dispersion
                 float dispersionVelocityforAngle = 1000 / incrementVelocity * Mathf.Sin(dispersionAngle * Mathf.Deg2Rad); // convert m/s despersion to angle, accounting for vel of round
+                float subProjVelocity = GetDragAdjustedVelocity().magnitude + sBullet.bulletVelocity;
                 for (int s = 0; s < count * sBullet.projectileCount; s++) //this does mean that setting a subMunitionType to, say, shotgun shells and then setting a sMT projectile count of, say, 5, would have only 5 shotgun pellets spawn, even if the shutgun shell projectileCount = 30. Could always have it be count * subMunitiontype.projectileCount if you want shotshells as an allowable submunition
                 {
                     GameObject Bullet = ModuleWeapon.bulletPool.GetPooledObject();
@@ -1474,7 +1475,7 @@ namespace BDArmory.Bullets
                     pBullet.transform.position = currentPosition;
 
                     pBullet.caliber = sBullet.caliber;
-                    pBullet.bulletVelocity = GetDragAdjustedVelocity().magnitude + sBullet.bulletVelocity;
+                    pBullet.bulletVelocity = subProjVelocity;
                     pBullet.bulletMass = sBullet.bulletMass;
                     pBullet.incendiary = sBullet.incendiary;
                     pBullet.apBulletMod = sBullet.apBulletMod;

--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -1274,7 +1274,8 @@ namespace BDArmory.Bullets
                             // If we don't, I.E. the round isn't completely eroded, we decrease
                             // the velocity by a max of 5%, proportional to the adjustedPenRatio
                             //impactVelocity = impactVelocity * (0.95f + 0.05f * adjustedPenRatio);
-                            adjustedPenRatio *= 0.95f + 0.05f * adjustedPenRatio;
+                            adjustedPenRatio *= 0.05f;
+                            adjustedPenRatio += 0.95f;
                             //impactVelocity = impactVelocity * adjustedPenRatio;
                             //currentVelocity = hitPartVelocity + impactVelocity;
                         }

--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -1276,7 +1276,7 @@ namespace BDArmory.Bullets
                             // If we don't, I.E. the round isn't completely eroded, we decrease
                             // the velocity by a max of 5%, proportional to the adjustedPenRatio
                             //impactVelocity = impactVelocity * (0.95f + 0.05f * adjustedPenRatio);
-                            adjustedPenRatio = 0.95f + 0.05f * adjustedPenRatio;
+                            adjustedPenRatio *= 0.95f + 0.05f * adjustedPenRatio;
                             //impactVelocity = impactVelocity * adjustedPenRatio;
                             //currentVelocity = hitPartVelocity + impactVelocity;
                         }

--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -145,7 +145,6 @@ namespace BDArmory.Bullets
         public PooledRocket tgtRocket = null;
         public PooledBullet tgtShell = null;
 
-        float atmosphereDensity;
         public int penTicker = 0;
 
         Ray bulletRay;
@@ -543,11 +542,11 @@ namespace BDArmory.Bullets
         private void LeapfrogVelocityHalfStep(float period)
         {
             timeElapsedSinceCurrentSpeedWasAdjusted += period; // Track flight time for drag purposes
-            UpdateDragEstimate(); // Update the drag estimate, accounting for water/air environment changes. Note: changes due to bulletDrop aren't being applied to the drag.
             if (bulletDrop)
                 currentVelocity += period * FlightGlobals.getGeeForceAtPosition(currentPosition);
             if (underwater)
             {
+                UpdateDragEstimate(); //update the drag estimate, accounting for water/air environment changes. Note: changes due to bulletDrop aren't being applied to the drop.
                 currentVelocity *= dragVelocityFactor; // Note: If applied to aerial flight, this screws up targeting, because the weapon's aim code doesn't know how to account for drag. Only have it apply when underwater for now. Review later?
                 currentSpeed = currentVelocity.magnitude;
                 timeElapsedSinceCurrentSpeedWasAdjusted = 0;
@@ -560,8 +559,7 @@ namespace BDArmory.Bullets
         /// <returns></returns>
         Vector3 GetDragAdjustedVelocity()
         {
-            atmosphereDensity = (float)FlightGlobals.getAtmDensity(FlightGlobals.getStaticPressure(currentPosition), FlightGlobals.getExternalTemperature(currentPosition)); //moving this here so it's not getting called 2x a tick in LeapFrogVelocityHalfStep
-
+            UpdateDragEstimate();
             if (timeElapsedSinceCurrentSpeedWasAdjusted > 0)
             {
                 return currentVelocity * dragVelocityFactor;
@@ -1680,7 +1678,7 @@ namespace BDArmory.Bullets
             if (underwater)
                 atmDensity = 1030f; // Sea water (3% salt) has a density of 1030kg/m^3 at 4°C at sea level. https://en.wikipedia.org/wiki/Density#Various_materials
             else
-                atmDensity = atmosphereDensity;
+                atmDensity = (float)FlightGlobals.getAtmDensity(FlightGlobals.getStaticPressure(currentPosition), FlightGlobals.getExternalTemperature(currentPosition)); 
 
             dragVelocityFactor = 2f * ballisticCoefficient / (timeElapsed * initialSpeed * atmDensity + 2f * ballisticCoefficient);
 

--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -145,7 +145,6 @@ namespace BDArmory.Bullets
         public PooledRocket tgtRocket = null;
         public PooledBullet tgtShell = null;
 
-        float atmosphereDensity;
         public int penTicker = 0;
 
         Ray bulletRay;
@@ -543,11 +542,11 @@ namespace BDArmory.Bullets
         private void LeapfrogVelocityHalfStep(float period)
         {
             timeElapsedSinceCurrentSpeedWasAdjusted += period; // Track flight time for drag purposes
-            UpdateDragEstimate(); // Update the drag estimate, accounting for water/air environment changes. Note: changes due to bulletDrop aren't being applied to the drag.
             if (bulletDrop)
                 currentVelocity += period * FlightGlobals.getGeeForceAtPosition(currentPosition);
             if (underwater)
             {
+                UpdateDragEstimate(); // Update the drag estimate, accounting for water/air environment changes. Note: changes due to bulletDrop aren't being applied to the drag.
                 currentVelocity *= dragVelocityFactor; // Note: If applied to aerial flight, this screws up targeting, because the weapon's aim code doesn't know how to account for drag. Only have it apply when underwater for now. Review later?
                 currentSpeed = currentVelocity.magnitude;
                 timeElapsedSinceCurrentSpeedWasAdjusted = 0;
@@ -560,8 +559,7 @@ namespace BDArmory.Bullets
         /// <returns></returns>
         Vector3 GetDragAdjustedVelocity()
         {
-            atmosphereDensity = (float)FlightGlobals.getAtmDensity(FlightGlobals.getStaticPressure(currentPosition), FlightGlobals.getExternalTemperature(currentPosition)); //moving this here so it's not getting called 2x a tick in LeapFrogVelocityHalfStep
-
+            UpdateDragEstimate();
             if (timeElapsedSinceCurrentSpeedWasAdjusted > 0)
             {
                 return currentVelocity * dragVelocityFactor;
@@ -1680,7 +1678,7 @@ namespace BDArmory.Bullets
             if (underwater)
                 atmDensity = 1030f; // Sea water (3% salt) has a density of 1030kg/m^3 at 4°C at sea level. https://en.wikipedia.org/wiki/Density#Various_materials
             else
-                atmDensity = atmosphereDensity;
+                atmDensity = (float)FlightGlobals.getAtmDensity(FlightGlobals.getStaticPressure(currentPosition), FlightGlobals.getExternalTemperature(currentPosition)); //moving this here so it's not getting called 2x a tick in LeapFrogVelocityHalfStep
 
             dragVelocityFactor = 2f * ballisticCoefficient / (timeElapsed * initialSpeed * atmDensity + 2f * ballisticCoefficient);
 

--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -507,7 +507,6 @@ namespace BDArmory.Bullets
         /// <param name="period">Period to consider, typically Time.fixedDeltaTime</param>
         public void MoveBullet(float period)
         {
-            atmosphereDensity = (float)FlightGlobals.getAtmDensity(FlightGlobals.getStaticPressure(currentPosition), FlightGlobals.getExternalTemperature(currentPosition)); //moving this here so it's not getting called 2x a tick in LeapFrogVelocityHalfStep
             // Initial half-timestep velocity change (leapfrog integrator)
             LeapfrogVelocityHalfStep(0.5f * period);
 
@@ -561,6 +560,8 @@ namespace BDArmory.Bullets
         /// <returns></returns>
         Vector3 GetDragAdjustedVelocity()
         {
+            atmosphereDensity = (float)FlightGlobals.getAtmDensity(FlightGlobals.getStaticPressure(currentPosition), FlightGlobals.getExternalTemperature(currentPosition)); //moving this here so it's not getting called 2x a tick in LeapFrogVelocityHalfStep
+
             if (timeElapsedSinceCurrentSpeedWasAdjusted > 0)
             {
                 return currentVelocity * dragVelocityFactor;
@@ -1275,8 +1276,7 @@ namespace BDArmory.Bullets
                             // If we don't, I.E. the round isn't completely eroded, we decrease
                             // the velocity by a max of 5%, proportional to the adjustedPenRatio
                             //impactVelocity = impactVelocity * (0.95f + 0.05f * adjustedPenRatio);
-                            adjustedPenRatio *= 0.05f;
-                            adjustedPenRatio += 0.95f;
+                            adjustedPenRatio = 0.95f + 0.05f * adjustedPenRatio;
                             //impactVelocity = impactVelocity * adjustedPenRatio;
                             //currentVelocity = hitPartVelocity + impactVelocity;
                         }

--- a/BDArmory/Ammo/PooledRocket.cs
+++ b/BDArmory/Ammo/PooledRocket.cs
@@ -614,7 +614,7 @@ namespace BDArmory.Bullets
                 if (FlightGlobals.getAltitudeAtPos(currentPosition) > 0 && startUnderwater)
                 {
                     startUnderwater = false;
-                    FXMonger.Splash(currentPosition, caliber);
+                    if (BDArmorySettings.WATER_HIT_FX) FXMonger.Splash(currentPosition, caliber);
                 }
                 if (FlightGlobals.getAltitudeAtPos(currentPosition) <= 0 && !startUnderwater)
                 {
@@ -622,7 +622,7 @@ namespace BDArmory.Bullets
                     {
                         Detonate(currentPosition, false);
                     }
-                    FXMonger.Splash(currentPosition, caliber);
+                    if (BDArmorySettings.WATER_HIT_FX) FXMonger.Splash(currentPosition, caliber);
                 }
             }
 

--- a/BDArmory/Competition/BDACompetitionMode.cs
+++ b/BDArmory/Competition/BDACompetitionMode.cs
@@ -1140,7 +1140,7 @@ namespace BDArmory.Competition
                         Debug.Log($"[BDArmory.BDACompetitionMode]: Kerbal has left the seat of {vessel.vesselName} and it has no other controls, disabling the AI.");
                         AI.DeactivatePilot();
                     }
-                }
+                }//no srfAI/VTOLAI/OAI crew check? FIXME later
             }
         }
 

--- a/BDArmory/Competition/OrchestrationStrategies/WaypointFollowingStrategy.cs
+++ b/BDArmory/Competition/OrchestrationStrategies/WaypointFollowingStrategy.cs
@@ -122,7 +122,7 @@ namespace BDArmory.Competition.OrchestrationStrategies
                 {
                     displayName += " (" + BDArmorySettings.HOS_BADGE + ")";
                 }
-                BDACompetitionMode.Instance.competitionStatus.Add($"  - {displayName}: Time: {elapsedTime:F1}s, Waypoints reached: {waypointCount}, Deviation: {deviation}");
+                BDACompetitionMode.Instance.competitionStatus.Add($"  - {displayName}: Time: {elapsedTime:F2}s, Waypoints reached: {waypointCount}, Deviation: {deviation}");
 
                 Debug.Log(string.Format("[BDArmory.WaypointFollowingStrategy]: Finished {0}, elapsed={1:0.00}, count={2}, deviation={3:0.00}", player, elapsedTime, waypointCount, deviation));
             }

--- a/BDArmory/Control/BDGenericAIBase.cs
+++ b/BDArmory/Control/BDGenericAIBase.cs
@@ -106,10 +106,21 @@ namespace BDArmory.Control
             debugString.Length = 0;
             if (!weaponManager || !vessel || !vessel.transform || vessel.packed || !vessel.mainBody)
                 return;
-            // nobody is controlling any more possibly due to G forces?
-            if (!vessel.isCommandable)
+            //vessel lost command parts from damage?
+            if (!vessel.isCommandable) //isCommandable is only false when there is *no* command parts on the vessel (cockpits/probecores/etc)
             {
+                DeactivatePilot();
+                debugString.AppendLine($"Vessel: No Command parts!");
                 if (vessel.Autopilot.Enabled) Debug.Log("[BDArmory.BDGenericAIBase]: " + vessel.vesselName + " is not commandable, disabling autopilot.");
+                s.NeutralizeStick();
+                vessel.Autopilot.Disable();
+                return;
+            }
+            // nobody is controlling any more possibly due to G forces?
+            if (!vessel.IsControllable) //false when probes out of EC/cockpits don't have pilots
+            {
+                debugString.AppendLine($"Vessel: No Control!");
+                if (vessel.Autopilot.Enabled) Debug.Log("[BDArmory.BDGenericAIBase]: " + vessel.vesselName + " is not controllable, disabling autopilot.");
                 s.NeutralizeStick();
                 vessel.Autopilot.Disable();
                 return;
@@ -290,7 +301,7 @@ namespace BDArmory.Control
             if (!pilotEnabled || !vessel.isActiveVessel) return;
             if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI)
             {
-                GUI.Label(new Rect(200, Screen.height - 350, 600, 350), $"{vessel.name}\n{debugString.ToString()}");
+                GUI.Label(new Rect(200, Screen.height - 700, 600, 700), $"{vessel.name}\n{debugString.ToString()}");
             }
         }
 

--- a/BDArmory/Control/BDGenericAIBase.cs
+++ b/BDArmory/Control/BDGenericAIBase.cs
@@ -621,13 +621,14 @@ namespace BDArmory.Control
         }
 
         Coroutine maintainingFuelLevelsCoroutine;
+        Coroutine maintainingWaypointFuelLevelsCoroutine;
         /// <summary>
         /// Prevent fuel resource drain until the next waypoint.
         /// </summary>
         public void MaintainFuelLevelsUntilWaypoint()
         {
-            if (maintainingFuelLevelsCoroutine != null) StopCoroutine(maintainingFuelLevelsCoroutine);
-            maintainingFuelLevelsCoroutine = StartCoroutine(MaintainFuelLevelsUntilWaypointCoroutine());
+            if (maintainingWaypointFuelLevelsCoroutine != null) StopCoroutine(maintainingWaypointFuelLevelsCoroutine);
+            maintainingWaypointFuelLevelsCoroutine = StartCoroutine(MaintainFuelLevelsUntilWaypointCoroutine());
         }
         /// <summary>
         /// Prevent fuel resource drain until the next waypoint (coroutine).

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -2333,12 +2333,11 @@ namespace BDArmory.Control
                         float magnifier = Mathf.Clamp(targetAngVel, 1f, 2f);
                         magnifier += ((magnifier - 1f) * Mathf.Sin(Time.time * 0.75f));
                         if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI) debugString.AppendLine($"targetAngVel: {targetAngVel:F4}, magnifier: {magnifier:F2}");
-                        target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position;
                         target -= magnifier * leadOffset; // The effect of this is to exagerate the lead if the angular velocity is > 1
                         //need to subtract the angle of the gun if offset/angled from the target est. position
-                        //leadOffset = (weapon.fireTransforms[0].transform.position + (weapon.fireTransforms[0].forward * distanceToTarget)) - (vesselTransform.position + (vesselTransform.up * distanceToTarget));
-                        //target -= leadOffset; //correctly account for offset guns/schrage Musik                        
-                        angleToTarget = Vector3.Angle(vesselTransform.up, target - vesselTransform.position);
+                        //target -= leadOffset; //correctly account for offset guns/schrage Musik
+                        target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position;
+                        angleToTarget = Vector3.Angle(weapon.fireTransforms[0].transform.position, target - vesselTransform.position);
                         if (distanceToTarget < weaponManager.gunRange && angleToTarget < 20) // FIXME This ought to be changed to a dynamic angle like the firing angle.
                         {
                             steerMode = SteerModes.Aiming; //steer to aim

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -2333,11 +2333,11 @@ namespace BDArmory.Control
                         float magnifier = Mathf.Clamp(targetAngVel, 1f, 2f);
                         magnifier += ((magnifier - 1f) * Mathf.Sin(Time.time * 0.75f));
                         if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI) debugString.AppendLine($"targetAngVel: {targetAngVel:F4}, magnifier: {magnifier:F2}");
+                        target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position;
                         target -= magnifier * leadOffset; // The effect of this is to exagerate the lead if the angular velocity is > 1
                         //need to subtract the angle of the gun if offset/angled from the target est. position
                         //leadOffset = (weapon.fireTransforms[0].transform.position + (weapon.fireTransforms[0].forward * distanceToTarget)) - (vesselTransform.position + (vesselTransform.up * distanceToTarget));
-                        //target -= leadOffset; //correctly account for offset guns/schrage Musik
-                        target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position;
+                        //target -= leadOffset; //correctly account for offset guns/schrage Musik                        
                         angleToTarget = Vector3.Angle(vesselTransform.up, target - vesselTransform.position);
                         if (distanceToTarget < weaponManager.gunRange && angleToTarget < 20) // FIXME This ought to be changed to a dynamic angle like the firing angle.
                         {

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -2264,9 +2264,9 @@ namespace BDArmory.Control
                         {
                             target = MissileGuidance.GetAirToAirFireSolution(missile, v);
                         }
-                        //Vector3 leadOffset = (missile.MissileReferenceTransform.position + (missile.MissileReferenceTransform.forward * distanceToTarget)) - (vesselTransform.position + (vesselTransform.up * distanceToTarget));
-                        //target -= leadOffset; //correctly account for missiles mounted at an angle (important if heater to keep them pointed at heatsource and/or keep target within boresight)
-                        target = Quaternion.FromToRotation(missile.MissileReferenceTransform.forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position;
+                        Vector3 leadOffset = (missile.MissileReferenceTransform.position + (missile.MissileReferenceTransform.forward * distanceToTarget)) - (vesselTransform.position + (vesselTransform.up * distanceToTarget));
+                        target -= leadOffset; //correctly account for missiles mounted at an angle (important if heater to keep them pointed at heatsource and/or keep target within boresight)
+                        //target = Quaternion.FromToRotation(missile.MissileReferenceTransform.forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position;
                         angleToTarget = Vector3.Angle(vesselTransform.up, target - vesselTransform.position);
                         if (angleToTarget < 20f)
                         {
@@ -2335,9 +2335,9 @@ namespace BDArmory.Control
                         if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI) debugString.AppendLine($"targetAngVel: {targetAngVel:F4}, magnifier: {magnifier:F2}");
                         target -= magnifier * leadOffset; // The effect of this is to exagerate the lead if the angular velocity is > 1
                         //need to subtract the angle of the gun if offset/angled from the target est. position
-                        //leadOffset = (weapon.fireTransforms[0].transform.position + (weapon.fireTransforms[0].forward * distanceToTarget)) - (vesselTransform.position + (vesselTransform.up * distanceToTarget));
-                        //target -= leadOffset; //correctly account for offset guns/schrage Musik
-                        target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position;
+                        leadOffset = (weapon.fireTransforms[0].transform.position + (weapon.fireTransforms[0].forward * distanceToTarget)) - (vesselTransform.position + (vesselTransform.up * distanceToTarget));
+                        target -= leadOffset; //correctly account for offset guns/schrage Musik
+                        //target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position;
                         angleToTarget = Vector3.Angle(vesselTransform.up, target - vesselTransform.position);
                         if (distanceToTarget < weaponManager.gunRange && angleToTarget < 20) // FIXME This ought to be changed to a dynamic angle like the firing angle.
                         {
@@ -2381,8 +2381,8 @@ namespace BDArmory.Control
                         //else if (distanceToTarget > weaponManager.gunRange * 1.5f || Vector3.Dot(target - vesselTransform.position, vesselTransform.up) < 0) // Target is airborne a long way away or behind us.
                         else if (Vector3.Dot(target - vesselTransform.position, weapon.fireTransforms[0].forward) < 0) //If a gun is selected, craft is probably already within gunrange, or a couple of seconds of being in gunrange
                         {
-                            //target = v.CoM; // Don't bother with the off-by-one physics frame correction as this doesn't need to be so accurate here.
-                            target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (v.CoM - vesselTransform.position) + vesselTransform.position;
+                            target = v.CoM; // Don't bother with the off-by-one physics frame correction as this doesn't need to be so accurate here.
+                            //target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (v.CoM - vesselTransform.position) + vesselTransform.position;
                         }
                     }
                 }

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -2264,8 +2264,9 @@ namespace BDArmory.Control
                         {
                             target = MissileGuidance.GetAirToAirFireSolution(missile, v);
                         }
-                        Vector3 leadOffset = (missile.MissileReferenceTransform.position + (missile.MissileReferenceTransform.forward * distanceToTarget)) - (vesselTransform.position + (vesselTransform.up * distanceToTarget));
-                        target -= leadOffset; //correctly account for missiles mounted at an angle (important if heater to keep them pointed at heatsource and/or keep target within boresight)
+                        //Vector3 leadOffset = (missile.MissileReferenceTransform.position + (missile.MissileReferenceTransform.forward * distanceToTarget)) - (vesselTransform.position + (vesselTransform.up * distanceToTarget));
+                        //target -= leadOffset; //correctly account for missiles mounted at an angle (important if heater to keep them pointed at heatsource and/or keep target within boresight)
+                        target = Quaternion.FromToRotation(missile.MissileReferenceTransform.forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position;
                         angleToTarget = Vector3.Angle(vesselTransform.up, target - vesselTransform.position);
                         if (angleToTarget < 20f)
                         {
@@ -2334,9 +2335,9 @@ namespace BDArmory.Control
                         if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI) debugString.AppendLine($"targetAngVel: {targetAngVel:F4}, magnifier: {magnifier:F2}");
                         target -= magnifier * leadOffset; // The effect of this is to exagerate the lead if the angular velocity is > 1
                         //need to subtract the angle of the gun if offset/angled from the target est. position
-                        //leadOffset = (vesselTransform.position + (vesselTransform.up * distanceToTarget)) - (weapon.fireTransforms[0].transform.position + (weapon.fireTransforms[0].forward * distanceToTarget));
-                        leadOffset = (weapon.fireTransforms[0].transform.position + (weapon.fireTransforms[0].forward * distanceToTarget)) - (vesselTransform.position + (vesselTransform.up * distanceToTarget));
-                        target -= leadOffset; //correctly account for offset guns/schrage Musik
+                        //leadOffset = (weapon.fireTransforms[0].transform.position + (weapon.fireTransforms[0].forward * distanceToTarget)) - (vesselTransform.position + (vesselTransform.up * distanceToTarget));
+                        //target -= leadOffset; //correctly account for offset guns/schrage Musik
+                        target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position;
                         angleToTarget = Vector3.Angle(vesselTransform.up, target - vesselTransform.position);
                         if (distanceToTarget < weaponManager.gunRange && angleToTarget < 20) // FIXME This ought to be changed to a dynamic angle like the firing angle.
                         {
@@ -2380,7 +2381,8 @@ namespace BDArmory.Control
                         //else if (distanceToTarget > weaponManager.gunRange * 1.5f || Vector3.Dot(target - vesselTransform.position, vesselTransform.up) < 0) // Target is airborne a long way away or behind us.
                         else if (Vector3.Dot(target - vesselTransform.position, weapon.fireTransforms[0].forward) < 0) //If a gun is selected, craft is probably already within gunrange, or a couple of seconds of being in gunrange
                         {
-                            target = v.CoM; // Don't bother with the off-by-one physics frame correction as this doesn't need to be so accurate here.
+                            //target = v.CoM; // Don't bother with the off-by-one physics frame correction as this doesn't need to be so accurate here.
+                            target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (v.CoM - vesselTransform.position) + vesselTransform.position;
                         }
                     }
                 }

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -2264,9 +2264,9 @@ namespace BDArmory.Control
                         {
                             target = MissileGuidance.GetAirToAirFireSolution(missile, v);
                         }
-                        Vector3 leadOffset = (missile.MissileReferenceTransform.position + (missile.MissileReferenceTransform.forward * distanceToTarget)) - (vesselTransform.position + (vesselTransform.up * distanceToTarget));
-                        target -= leadOffset; //correctly account for missiles mounted at an angle (important if heater to keep them pointed at heatsource and/or keep target within boresight)
-                        //target = Quaternion.FromToRotation(missile.MissileReferenceTransform.forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position;
+                        //Vector3 leadOffset = (missile.MissileReferenceTransform.position + (missile.MissileReferenceTransform.forward * distanceToTarget)) - (vesselTransform.position + (vesselTransform.up * distanceToTarget));
+                        //target -= leadOffset; //correctly account for missiles mounted at an angle (important if heater to keep them pointed at heatsource and/or keep target within boresight)
+                        target = Quaternion.FromToRotation(missile.MissileReferenceTransform.forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position;
                         angleToTarget = Vector3.Angle(vesselTransform.up, target - vesselTransform.position);
                         if (angleToTarget < 20f)
                         {
@@ -2335,9 +2335,9 @@ namespace BDArmory.Control
                         if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI) debugString.AppendLine($"targetAngVel: {targetAngVel:F4}, magnifier: {magnifier:F2}");
                         target -= magnifier * leadOffset; // The effect of this is to exagerate the lead if the angular velocity is > 1
                         //need to subtract the angle of the gun if offset/angled from the target est. position
-                        leadOffset = (weapon.fireTransforms[0].transform.position + (weapon.fireTransforms[0].forward * distanceToTarget)) - (vesselTransform.position + (vesselTransform.up * distanceToTarget));
-                        target -= leadOffset; //correctly account for offset guns/schrage Musik
-                        //target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position;
+                        //leadOffset = (weapon.fireTransforms[0].transform.position + (weapon.fireTransforms[0].forward * distanceToTarget)) - (vesselTransform.position + (vesselTransform.up * distanceToTarget));
+                        //target -= leadOffset; //correctly account for offset guns/schrage Musik
+                        target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position;
                         angleToTarget = Vector3.Angle(vesselTransform.up, target - vesselTransform.position);
                         if (distanceToTarget < weaponManager.gunRange && angleToTarget < 20) // FIXME This ought to be changed to a dynamic angle like the firing angle.
                         {
@@ -2381,8 +2381,8 @@ namespace BDArmory.Control
                         //else if (distanceToTarget > weaponManager.gunRange * 1.5f || Vector3.Dot(target - vesselTransform.position, vesselTransform.up) < 0) // Target is airborne a long way away or behind us.
                         else if (Vector3.Dot(target - vesselTransform.position, weapon.fireTransforms[0].forward) < 0) //If a gun is selected, craft is probably already within gunrange, or a couple of seconds of being in gunrange
                         {
-                            target = v.CoM; // Don't bother with the off-by-one physics frame correction as this doesn't need to be so accurate here.
-                            //target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (v.CoM - vesselTransform.position) + vesselTransform.position;
+                            //target = v.CoM; // Don't bother with the off-by-one physics frame correction as this doesn't need to be so accurate here.
+                            target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (v.CoM - vesselTransform.position) + vesselTransform.position;
                         }
                     }
                 }

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -2250,7 +2250,7 @@ namespace BDArmory.Control
                 {
                     if (missile.GetWeaponClass() == WeaponClasses.Missile)
                     {
-                        if (distanceToTarget > 5500f)
+                        if (distanceToTarget > 5500f) //why 5.5km?
                         {
                             finalMaxSteer = GetSteerLimiterForSpeedAndPower();
                         }
@@ -2331,6 +2331,10 @@ namespace BDArmory.Control
                         magnifier += ((magnifier - 1f) * Mathf.Sin(Time.time * 0.75f));
                         if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI) debugString.AppendLine($"targetAngVel: {targetAngVel:F4}, magnifier: {magnifier:F2}");
                         target -= magnifier * leadOffset; // The effect of this is to exagerate the lead if the angular velocity is > 1
+                        //need to subtract the angle of the gun if offset/angled from the target est. position
+                        //leadOffset = (vesselTransform.position + (vesselTransform.up * distanceToTarget)) - (weapon.fireTransforms[0].transform.position + (weapon.fireTransforms[0].forward * distanceToTarget));
+                        leadOffset = (weapon.fireTransforms[0].transform.position + (weapon.fireTransforms[0].forward * distanceToTarget)) - (vesselTransform.position + (vesselTransform.up * distanceToTarget));
+                        target -= leadOffset; //correctly account for offset guns/schrage Musik
                         angleToTarget = Vector3.Angle(vesselTransform.up, target - vesselTransform.position);
                         if (distanceToTarget < weaponManager.gunRange && angleToTarget < 20) // FIXME This ought to be changed to a dynamic angle like the firing angle.
                         {
@@ -2372,7 +2376,7 @@ namespace BDArmory.Control
                             }
                         }
                         //else if (distanceToTarget > weaponManager.gunRange * 1.5f || Vector3.Dot(target - vesselTransform.position, vesselTransform.up) < 0) // Target is airborne a long way away or behind us.
-                        else if (Vector3.Dot(target - vesselTransform.position, vesselTransform.up) < 0) //If a gun is selected, craft is probably already within gunrange, or a couple of seconds of being in gunrange
+                        else if (Vector3.Dot(target - vesselTransform.position, weapon.fireTransforms[0].forward) < 0) //If a gun is selected, craft is probably already within gunrange, or a couple of seconds of being in gunrange
                         {
                             target = v.CoM; // Don't bother with the off-by-one physics frame correction as this doesn't need to be so accurate here.
                         }

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -1584,7 +1584,9 @@ namespace BDArmory.Control
             }
 
             SetAutoTuneFields();
-            CheatOptions.InfinitePropellant = autoTune || BDArmorySettings.INFINITE_FUEL; // Prevent fuel drain while auto-tuning.
+            MaintainFuelLevels(autoTune); // Prevent fuel drain while auto-tuning.
+            //doesn't work for FS helicopter engines, reverting to older method for inf. fuel.
+            //CheatOptions.InfinitePropellant = autoTune || BDArmorySettings.INFINITE_FUEL; // Prevent fuel drain while auto-tuning.
             OtherUtils.SetTimeOverride(autoTune);
         }
         void SetAutoTuneFields()
@@ -2518,7 +2520,7 @@ namespace BDArmory.Control
             {
                 isPSM = false;
             }
-            Vector3 targetDirection = (targetPosition - vesselTransform.position).normalized;
+            Vector3 targetDirection = (targetPosition - vesselTransform.position).normalized;                        
             if (AutoTune && (Vector3.Dot(targetDirection, vesselTransform.up) > 0.9397f)) // <20°
             {
                 steerMode = SteerModes.Aiming; // Pretend to aim when on target.

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -2337,7 +2337,7 @@ namespace BDArmory.Control
                         //need to subtract the angle of the gun if offset/angled from the target est. position
                         //target -= leadOffset; //correctly account for offset guns/schrage Musik
                         target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position;
-                        angleToTarget = Vector3.Angle(weapon.fireTransforms[0].transform.position, target - vesselTransform.position);
+                        angleToTarget = Vector3.Angle(weapon.fireTransforms[0].forward, target - vesselTransform.position);
                         if (distanceToTarget < weaponManager.gunRange && angleToTarget < 20) // FIXME This ought to be changed to a dynamic angle like the firing angle.
                         {
                             steerMode = SteerModes.Aiming; //steer to aim

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -2329,14 +2329,8 @@ namespace BDArmory.Control
                     {
                         Vector3 leadOffset = weapon.GetLeadOffset();
 
-                        float targetAngVel = Vector3.Angle(v.transform.position - vessel.transform.position, v.transform.position + (vessel.Velocity()) - vessel.transform.position);
-                        float magnifier = Mathf.Clamp(targetAngVel, 1f, 2f);
-                        magnifier += ((magnifier - 1f) * Mathf.Sin(Time.time * 0.75f));
-                        if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI) debugString.AppendLine($"targetAngVel: {targetAngVel:F4}, magnifier: {magnifier:F2}");
-                        target -= magnifier * leadOffset; // The effect of this is to exagerate the lead if the angular velocity is > 1
-                        //need to subtract the angle of the gun if offset/angled from the target est. position
-                        //target -= leadOffset; //correctly account for offset guns/schrage Musik
-                        target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position;
+                        target -= leadOffset;
+                        target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position; //correctly account for offset guns/schrage Musik
                         angleToTarget = Vector3.Angle(weapon.fireTransforms[0].forward, target - vesselTransform.position);
                         if (distanceToTarget < weaponManager.gunRange && angleToTarget < 20) // FIXME This ought to be changed to a dynamic angle like the firing angle.
                         {

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -2264,7 +2264,9 @@ namespace BDArmory.Control
                         {
                             target = MissileGuidance.GetAirToAirFireSolution(missile, v);
                         }
-
+                        Vector3 leadOffset = (missile.MissileReferenceTransform.position + (missile.MissileReferenceTransform.forward * distanceToTarget)) - (vesselTransform.position + (vesselTransform.up * distanceToTarget));
+                        target -= leadOffset; //correctly account for missiles mounted at an angle (important if heater to keep them pointed at heatsource and/or keep target within boresight)
+                        angleToTarget = Vector3.Angle(vesselTransform.up, target - vesselTransform.position);
                         if (angleToTarget < 20f)
                         {
                             steerMode = SteerModes.Aiming;

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -2327,10 +2327,18 @@ namespace BDArmory.Control
                     ModuleWeapon weapon = weaponManager.currentGun;
                     if (weapon != null)
                     {
-                        Vector3 leadOffset = weapon.GetLeadOffset();
-
-                        target -= leadOffset;
                         target = Quaternion.FromToRotation(weapon.fireTransforms[0].forward, vesselTransform.up) * (target - vesselTransform.position) + vesselTransform.position; //correctly account for offset guns/schrage Musik
+                        Vector3 weaponOffset = Vector3.zero;
+                        if (part.symmetryCounterparts.Count == 0)
+                            weaponOffset = (vessel.ReferenceTransform.position - weapon.fireTransforms[0].position);
+                        else
+                        {
+                            weaponOffset = (vessel.ReferenceTransform.position - weapon.part.parent.partBuoyancy.transform.position); //symmetry twins would be equally offset from parent part's center, so just use that for the average
+                        }
+                        debugString.AppendLine($"WeaponOffset ({v.vesselName}): {weaponOffset.x}x m; {weaponOffset.y}y m; {weaponOffset.z}z m");
+                        target += weaponOffset; //account for weapons with translational offset from longitudinal axis
+                        Vector3 leadOffset = weapon.GetLeadOffset();
+                        target -= leadOffset;
                         angleToTarget = Vector3.Angle(weapon.fireTransforms[0].forward, target - vesselTransform.position);
                         if (distanceToTarget < weaponManager.gunRange && angleToTarget < 20) // FIXME This ought to be changed to a dynamic angle like the firing angle.
                         {

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -7197,10 +7197,12 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
                 //radar missiles
                 if (!results.foundTorpedo)
                 {
+                    //if (results.foundMissile) //make sure underAttack still gets called if incoming missile is GPS/INS
+                        StartCoroutine(UnderAttackRoutine());
                     if (results.foundRadarMissile) //have this require an RWR?
                     {
                         //if (!rwr && incomingMissileDistance <= guardRange * 0.33f) //within ID range?
-                        StartCoroutine(UnderAttackRoutine());
+                        //StartCoroutine(UnderAttackRoutine());
 
                         FireChaff();
                         FireECM(10);
@@ -7208,7 +7210,7 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
                     //laser missiles
                     if (results.foundAGM) //Assume Laser Warning Receiver regardless of omniDetection? Or move laser missiles to the passive missiles section?
                     {
-                        StartCoroutine(UnderAttackRoutine());
+                        //StartCoroutine(UnderAttackRoutine());
 
                         FireSmoke();
                         if (targetMissiles && guardTarget == null)
@@ -7241,7 +7243,7 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
 
                             if (results.incomingMissiles[0].guidanceType == MissileBase.TargetingModes.Gps)
                                 FireECM(cmThreshold);
-                            StartCoroutine(UnderAttackRoutine());
+                            //StartCoroutine(UnderAttackRoutine());
                         }
                         else //one passive missile is going to be indistinguishable from another, until it gets close enough to evaluate
                         {
@@ -7298,7 +7300,7 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
                                     FireOCM(true);
                                 }
                             }
-                            StartCoroutine(UnderAttackRoutine());
+                            //StartCoroutine(UnderAttackRoutine());
                         }
                     }
                 }

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -1600,7 +1600,7 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
             if (!BDArmorySettings.DEBUG_LINES && lr != null) { lr.enabled = false; }
             if (HighLogic.LoadedSceneIsFlight && vessel == FlightGlobals.ActiveVessel &&
                 BDArmorySetup.GAME_UI_ENABLED && !MapView.MapIsEnabled)
-            {
+            {                
                 if (BDArmorySettings.DEBUG_LINES)
                 {
                     if (incomingMissileVessel)
@@ -1613,7 +1613,7 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
                         ((vessel.LandedOrSplashed && (guardTarget.transform.position - transform.position).sqrMagnitude > 2250000f) ?
                         transform.position + (SurfaceVisionOffset.Evaluate((guardTarget.CoM - transform.position).magnitude) * VectorUtils.GetUpDirection(transform.position)) : transform.position), 3, Color.yellow);
                 }
-
+                
                 if (showBombAimer)
                 {
                     MissileBase ml = CurrentMissile;
@@ -6343,8 +6343,11 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
                                 }
                             }
                             // check DLZ                            
-                            MissileLauncher mlauncher = ml as MissileLauncher;
-                            float fireFOV = mlauncher.missileTurret ? mlauncher.missileTurret.turret.yawRange : mlauncher.multiLauncher && mlauncher.multiLauncher.turret ? mlauncher.multiLauncher.turret.turret.yawRange : -1;
+							float fireFOV = -1;
+							MissileLauncher mlauncher = ml as MissileLauncher;
+							if (mlauncher != null) //else MMGs throw an Error here
+                            fireFOV = mlauncher.missileTurret ? mlauncher.missileTurret.turret.yawRange : mlauncher.multiLauncher && mlauncher.multiLauncher.turret ? mlauncher.multiLauncher.turret.turret.yawRange : -1;
+
                             MissileLaunchParams dlz = MissileLaunchParams.GetDynamicLaunchParams(ml, targetVessel.Velocity(), targetVessel.transform.position, fireFOV,
                                 (ml.TargetingMode == MissileBase.TargetingModes.Laser && BDATargetManager.ActiveLasers.Count <= 0 || ml.TargetingMode == MissileBase.TargetingModes.Radar && !_radarsEnabled && !ml.radarLOAL));
                             if (vessel.srfSpeed > ml.minLaunchSpeed && distanceToTarget < dlz.maxLaunchRange && distanceToTarget > dlz.minLaunchRange)

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -4831,6 +4831,8 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
 
                                     if (targetWeapon != null && (candidateYTraverse > 0 || candidatePTraverse > 0)) //prioritize turreted lasers
                                     {
+                                        ModuleTurret turret = Laser.turret;
+                                        if (!TargetInTurretRange(turret, 15, default, Laser)) continue; // weight selection towards turrets that can fire on missile
                                         targetWeapon = item.Current;
                                         break;
                                     }
@@ -4860,7 +4862,8 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
                                     }
                                     if (candidateYTraverse > 0 || candidatePTraverse > 0)
                                     {
-                                        candidateRPM *= 2.0f; // weight selection towards turrets
+                                        ModuleTurret turret = Gun.turret;
+                                        candidateRPM *= TargetInTurretRange(turret, 5, default, Gun) ? 2.0f : 0.01f; // weight selection towards turrets that can fire on missile
                                     }
                                     if (candidatePFuzed || candidateVTFuzed)
                                     {
@@ -4904,7 +4907,8 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
 
                                     if (candidateYTraverse > 0 || candidatePTraverse > 0)
                                     {
-                                        candidateRPM *= 2.0f; // weight selection towards turrets
+                                        ModuleTurret turret = Rocket.turret;
+                                        candidateRPM *= TargetInTurretRange(turret, 5, default, Rocket) ? 2.0f : 0.01f; // weight selection towards turrets that can fire on missile
                                     }
                                     if (targetRocketAccel < candidateRocketAccel)
                                     {
@@ -5108,7 +5112,8 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
 
                                     if (candidateYTraverse > 0 || candidatePTraverse > 0)
                                     {
-                                        candidateRPM *= 2.0f; // weight selection towards turrets
+                                        ModuleTurret turret = Rocket.turret;
+                                        candidateRPM *= TargetInTurretRange(turret, 15, default, Rocket) ? 2.0f : 0.01f; // weight selection towards turrets that can face in the right direction
                                     }
 
                                     if (targetRocketAccel < candidateRocketAccel)
@@ -5192,7 +5197,8 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
                                     {//weight selection towards larger caliber bullets, modified by turrets/fuzes/range settings when shooting bombers
                                         if (candidateGimbal = true && candidateTraverse > 0)
                                         {
-                                            candidateCaliber *= 1.5f; // weight selection towards turrets
+                                            ModuleTurret turret = Gun.turret;
+                                            candidateCaliber *= TargetInTurretRange(turret, 15, default, Gun) ? 1.5f : 0.01f; // weight selection towards turrets that can face the right direction
                                         }
                                         if (candidatePFuzed || candidateVTFuzed)
                                         {
@@ -5212,7 +5218,8 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
                                     {
                                         if (candidateGimbal = true && candidateTraverse > 0)
                                         {
-                                            candidateRPM *= 1.5f; // weight selection towards turrets
+                                            ModuleTurret turret = Gun.turret;
+                                            candidateRPM *= TargetInTurretRange(turret, 15, default, Gun) ? 1.5f : 0.01f; // weight selection towards turrets that can face the right direction
                                         }
                                         if (candidatePFuzed || candidateVTFuzed)
                                         {
@@ -5285,7 +5292,8 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
 
                                     if (candidateGimbal = true && candidateTraverse > 0)
                                     {
-                                        candidateRPM *= 1.5f; // weight selection towards turreted lasers
+                                        ModuleTurret turret = Laser.turret;
+                                        candidateRPM *= TargetInTurretRange(turret, 15, default, Laser) ? 1.5f : 0.01f; // weight selection towards turrets that can point in the right direction
                                     }
                                     if (candidateMinrange > distance || distance > candidateMaxRange)
                                     {
@@ -5467,7 +5475,8 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
 
                                     if (candidateGimbal = true && candidateTraverse > 0)
                                     {
-                                        candidateRPM *= 1.5f; // weight selection towards turreted lasers
+                                        ModuleTurret turret = Laser.turret;
+                                        candidateRPM *= TargetInTurretRange(turret, 0, default, Laser) ? 1.5f : 0.01f; // weight selection towards turrets that can point in the right direction
                                     }
                                     if (HEpulses)
                                     {
@@ -5534,7 +5543,8 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
                                     }
                                     if (candidateGimbal && candidateTraverse > 0)
                                     {
-                                        candidateRPM *= 1.5f; // weight selection towards turrets
+                                        ModuleTurret turret = Gun.turret;
+                                        candidateRPM *= TargetInTurretRange(turret, 0, default, Gun) ? 1.5f : 0.01f; // weight selection towards turrets that can point in the right direction
                                     }
                                     if (candidateMinrange > distance || distance > candidateMaxRange)
                                     {
@@ -6111,7 +6121,8 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
 
                                         if (candidateGimbal = true && candidateTraverse > 0)
                                         {
-                                            candidateRPM *= 1.5f; // weight selection towards turreted lasers
+                                            ModuleTurret turret = Laser.turret;
+                                            candidateRPM *= TargetInTurretRange(turret, 15, default, Laser) ? 1.5f : 0.01f; // weight selection towards turrets that can point in the right direction
                                         }
                                         if (candidateMinrange > distance || distance > candidateMaxrange / 10)
                                         {
@@ -6248,11 +6259,11 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
                             if (distanceToTarget < gun.minSafeDistance) return false;
 
                             // check yaw range of turret
-                            ModuleTurret turret = gun.turret;
-                            float gimbalTolerance = vessel.LandedOrSplashed ? 0 : 15;
-                            if (turret != null)
-                                if (!TargetInTurretRange(turret, gimbalTolerance, default, gun))
-                                    return false;
+                            //ModuleTurret turret = gun.turret;
+                            //float gimbalTolerance = vessel.LandedOrSplashed ? 0 : 15;
+                            //if (turret != null)
+                                //if (!TargetInTurretRange(turret, gimbalTolerance, default, gun))
+                                    //return false;
 
                             // check overheat, reloading, ability to fire soon
                             if (!gun.hasGunner)

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -13,15 +13,30 @@ IMPROVEMENTS / FIXES
 	- Waypoint Gates can now set AI speed limits on a per-gate basis to permit setting up braking zones before a turn/Rally courses with target speeds/etc.
 	- 'Activate Guard After Gate n' setting now ends the course when FFA is complete, not when last alive craft completes the course.
 	- List of things that cannot be set to Wood hull material expanded to other functional parts (servos/radiators/ISRU converters/RTGs) that couldn't logically be made out of wood.
+	- Vengeance Mutator blast radius and delay can now be set in the BDA settings menu.
+	- Fixes AutoTune infinite fuel not applying to Firespitter helicopter engines.
+	- BDA settings no longer blanket reset on KSP restart.
+- UI:
+	- Vessel Switcher GUi and competition Marquee now display Waypoint times to hundredths of a second.
+- AI:
+	- Fix Kerbal G-Loss of Consciousness implementation; AI now go deadstick when pilot is knocked out.
+	- Can now toggle AI radar shut-off behavior when targeted by HARMs either on a per-radar basis, or globally for all radars on a ship via the Weapon Manager.
+	- AI now understands how to aim weapons not aligned with prograde for Schrage Muzik-style weapon arrangements.
 - Competition:
 	- Save/load tournament score weights to/from the settings.cfg.
+	- Waypoint Mode max laps can now be set to a user-specified value (WAYPOINT_MAX_LAPS, default 5) in the BDA settings menu.
 - Weapons:
 	- Fix lasers being able to fire as long as > 0 EC is present.
 	- Add bulletLuminance field for setting non-tracer brightness.
 	- Fix weapons in salvo mode with symmetry twins firing when only enough ammo for one weapon to fire.
 	- Fix heatRays not adding heat to hit parts.
+	- Fix kinetic damage having damage reduction from armor being applied when hitting unarmored parts.
 	- Missiles:
 		- Can now set cluster missile trigger distance when mounting cluster missiles on reloadable rails.
+		- Nuke LightFX radius now set by effective blast range, not thermalRadius value.
+		- Fix NRE when AI tries to fire Modular Missiles.
+- RWP:
+	- Add S6R5 dynamic recoil gamemode; recoil scales with vessel thrust.
 - ModIntegration:
 	- Fix the type to unbox MidChordSweep to.
 

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -36,6 +36,7 @@ IMPROVEMENTS / FIXES
 		- Can now set cluster missile trigger distance when mounting cluster missiles on reloadable rails.
 		- Nuke LightFX radius now set by effective blast range, not thermalRadius value.
 		- Fix NRE when AI tries to fire Modular Missiles.
+		- Fix heatseeking Missiles with very narrow sensorFOVs losing lock right before impact with a target.
 - RWP:
 	- Add S6R5 dynamic recoil gamemode; recoil scales with vessel thrust.
 - ModIntegration:

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -17,11 +17,12 @@ IMPROVEMENTS / FIXES
 	- Fixes AutoTune infinite fuel not applying to Firespitter helicopter engines.
 	- BDA settings no longer blanket reset on KSP restart.
 - UI:
-	- Vessel Switcher GUi and competition Marquee now display Waypoint times to hundredths of a second.
+	- Vessel Switcher GUI and competition Marquee now display Waypoint times to hundredths of a second.
 - AI:
-	- Fix Kerbal G-Loss of Consciousness implementation; AI now go deadstick when pilot is knocked out.
-	- Can now toggle AI radar shut-off behavior when targeted by HARMs either on a per-radar basis, or globally for all radars on a ship via the Weapon Manager.
-	- AI now understands how to aim weapons not aligned with prograde for Schrage Muzik-style weapon arrangements.
+	- Fix Kerbal G-Loss of Consciousness implementation; AI now goes deadstick when pilot is knocked out.
+	- Can now toggle AI radar shut-off behavior when targeted by HARMs either on a per-radar basis, or globally for all radars on a craft via the Weapon Manager.
+	- AI now understands how to aim weapons not aligned with prograde for Schrage Musik-style weapon arrangements.
+	- AI now takes evasive maneuvers when under attack from incoming INS/GPS missiles.
 - Competition:
 	- Save/load tournament score weights to/from the settings.cfg.
 	- Waypoint Mode max laps can now be set to a user-specified value (WAYPOINT_MAX_LAPS, default 5) in the BDA settings menu.

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -1099,6 +1099,7 @@ Localization
         #LOC_BDArmory_Fire = Fire
         #LOC_BDArmory_ToggleRadar = Toggle Radar
         #LOC_BDArmory_ToggleIRST = Toggle IRST
+        #LOC_BDArmory_DynamicRadar = Disable Radar vs ARMs
 
         #LOC_BDArmory_GuardMode = Guard Mode:\u0020
         #LOC_BDArmory_Team = Team
@@ -1193,7 +1194,7 @@ Localization
         #LOC_BDArmory_Icon_opacity = Opacity:
         #LOC_BDArmory_Icon_distance_threshold = Distance Threshold:
         #LOC_BDArmory_Icon_max_distance_threshold = Max Distance Threshold:
-        #LOC_BDArmory_Icon_telemetry = Enable Telemetry;
+        #LOC_BDArmory_Icon_telemetry = Enable Telemetry
         #LOC_BDArmory_Icon_colorget = Apply
 
         //Armor stuff

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -124,6 +124,7 @@ Localization
         #LOC_BDArmory_Settings_InfiniteMissiles = Infinite Ordinance
         #LOC_BDArmory_Settings_BulletFX = Bullet FX
         #LOC_BDArmory_Settings_BulletHits = Bullet Hits
+        #LOC_BDArmory_Settings_WaterHitFX = Water Hit FX
         #LOC_BDArmory_Settings_EjectShells = Eject Shells
         #LOC_BDArmory_Settings_VesselRelativeBulletChecks = Vessel-Relative Bullet Checks
         #LOC_BDArmory_Settings_AimAssist = Aim Assist

--- a/BDArmory/FX/NukeFX.cs
+++ b/BDArmory/FX/NukeFX.cs
@@ -324,7 +324,11 @@ namespace BDArmory.FX
             {
                 if (hasDetonated)
                 {
-                    if (LightFx != null) LightFx.intensity -= 12 * scale * Time.deltaTime;
+                    if (LightFx != null)
+                    {
+                        LightFx.intensity -= 12 * scale * Time.deltaTime;
+                        LightFx.range -= 12 * scale * Time.deltaTime;
+                    }
                     if (TimeIndex > 0.3f && pEmitters != null) // 0.3s seems to be enough to always show the explosion, but 0.2s isn't for some reason.
                     {
                         if (TimeIndex > 0.3f && pEmitters != null) // 0.3s seems to be enough to always show the explosion, but 0.2s isn't for some reason.
@@ -339,6 +343,14 @@ namespace BDArmory.FX
                     foreach (var fx in fxEmitters) if (fx.gameObject.activeSelf) fx.Position = Position; // Update FX emitter positions.
                 }
             }
+			else
+			{
+				hasDetonated = false;
+                LightFx.intensity = 0;
+                LightFx.range = 0;
+                gameObject.SetActive(false);
+                return;
+			}			
         }
 
         public void FixedUpdate()
@@ -416,8 +428,11 @@ namespace BDArmory.FX
                 }
             }
 
-            if (hasDetonated && explosionEvents.Count == 0 && TimeIndex > MaxTime)
+            if (hasDetonated && explosionEvents.Count == 0 || TimeIndex > MaxTime)
             {
+                hasDetonated = false;
+                LightFx.intensity = 0;
+                LightFx.range = 0;
                 gameObject.SetActive(false);
                 return;
             }
@@ -621,6 +636,7 @@ namespace BDArmory.FX
                 eFx.audioSource.volume = 5;
                 eFx.LightFx = templateFX.AddComponent<Light>();
                 eFx.LightFx.color = GUIUtils.ParseColor255("255,238,184,255");
+                eFx.LightFx.range = radius / 3;
                 eFx.LightFx.intensity = radius / 3;
                 eFx.LightFx.shadows = LightShadows.None;
                 templateFX.SetActive(false);

--- a/BDArmory/FX/NukeFX.cs
+++ b/BDArmory/FX/NukeFX.cs
@@ -141,6 +141,14 @@ namespace BDArmory.FX
                     audioSource.PlayOneShot(audioClips[SoundPath]);
                 }
             }
+            else
+            {
+                hasDetonated = false;
+                LightFx.intensity = 0;
+                LightFx.range = 0;
+                gameObject.SetActive(false);
+                return;
+            }
         }
 
         void OnDisable()
@@ -320,37 +328,26 @@ namespace BDArmory.FX
         {
             if (!gameObject.activeInHierarchy) return;
 
-            if (HighLogic.LoadedSceneIsFlight)
+            if (hasDetonated)
             {
-                if (hasDetonated)
+                if (LightFx != null)
                 {
-                    if (LightFx != null)
-                    {
-                        LightFx.intensity -= 12 * scale * Time.deltaTime;
-                        LightFx.range -= 12 * scale * Time.deltaTime;
-                    }
+                    LightFx.intensity -= 12 * scale * Time.deltaTime;
+                    LightFx.range -= 12 * scale * Time.deltaTime;
+                }
+                if (TimeIndex > 0.3f && pEmitters != null) // 0.3s seems to be enough to always show the explosion, but 0.2s isn't for some reason.
+                {
                     if (TimeIndex > 0.3f && pEmitters != null) // 0.3s seems to be enough to always show the explosion, but 0.2s isn't for some reason.
                     {
-                        if (TimeIndex > 0.3f && pEmitters != null) // 0.3s seems to be enough to always show the explosion, but 0.2s isn't for some reason.
+                        foreach (var pe in pEmitters)
                         {
-                            foreach (var pe in pEmitters)
-                            {
-                                if (pe == null) continue;
-                                pe.emit = false;
-                            }
+                            if (pe == null) continue;
+                            pe.emit = false;
                         }
                     }
-                    foreach (var fx in fxEmitters) if (fx.gameObject.activeSelf) fx.Position = Position; // Update FX emitter positions.
                 }
+                foreach (var fx in fxEmitters) if (fx.gameObject.activeSelf) fx.Position = Position; // Update FX emitter positions.
             }
-			else
-			{
-				hasDetonated = false;
-                LightFx.intensity = 0;
-                LightFx.range = 0;
-                gameObject.SetActive(false);
-                return;
-			}			
         }
 
         public void FixedUpdate()
@@ -428,7 +425,7 @@ namespace BDArmory.FX
                 }
             }
 
-            if (hasDetonated && explosionEvents.Count == 0 || TimeIndex > MaxTime)
+            if (hasDetonated && explosionEvents.Count == 0 && TimeIndex > MaxTime)
             {
                 hasDetonated = false;
                 LightFx.intensity = 0;

--- a/BDArmory/FX/NukeFX.cs
+++ b/BDArmory/FX/NukeFX.cs
@@ -364,7 +364,7 @@ namespace BDArmory.FX
                     CalculateBlastEvents();
 
                     LightFx = gameObject.GetComponent<Light>();
-                    LightFx.range = thermalRadius;
+                    LightFx.range = BDAMath.Sqrt(yield) * 1000;
                     LightFx.intensity = thermalRadius / 3f;
                     if (lastValidAtmDensity < 0.05)
                     {

--- a/BDArmory/GameModes/Asteroids.cs
+++ b/BDArmory/GameModes/Asteroids.cs
@@ -757,6 +757,7 @@ namespace BDArmory.GameModes
                 {
                     if (asteroids[i] == null || asteroids[i].packed || !asteroids[i].loaded || asteroids[i].rootPart.Rigidbody == null) continue;
                     var nudge = new Vector3d(RNG.NextDouble() - 0.5, RNG.NextDouble() - 0.5, RNG.NextDouble() - 0.5) * 100;
+                    Vector3d anomalousAttractionHOS = Vector3d.zero;
                     if (BDArmorySettings.ASTEROID_FIELD_ANOMALOUS_ATTRACTION)
                     {
                         anomalousAttraction = Vector3d.zero;
@@ -771,7 +772,6 @@ namespace BDArmory.GameModes
                     }
                     if (BDArmorySettings.ENABLE_HOS && BDArmorySettings.HALL_OF_SHAME_LIST.Count > 0 && BDArmorySettings.HOS_ASTEROID)
                     {
-                        anomalousAttraction = Vector3d.zero;
                         foreach (var weaponManager in LoadedVesselSwitcher.Instance.WeaponManagers.SelectMany(tm => tm.Value))
                         {
                             if (weaponManager == null) continue;
@@ -779,11 +779,11 @@ namespace BDArmory.GameModes
                             {
                                 offset = weaponManager.vessel.transform.position - asteroids[i].transform.position;
                                 factor = (Vector3.Dot(asteroids[i].Velocity(), weaponManager.vessel.Velocity()) < 0 ? (float)(asteroids[i].srf_velocity - weaponManager.vessel.srf_velocity).magnitude : 1);
-                                if (offset.sqrMagnitude < 6250000) anomalousAttraction += factor * attractionFactors[asteroids[i].vesselName] * offset.normalized;
+                                if (offset.sqrMagnitude < 6250000) anomalousAttractionHOS += factor * attractionFactors[asteroids[i].vesselName] * offset.normalized;
                             }
                         }
                     }
-                    asteroids[i].rootPart.Rigidbody.AddForce((-FlightGlobals.getGeeForceAtPosition(asteroids[i].transform.position) - asteroids[i].srf_velocity / 10f + nudge + anomalousAttraction) * TimeWarp.CurrentRate, ForceMode.Acceleration); // Float and reduce motion.
+                    asteroids[i].rootPart.Rigidbody.AddForce((-FlightGlobals.getGeeForceAtPosition(asteroids[i].transform.position) - asteroids[i].srf_velocity / 10f + nudge + anomalousAttraction + anomalousAttractionHOS) * TimeWarp.CurrentRate, ForceMode.Acceleration); // Float and reduce motion.
                 }
                 if (Time.time - repulseTimer > 1) // Once per second repulse nearby asteroids from each other to avoid them sticking. Not too often since it's O(N^2). This might be more performant using an OverlapSphere.
                 {

--- a/BDArmory/GameModes/Asteroids.cs
+++ b/BDArmory/GameModes/Asteroids.cs
@@ -769,6 +769,20 @@ namespace BDArmory.GameModes
                         }
                         anomalousAttraction *= BDArmorySettings.ASTEROID_FIELD_ANOMALOUS_ATTRACTION_STRENGTH;
                     }
+                    if (BDArmorySettings.ENABLE_HOS && BDArmorySettings.HALL_OF_SHAME_LIST.Count > 0 && BDArmorySettings.HOS_ASTEROID)
+                    {
+                        anomalousAttraction = Vector3d.zero;
+                        foreach (var weaponManager in LoadedVesselSwitcher.Instance.WeaponManagers.SelectMany(tm => tm.Value))
+                        {
+                            if (weaponManager == null) continue;
+                            if (BDArmorySettings.HALL_OF_SHAME_LIST.Contains(weaponManager.vessel.GetName()))
+                            {
+                                offset = weaponManager.vessel.transform.position - asteroids[i].transform.position;
+                                factor = (Vector3.Dot(asteroids[i].Velocity(), weaponManager.vessel.Velocity()) < 0 ? (float)(asteroids[i].srf_velocity - weaponManager.vessel.srf_velocity).magnitude : 1);
+                                if (offset.sqrMagnitude < 6250000) anomalousAttraction += factor * attractionFactors[asteroids[i].vesselName] * offset.normalized;
+                            }
+                        }
+                    }
                     asteroids[i].rootPart.Rigidbody.AddForce((-FlightGlobals.getGeeForceAtPosition(asteroids[i].transform.position) - asteroids[i].srf_velocity / 10f + nudge + anomalousAttraction) * TimeWarp.CurrentRate, ForceMode.Acceleration); // Float and reduce motion.
                 }
                 if (Time.time - repulseTimer > 1) // Once per second repulse nearby asteroids from each other to avoid them sticking. Not too often since it's O(N^2). This might be more performant using an OverlapSphere.

--- a/BDArmory/GameModes/Mutators/BDAMutator.cs
+++ b/BDArmory/GameModes/Mutators/BDAMutator.cs
@@ -453,7 +453,7 @@ namespace BDArmory.GameModes
             if (!Vengeance) return;
             if (!BDACompetitionMode.Instance.competitionIsActive) return;
             if (BDArmorySettings.DEBUG_OTHER) Debug.Log("[BDArmory.BDAMutator]: triggering vengeance nuke");
-            NukeFX.CreateExplosion(part.transform.position, ExplosionSourceType.Other, this.vessel.GetName(), "Vengeance Explosion", 2.5f, 300, 1.5f, 1.5f, true,
+            NukeFX.CreateExplosion(part.transform.position, ExplosionSourceType.Other, this.vessel.GetName(), "Vengeance Explosion", BDArmorySettings.VENGEANCE_DELAY, 200 * BDArmorySettings.VENGEANCE_YIELD, BDArmorySettings.VENGEANCE_YIELD, BDArmorySettings.VENGEANCE_YIELD, false,
                 "BDArmory/Models/explosion/nuke/nukeBoom",
                 "BDArmory/Models/explosion/nuke/nukeFlash",
                 "BDArmory/Models/explosion/nuke/nukeShock",

--- a/BDArmory/GameModes/Mutators/BDAMutator.cs
+++ b/BDArmory/GameModes/Mutators/BDAMutator.cs
@@ -448,8 +448,10 @@ namespace BDArmory.GameModes
                 }
             }
         }
+        bool hasDetonated = false;
         void Detonate()
         {
+            if (hasDetonated) return;
             if (!Vengeance) return;
             if (!BDACompetitionMode.Instance.competitionIsActive) return;
             if (BDArmorySettings.DEBUG_OTHER) Debug.Log("[BDArmory.BDAMutator]: triggering vengeance nuke");
@@ -462,6 +464,7 @@ namespace BDArmory.GameModes
                 "BDArmory/Models/explosion/nuke/nukeScatter",
                 "BDArmory/Models/Mutators/Vengence",
                 nukePart: part);
+            hasDetonated = true;
         }
     }
 }

--- a/BDArmory/GameModes/Waypoints/WaypointCourses.cs
+++ b/BDArmory/GameModes/Waypoints/WaypointCourses.cs
@@ -221,14 +221,17 @@ namespace BDArmory.GameModes.Waypoints
                         {
                             string[] datavars;
                             datavars = waypoints[i].Split(new char[] { '|' });
-                            if (datavars.Length < 4)
-                                datavars[3] = "-1";
                             string WPname = (string)ParseValue(typeof(string), datavars[0]);
                             WPname = WPname.Trim(' ');
                             if (string.IsNullOrEmpty(WPname)) WPname = $"Waypoint {i}";
                             var location = (Vector3)ParseValue(typeof(Vector3), datavars[1]);
                             var scale = (float)ParseValue(typeof(float), datavars[2]);
-                            var speed = (float)ParseValue(typeof(float), datavars[3]);
+                            float speed;
+                            try
+                            {
+                                speed = (float)ParseValue(typeof(float), datavars[3]);
+                            }
+                            catch {speed = -1f; }
                             if (name != null && location != null)
                                 waypointList.Add(new Waypoint(WPname, location, scale, speed));
                         }

--- a/BDArmory/Guidances/MissileGuidance.cs
+++ b/BDArmory/Guidances/MissileGuidance.cs
@@ -136,11 +136,17 @@ namespace BDArmory.Guidances
             Vector3 targetAcceleration, Vessel missileVessel, out float timeToImpact, float minSpeed = 200)
         {
             float leadTime = 0;
-            float targetDistance = Vector3.Distance(targetPosition, missileVessel.CoM);
+            float RSqr = Vector3.SqrMagnitude(targetPosition - missileVessel.CoM);
 
             Vector3 currVel = Mathf.Max((float)missileVessel.srfSpeed, minSpeed) * missileVessel.Velocity().normalized;
 
-            leadTime = targetDistance / (targetVelocity - currVel).magnitude;
+            Vector3 Rdir = (targetPosition - missileVessel.CoM);
+            leadTime = -RSqr / Vector3.Dot(targetVelocity - currVel, Rdir);
+
+            if (leadTime <= 0f)
+                leadTime = float.PositiveInfinity;
+
+            //leadTime = targetDistance / (targetVelocity - currVel).magnitude;
             timeToImpact = leadTime;
             leadTime = Mathf.Clamp(leadTime, 0f, 8f);
 

--- a/BDArmory/Radar/ModuleRadar.cs
+++ b/BDArmory/Radar/ModuleRadar.cs
@@ -103,6 +103,10 @@ namespace BDArmory.Radar
         [KSPField]
         public int sonarType = 0; //0 = Radar; 1 == Active Sonar; 2 == Passive Sonar
 
+        [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_DynamicRadar", advancedTweakable = true),//Disable Radar vs ARMs
+            UI_Toggle(enabledText = "#LOC_BDArmory_true", disabledText = "#LOC_BDArmory_false", scene = UI_Scene.All),]//Starboard (CW)--Port (CCW)
+        public bool DynamicRadar = true;
+
         public enum SonarModes
         {
             None = 0,

--- a/BDArmory/Settings/BDAPersistentSettingsField.cs
+++ b/BDArmory/Settings/BDAPersistentSettingsField.cs
@@ -10,7 +10,6 @@ namespace BDArmory.Settings
     [AttributeUsage(AttributeTargets.Field)]
     public class BDAPersistentSettingsField : Attribute
     {
-        public bool RWPFilter = false;
         public BDAPersistentSettingsField()
         {
         }

--- a/BDArmory/Settings/BDAPersistentSettingsField.cs
+++ b/BDArmory/Settings/BDAPersistentSettingsField.cs
@@ -10,6 +10,7 @@ namespace BDArmory.Settings
     [AttributeUsage(AttributeTargets.Field)]
     public class BDAPersistentSettingsField : Attribute
     {
+        public bool RWPFilter = false;
         public BDAPersistentSettingsField()
         {
         }

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -42,11 +42,11 @@ namespace BDArmory.Settings
         //[BDAPersistentSettingsField] public static bool INSTAKILL = true; //Deprecated, only affects lasers; use an Instagib mutator isntead
         [BDAPersistentSettingsField] public static bool AI_TOOLBAR_BUTTON = true;                 // Show or hide the BDA AI toolbar button.
         [BDAPersistentSettingsField] public static bool VM_TOOLBAR_BUTTON = true;                 // Show or hide the BDA VM toolbar button.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool INFINITE_AMMO = false;              //infinite Bullets/rockets/laserpower
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool INFINITE_ORDINANCE = false;         //infinite missiles/bombs (on ordinance w/ Reload Module)
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool LIMITED_ORDINANCE = false;         //MML ammo clamped to salvo size, no relaods
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool INFINITE_FUEL = false;              //Infinite propellant
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool INFINITE_EC = false;                          //Infinite electric charge
+        [BDAPersistentSettingsField] public static bool INFINITE_AMMO = false;              //infinite Bullets/rockets/laserpower
+        [BDAPersistentSettingsField] public static bool INFINITE_ORDINANCE = false;         //infinite missiles/bombs (on ordinance w/ Reload Module)
+        [BDAPersistentSettingsField] public static bool LIMITED_ORDINANCE = false;         //MML ammo clamped to salvo size, no relaods
+        [BDAPersistentSettingsField] public static bool INFINITE_FUEL = false;              //Infinite propellant
+        [BDAPersistentSettingsField] public static bool INFINITE_EC = false;                          //Infinite electric charge
         [BDAPersistentSettingsField] public static bool BULLET_HITS = true;
         [BDAPersistentSettingsField] public static bool WATER_HIT_FX = true;
         [BDAPersistentSettingsField] public static bool EJECT_SHELLS = true;
@@ -54,7 +54,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static bool AIM_ASSIST = true;
         [BDAPersistentSettingsField] public static bool AIM_ASSIST_MODE = true;              // true = reticle follows bullet CPA position, false = reticle follows aiming position.
         [BDAPersistentSettingsField] public static bool DRAW_AIMERS = true;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool RESTORE_KAL = true;                  // Restore the Part, Module and AxisField references on the KAL to make it work.
+        [BDAPersistentSettingsField] public static bool RESTORE_KAL = true;                  // Restore the Part, Module and AxisField references on the KAL to make it work.
 
         [BDAPersistentSettingsField] public static bool REMOTE_SHOOTING = false;
         [BDAPersistentSettingsField] public static bool BOMB_CLEARANCE_CHECK = false;
@@ -63,17 +63,17 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static bool BULLET_DECALS = true;
         [BDAPersistentSettingsField] public static bool GAPLESS_PARTICLE_EMITTERS = true;         // Use gapless particle emitters.
         [BDAPersistentSettingsField] public static bool FLARE_SMOKE = true;                       // Flares leave a trail of smoke.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool DISABLE_RAMMING = false;                  // Prevent craft from going into ramming mode when out of ammo.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool DEFAULT_FFA_TARGETING = false;            // Free-for-all combat style instead of teams (changes target selection behaviour). This could be removed now.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool RUNWAY_PROJECT = false;                    // Enable/disable Runway Project specific enhancements.
+        [BDAPersistentSettingsField] public static bool DISABLE_RAMMING = false;                  // Prevent craft from going into ramming mode when out of ammo.
+        [BDAPersistentSettingsField] public static bool DEFAULT_FFA_TARGETING = false;            // Free-for-all combat style instead of teams (changes target selection behaviour). This could be removed now.
+        [BDAPersistentSettingsField] public static bool RUNWAY_PROJECT = false;                    // Enable/disable Runway Project specific enhancements.
         //[BDAPersistentSettingsField] public static bool DISABLE_KILL_TIMER = true;                //disables the kill timers.
         [BDAPersistentSettingsField] public static bool AUTO_ENABLE_VESSEL_SWITCHING = false;     // Automatically enables vessel switching on competition start.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool AUTONOMOUS_COMBAT_SEATS = false;          // Enable/disable seats without kerbals.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool DESTROY_UNCONTROLLED_WMS = true;         // Automatically destroy the WM if there's no kerbal or drone core controlling it.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool RESET_HP = false;                         // Automatically reset HP of parts of vessels when they're spawned in flight mode.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool RESET_ARMOUR = false;                     // Automatically reset Armor material of parts of vessels when they're spawned in flight mode.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool RESET_HULL = false;                     // Automatically reset hull material of parts of vessels when they're spawned in flight mode.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static int KERBAL_SAFETY = 1;                         // Try to save kerbals by ejecting/leaving seats and deploying parachutes.
+        [BDAPersistentSettingsField] public static bool AUTONOMOUS_COMBAT_SEATS = false;          // Enable/disable seats without kerbals.
+        [BDAPersistentSettingsField] public static bool DESTROY_UNCONTROLLED_WMS = true;         // Automatically destroy the WM if there's no kerbal or drone core controlling it.
+        [BDAPersistentSettingsField] public static bool RESET_HP = false;                         // Automatically reset HP of parts of vessels when they're spawned in flight mode.
+        [BDAPersistentSettingsField] public static bool RESET_ARMOUR = false;                     // Automatically reset Armor material of parts of vessels when they're spawned in flight mode.
+        [BDAPersistentSettingsField] public static bool RESET_HULL = false;                     // Automatically reset hull material of parts of vessels when they're spawned in flight mode.
+        [BDAPersistentSettingsField] public static int KERBAL_SAFETY = 1;                         // Try to save kerbals by ejecting/leaving seats and deploying parachutes.
         [BDAPersistentSettingsField] public static bool TRACE_VESSELS_DURING_COMPETITIONS = false; // Trace vessel positions and rotations during competitions.
         [BDAPersistentSettingsField] public static bool AUTO_LOG_TIME_SYNC = false;               // Log time synchronisation info automatically during competitions.
         [BDAPersistentSettingsField] public static float LOG_TIME_SYNC_INTERVAL = 0.2f;           // Interval for logging time synchronisation information (approx).
@@ -87,10 +87,10 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static bool DISPLAY_COMPETITION_STATUS = true;             //Display competition status
         [BDAPersistentSettingsField] public static bool DISPLAY_COMPETITION_STATUS_WITH_HIDDEN_UI = false; // Display the competition status when using the "hidden UI"
         [BDAPersistentSettingsField] public static bool SCROLL_ZOOM_PREVENTION = true;                 // Prevent scroll-zoom when over most BDA windows.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BULLET_WATER_DRAG = true;                       // do bullets/rockets get slowed down if fired into/under water
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool UNDERWATER_VISION = false;                       //If false, Subs and other submerged vessels fully visible to surface/air craft and vice versa without detectors?
+        [BDAPersistentSettingsField] public static bool BULLET_WATER_DRAG = true;                       // do bullets/rockets get slowed down if fired into/under water
+        [BDAPersistentSettingsField] public static bool UNDERWATER_VISION = false;                       //If false, Subs and other submerged vessels fully visible to surface/air craft and vice versa without detectors?
         [BDAPersistentSettingsField] public static bool PERSISTENT_FX = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool LEGACY_ARMOR = false;
+        [BDAPersistentSettingsField] public static bool LEGACY_ARMOR = false;
         [BDAPersistentSettingsField] public static bool HACK_INTAKES = false;
         [BDAPersistentSettingsField] public static bool COMPETITION_CLOSE_SETTINGS_ON_COMPETITION_START = false; // Close the settings window when clicking the start competition button.
         [BDAPersistentSettingsField] public static bool AUTO_LOAD_TO_KSC = false;                      // Automatically load the last used save and go to the KSC.
@@ -112,22 +112,22 @@ namespace BDArmory.Settings
         #endregion
 
         #region General slider settings
-        [BDAPersistentSettingsField(RWPFilter = true)] public static int COMPETITION_DURATION = 0;                       // Competition duration in minutes (0=unlimited)
+        [BDAPersistentSettingsField] public static int COMPETITION_DURATION = 0;                       // Competition duration in minutes (0=unlimited)
         [BDAPersistentSettingsField] public static float COMPETITION_INITIAL_GRACE_PERIOD = 10;        // Competition initial grace period in seconds.
         [BDAPersistentSettingsField] public static float COMPETITION_FINAL_GRACE_PERIOD = 10;          // Competition final grace period in seconds.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float COMPETITION_KILL_TIMER = 15;                  // Competition kill timer in seconds.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float COMPETITION_KILLER_GM_FREQUENCY = 60;         // Competition killer GM timer in seconds.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float COMPETITION_KILLER_GM_GRACE_PERIOD = 150;     // Competition killer GM grace period in seconds.
+        [BDAPersistentSettingsField] public static float COMPETITION_KILL_TIMER = 15;                  // Competition kill timer in seconds.
+        [BDAPersistentSettingsField] public static float COMPETITION_KILLER_GM_FREQUENCY = 60;         // Competition killer GM timer in seconds.
+        [BDAPersistentSettingsField] public static float COMPETITION_KILLER_GM_GRACE_PERIOD = 150;     // Competition killer GM grace period in seconds.
         [BDAPersistentSettingsField] public static float COMPETITION_ALTITUDE_LIMIT_HIGH = 55;         // Altitude (high) in km at which to kill off craft.
         [BDAPersistentSettingsField] public static float COMPETITION_ALTITUDE_LIMIT_LOW = -39;          // Altitude (low) in km at which to kill off craft.
         [BDAPersistentSettingsField] public static bool COMPETITION_ALTITUDE__LIMIT_ASL = false;       // Does Killer GM use ASL or AGL for latitide ceiling/floor?
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool COMPETITION_GM_KILL_WEAPON = false;             // Competition GM will kill weaponless craft?
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool COMPETITION_GM_KILL_ENGINE = false;             // Competition GM will kill engineless craft?
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool COMPETITION_GM_KILL_DISABLED = false;           // Competition GM will kill craft that are disabled (no weapons or ammo, no engine [Pilot/VTOL/Ship/Sub] or no wheels [Surface])
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float COMPETITION_GM_KILL_HP = 0;                    // Competition GM will kill craft with low HP craft?
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float COMPETITION_GM_KILL_TIME = 0;                  // CompetitionGM Kill time
+        [BDAPersistentSettingsField] public static bool COMPETITION_GM_KILL_WEAPON = false;             // Competition GM will kill weaponless craft?
+        [BDAPersistentSettingsField] public static bool COMPETITION_GM_KILL_ENGINE = false;             // Competition GM will kill engineless craft?
+        [BDAPersistentSettingsField] public static bool COMPETITION_GM_KILL_DISABLED = false;           // Competition GM will kill craft that are disabled (no weapons or ammo, no engine [Pilot/VTOL/Ship/Sub] or no wheels [Surface])
+        [BDAPersistentSettingsField] public static float COMPETITION_GM_KILL_HP = 0;                    // Competition GM will kill craft with low HP craft?
+        [BDAPersistentSettingsField] public static float COMPETITION_GM_KILL_TIME = 0;                  // CompetitionGM Kill time
         [BDAPersistentSettingsField] public static float COMPETITION_NONCOMPETITOR_REMOVAL_DELAY = 30; // Competition non-competitor removal delay in seconds.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float COMPETITION_WAYPOINTS_GM_KILL_PERIOD = 60;    // Waypoint Competition GM kill period in seconds. Craft that don't pass a waypoint within this time are killed off.
+        [BDAPersistentSettingsField] public static float COMPETITION_WAYPOINTS_GM_KILL_PERIOD = 60;    // Waypoint Competition GM kill period in seconds. Craft that don't pass a waypoint within this time are killed off.
         [BDAPersistentSettingsField] public static float COMPETITION_DISTANCE = 1000;                  // Competition distance.
         [BDAPersistentSettingsField] public static float COMPETITION_INTRA_TEAM_SEPARATION_BASE = 800; // Intra-team separation (base value).
         [BDAPersistentSettingsField] public static float COMPETITION_INTRA_TEAM_SEPARATION_PER_MEMBER = 100; // Intra-team separation (per member value).
@@ -139,7 +139,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static int CAMERA_SWITCH_FREQUENCY = 10;                    // Controls the minimum time between automated camera switches
         [BDAPersistentSettingsField] public static int DEATH_CAMERA_SWITCH_INHIBIT_PERIOD = 2;         // Controls the delay before the next switch after the currently active vessel dies
         [BDAPersistentSettingsField] public static bool CAMERA_SWITCH_INCLUDE_MISSILES = false;        // Include missiles in the camera switching logic.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static int KERBAL_SAFETY_INVENTORY = 2;                    // Controls how Kerbal Safety adjusts the inventory of kerbals.
+        [BDAPersistentSettingsField] public static int KERBAL_SAFETY_INVENTORY = 2;                    // Controls how Kerbal Safety adjusts the inventory of kerbals.
         [BDAPersistentSettingsField] public static float TRIGGER_HOLD_TIME = 0.2f;
         [BDAPersistentSettingsField] public static float BDARMORY_UI_VOLUME = 0.35f;
         [BDAPersistentSettingsField] public static float BDARMORY_WEAPONS_VOLUME = 0.45f;
@@ -154,10 +154,10 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_SPREAD = 5f;
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_BIAS = 0.4f;
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_HIT_MULTIPLIER = 2f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float HP_THRESHOLD = 2000;                    //HP above this value will be scaled to a logarithmic value
+        [BDAPersistentSettingsField] public static float HP_THRESHOLD = 2000;                    //HP above this value will be scaled to a logarithmic value
         [BDAPersistentSettingsField] public static float HP_CLAMP = 0;                           //HP will be clamped to this value
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool PWING_EDGE_LIFT = true;                  //Toggle lift on PWing edges for balance with stock wings/remove edge abuse
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool PWING_THICKNESS_AFFECT_MASS_HP = false;  //pWing thickness contributes to its mass calc instead of a static LiftArea derived value
+        [BDAPersistentSettingsField] public static bool PWING_EDGE_LIFT = true;                  //Toggle lift on PWing edges for balance with stock wings/remove edge abuse
+        [BDAPersistentSettingsField] public static bool PWING_THICKNESS_AFFECT_MASS_HP = false;  //pWing thickness contributes to its mass calc instead of a static LiftArea derived value
         [BDAPersistentSettingsField] public static float MAX_PWING_LIFT = 4.54f;                //Clamp pWing lift to this amount
         [BDAPersistentSettingsField] public static float MAX_SAS_TORQUE = 30;                   //Clamp vessel total non-cockpit torque to this
         [BDAPersistentSettingsField] public static bool NUMERIC_INPUT_SELF_UPDATE = true;             // Automatically update the display string in NumericInputField after attempting to parse the value.
@@ -166,23 +166,23 @@ namespace BDArmory.Settings
         #endregion
 
         #region Physics constants
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float GLOBAL_LIFT_MULTIPLIER = 0.25f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float GLOBAL_DRAG_MULTIPLIER = 6f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float RECOIL_FACTOR = 0.75f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float DMG_MULTIPLIER = 100f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float BALLISTIC_DMG_FACTOR = 1.55f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float HITPOINT_MULTIPLIER = 3.0f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float EXP_DMG_MOD_BALLISTIC_NEW = 0.55f;     // HE bullet explosion damage multiplier
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float EXP_PEN_RESIST_MULT = 2.50f;           // Armor HE penetration resistance multiplier
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float EXP_DMG_MOD_MISSILE = 6.75f;           // Missile explosion damage multiplier
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float EXP_DMG_MOD_ROCKET = 1f;               // Rocket explosion damage multiplier (FIXME needs tuning; Note: rockets used Ballistic mod before, but probably ought to be more like missiles)
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float EXP_DMG_MOD_BATTLE_DAMAGE = 1f;        // Battle damage explosion damage multiplier (FIXME needs tuning; Note: CASE-0 explosions used Missile mod, while CASE-1, CASE-2 and fuel explosions used Ballistic mod)
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float EXP_IMP_MOD = 0.25f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float BUILDING_DMG_MULTIPLIER = 1f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool EXTRA_DAMAGE_SLIDERS = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float WEAPON_FX_DURATION = 15;               //how long do weapon secondary effects(EMP/choker/gravitic/etc) last
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float ZOMBIE_DMG_MULT = 0.1f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float ARMOR_MASS_MOD = 1f;                   //Armor mass multiplier
+        [BDAPersistentSettingsField] public static float GLOBAL_LIFT_MULTIPLIER = 0.25f;
+        [BDAPersistentSettingsField] public static float GLOBAL_DRAG_MULTIPLIER = 6f;
+        [BDAPersistentSettingsField] public static float RECOIL_FACTOR = 0.75f;
+        [BDAPersistentSettingsField] public static float DMG_MULTIPLIER = 100f;
+        [BDAPersistentSettingsField] public static float BALLISTIC_DMG_FACTOR = 1.55f;
+        [BDAPersistentSettingsField] public static float HITPOINT_MULTIPLIER = 3.0f;
+        [BDAPersistentSettingsField] public static float EXP_DMG_MOD_BALLISTIC_NEW = 0.55f;     // HE bullet explosion damage multiplier
+        [BDAPersistentSettingsField] public static float EXP_PEN_RESIST_MULT = 2.50f;           // Armor HE penetration resistance multiplier
+        [BDAPersistentSettingsField] public static float EXP_DMG_MOD_MISSILE = 6.75f;           // Missile explosion damage multiplier
+        [BDAPersistentSettingsField] public static float EXP_DMG_MOD_ROCKET = 1f;               // Rocket explosion damage multiplier (FIXME needs tuning; Note: rockets used Ballistic mod before, but probably ought to be more like missiles)
+        [BDAPersistentSettingsField] public static float EXP_DMG_MOD_BATTLE_DAMAGE = 1f;        // Battle damage explosion damage multiplier (FIXME needs tuning; Note: CASE-0 explosions used Missile mod, while CASE-1, CASE-2 and fuel explosions used Ballistic mod)
+        [BDAPersistentSettingsField] public static float EXP_IMP_MOD = 0.25f;
+        [BDAPersistentSettingsField] public static float BUILDING_DMG_MULTIPLIER = 1f;
+        [BDAPersistentSettingsField] public static bool EXTRA_DAMAGE_SLIDERS = false;
+        [BDAPersistentSettingsField] public static float WEAPON_FX_DURATION = 15;               //how long do weapon secondary effects(EMP/choker/gravitic/etc) last
+        [BDAPersistentSettingsField] public static float ZOMBIE_DMG_MULT = 0.1f;
+        [BDAPersistentSettingsField] public static float ARMOR_MASS_MOD = 1f;                   //Armor mass multiplier
         #endregion
 
         #region FX
@@ -208,76 +208,79 @@ namespace BDArmory.Settings
         #endregion
 
         #region Game modes
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool PEACE_MODE = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool TAG_MODE = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool PAINTBALL_MODE = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool GRAVITY_HACKS = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ALTITUDE_HACKS = false; //transfer to a RunWayRound number?
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BATTLEDAMAGE = true;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool HEART_BLEED_ENABLED = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool RESOURCE_STEAL_ENABLED = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ASTEROID_FIELD = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static int ASTEROID_FIELD_NUMBER = 100; // Number of asteroids
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float ASTEROID_FIELD_ALTITUDE = 2f; // Km.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float ASTEROID_FIELD_RADIUS = 5f; // Km.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ASTEROID_FIELD_ANOMALOUS_ATTRACTION = false; // Asteroids are attracted to vessels.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float ASTEROID_FIELD_ANOMALOUS_ATTRACTION_STRENGTH = 0.2f; // Strength of the effect.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ASTEROID_RAIN = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static int ASTEROID_RAIN_NUMBER = 100; // Number of asteroids
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float ASTEROID_RAIN_DENSITY = 0.5f; // Arbitrary density scale.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float ASTEROID_RAIN_ALTITUDE = 2f; // Km.k
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float ASTEROID_RAIN_RADIUS = 3f; // Km.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ASTEROID_RAIN_FOLLOWS_CENTROID = true;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ASTEROID_RAIN_FOLLOWS_SPREAD = true;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool MUTATOR_MODE = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ZOMBIE_MODE = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool DISCO_MODE = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool NO_ENGINES = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool WAYPOINTS_MODE = false;         // Waypoint section of Vessel Spawner Window.
+        [BDAPersistentSettingsField] public static bool PEACE_MODE = false;
+        [BDAPersistentSettingsField] public static bool TAG_MODE = false;
+        [BDAPersistentSettingsField] public static bool PAINTBALL_MODE = false;
+        [BDAPersistentSettingsField] public static bool GRAVITY_HACKS = false;
+        [BDAPersistentSettingsField] public static bool ALTITUDE_HACKS = false; //transfer to a RunWayRound number?
+        [BDAPersistentSettingsField] public static bool BATTLEDAMAGE = true;
+        [BDAPersistentSettingsField] public static bool HEART_BLEED_ENABLED = false;
+        [BDAPersistentSettingsField] public static bool RESOURCE_STEAL_ENABLED = false;
+        [BDAPersistentSettingsField] public static bool ASTEROID_FIELD = false;
+        [BDAPersistentSettingsField] public static int ASTEROID_FIELD_NUMBER = 100; // Number of asteroids
+        [BDAPersistentSettingsField] public static float ASTEROID_FIELD_ALTITUDE = 2f; // Km.
+        [BDAPersistentSettingsField] public static float ASTEROID_FIELD_RADIUS = 5f; // Km.
+        [BDAPersistentSettingsField] public static bool ASTEROID_FIELD_ANOMALOUS_ATTRACTION = false; // Asteroids are attracted to vessels.
+        [BDAPersistentSettingsField] public static float ASTEROID_FIELD_ANOMALOUS_ATTRACTION_STRENGTH = 0.2f; // Strength of the effect.
+        [BDAPersistentSettingsField] public static bool ASTEROID_RAIN = false;
+        [BDAPersistentSettingsField] public static int ASTEROID_RAIN_NUMBER = 100; // Number of asteroids
+        [BDAPersistentSettingsField] public static float ASTEROID_RAIN_DENSITY = 0.5f; // Arbitrary density scale.
+        [BDAPersistentSettingsField] public static float ASTEROID_RAIN_ALTITUDE = 2f; // Km.k
+        [BDAPersistentSettingsField] public static float ASTEROID_RAIN_RADIUS = 3f; // Km.
+        [BDAPersistentSettingsField] public static bool ASTEROID_RAIN_FOLLOWS_CENTROID = true;
+        [BDAPersistentSettingsField] public static bool ASTEROID_RAIN_FOLLOWS_SPREAD = true;
+        [BDAPersistentSettingsField] public static bool MUTATOR_MODE = false;
+        [BDAPersistentSettingsField] public static bool ZOMBIE_MODE = false;
+        [BDAPersistentSettingsField] public static bool DISCO_MODE = false;
+        [BDAPersistentSettingsField] public static bool NO_ENGINES = false;
+        [BDAPersistentSettingsField] public static bool WAYPOINTS_MODE = false;         // Waypoint section of Vessel Spawner Window.
         [BDAPersistentSettingsField] public static string PINATA_NAME = "Pinata";
         #endregion
 
         #region Battle Damage settings
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BATTLEDAMAGE_TOGGLE = false;    // Main battle damage toggle.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_DAMAGE_CHANCE = 5;          // Base chance per-hit to proc damage
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_SUBSYSTEMS = true;           // Non-critical module damage?
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_TANKS = true;                // Fuel tanks, batteries can leak/burn
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_TANK_LEAK_TIME = 20;        // Leak duration
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_TANK_LEAK_RATE = 1;         // Leak rate modifier
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_AMMOBINS = true;             // Can ammo bins explode?
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_VOLATILE_AMMO = false;       // Ammo bins guaranteed to explode when destroyed
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_PROPULSION = true;           // Engine thrust reduction, fires
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_PROP_FLOOR = 20;            // Minimum thrust% damaged engines produce
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_PROP_FLAMEOUT = 25;         // Remaining HP% engines flameout
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_PART_STRENGTH = false;        // Part strength - breakingForce/Torque - decreases as part takes damage
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_PROP_DAM_RATE = 1;          // Rate multiplier, 0.1-2
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_INTAKES = true;              // Can intakes be damaged?
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_GIMBALS = true;              // Can gimbals be disabled?
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_AEROPARTS = true;            // Lift loss & added drag
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_LIFT_LOSS_RATE = 1;         // Rate multiplier
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_CTRL_SRF = true;             // Disable ctrl srf actuatiors?
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_COCKPITS = false;            // Control degredation
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_PILOT_KILLS = false;         // Cockpit damage can kill pilots?
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_FIRES_ENABLED = true;        // Can fires occur
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_FIRE_DOT = true;             // Do fires do DoT
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_FIRE_DAMAGE = 5;            // Do fires do DoT
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_FIRE_HEATDMG = true;         // Do fires add heat to parts/are fires able to cook off fuel/ammo?
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_INTENSE_FIRES = false;       // Do fuel tank fires DoT get bigger over time?
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_FIRE_FUELEX = true;          // Can fires detonate fuel tanks
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_FIRE_CHANCE_TRACER = 10;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_FIRE_CHANCE_HE = 25;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_FIRE_CHANCE_INCENDIARY = 90;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ALLOW_ZOMBIE_BD = false;          // Allow battle damage to proc when using zombie mode?
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ENABLE_HOS = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static List<string> HALL_OF_SHAME_LIST = new List<string>();
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float HOS_FIRE = 0;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float HOS_MASS = 0;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float HOS_DMG = 0;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float HOS_THRUST = 0;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool HOS_SAS = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool HOS_ASTEROID = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static string HOS_MUTATOR = "";
-        [BDAPersistentSettingsField(RWPFilter = true)] public static string HOS_BADGE = "";
+        [BDAPersistentSettingsField] public static bool BATTLEDAMAGE_TOGGLE = false;    // Main battle damage toggle.
+        [BDAPersistentSettingsField] public static float BD_DAMAGE_CHANCE = 5;          // Base chance per-hit to proc damage
+        [BDAPersistentSettingsField] public static bool BD_SUBSYSTEMS = true;           // Non-critical module damage?
+        [BDAPersistentSettingsField] public static bool BD_TANKS = true;                // Fuel tanks, batteries can leak/burn
+        [BDAPersistentSettingsField] public static float BD_TANK_LEAK_TIME = 20;        // Leak duration
+        [BDAPersistentSettingsField] public static float BD_TANK_LEAK_RATE = 1;         // Leak rate modifier
+        [BDAPersistentSettingsField] public static bool BD_AMMOBINS = true;             // Can ammo bins explode?
+        [BDAPersistentSettingsField] public static bool BD_VOLATILE_AMMO = false;       // Ammo bins guaranteed to explode when destroyed
+        [BDAPersistentSettingsField] public static bool BD_PROPULSION = true;           // Engine thrust reduction, fires
+        [BDAPersistentSettingsField] public static float BD_PROP_FLOOR = 20;            // Minimum thrust% damaged engines produce
+        [BDAPersistentSettingsField] public static float BD_PROP_FLAMEOUT = 25;         // Remaining HP% engines flameout
+        [BDAPersistentSettingsField] public static bool BD_PART_STRENGTH = false;        // Part strength - breakingForce/Torque - decreases as part takes damage
+        [BDAPersistentSettingsField] public static float BD_PROP_DAM_RATE = 1;          // Rate multiplier, 0.1-2
+        [BDAPersistentSettingsField] public static bool BD_INTAKES = true;              // Can intakes be damaged?
+        [BDAPersistentSettingsField] public static bool BD_GIMBALS = true;              // Can gimbals be disabled?
+        [BDAPersistentSettingsField] public static bool BD_AEROPARTS = true;            // Lift loss & added drag
+        [BDAPersistentSettingsField] public static float BD_LIFT_LOSS_RATE = 1;         // Rate multiplier
+        [BDAPersistentSettingsField] public static bool BD_CTRL_SRF = true;             // Disable ctrl srf actuatiors?
+        [BDAPersistentSettingsField] public static bool BD_COCKPITS = false;            // Control degredation
+        [BDAPersistentSettingsField] public static bool BD_PILOT_KILLS = false;         // Cockpit damage can kill pilots?
+        [BDAPersistentSettingsField] public static bool BD_FIRES_ENABLED = true;        // Can fires occur
+        [BDAPersistentSettingsField] public static bool BD_FIRE_DOT = true;             // Do fires do DoT
+        [BDAPersistentSettingsField] public static float BD_FIRE_DAMAGE = 5;            // Do fires do DoT
+        [BDAPersistentSettingsField] public static bool BD_FIRE_HEATDMG = true;         // Do fires add heat to parts/are fires able to cook off fuel/ammo?
+        [BDAPersistentSettingsField] public static bool BD_INTENSE_FIRES = false;       // Do fuel tank fires DoT get bigger over time?
+        [BDAPersistentSettingsField] public static bool BD_FIRE_FUELEX = true;          // Can fires detonate fuel tanks
+        [BDAPersistentSettingsField] public static float BD_FIRE_CHANCE_TRACER = 10;
+        [BDAPersistentSettingsField] public static float BD_FIRE_CHANCE_HE = 25;
+        [BDAPersistentSettingsField] public static float BD_FIRE_CHANCE_INCENDIARY = 90;
+        #endregion
+
+        #region Hall of Shame Settings
+        [BDAPersistentSettingsField] public static bool ALLOW_ZOMBIE_BD = false;          // Allow battle damage to proc when using zombie mode?
+        [BDAPersistentSettingsField] public static bool ENABLE_HOS = false;
+        [BDAPersistentSettingsField] public static List<string> HALL_OF_SHAME_LIST = new List<string>();
+        [BDAPersistentSettingsField] public static float HOS_FIRE = 0;
+        [BDAPersistentSettingsField] public static float HOS_MASS = 0;
+        [BDAPersistentSettingsField] public static float HOS_DMG = 0;
+        [BDAPersistentSettingsField] public static float HOS_THRUST = 0;
+        [BDAPersistentSettingsField] public static bool HOS_SAS = false;
+        [BDAPersistentSettingsField] public static bool HOS_ASTEROID = false;
+        [BDAPersistentSettingsField] public static string HOS_MUTATOR = "";
+        [BDAPersistentSettingsField] public static string HOS_BADGE = "";
         #endregion
 
         #region Remote logging
@@ -339,55 +342,55 @@ namespace BDArmory.Settings
         #endregion
 
         #region Waypoints
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float WAYPOINTS_ALTITUDE = 0f;                // Altitude above ground of the waypoints.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool WAYPOINTS_ONE_AT_A_TIME = false;          // Send the craft one-at-a-time through the course.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool WAYPOINTS_VISUALIZE = true;               // Add Waypoint models to indicate the path
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool WAYPOINTS_INFINITE_FUEL_AT_START = true;  // Don't consume fuel prior to the first waypoint.
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float WAYPOINTS_SCALE = 0f;                   // Have model(or maybe WP radius proper) scale?
-        [BDAPersistentSettingsField(RWPFilter = true)] public static int WAYPOINT_COURSE_INDEX = 0;                 // Select from a set of courses
-        [BDAPersistentSettingsField(RWPFilter = true)] public static int WAYPOINT_LOOP_INDEX = 1;                   // Number of loops to generate
-        [BDAPersistentSettingsField(RWPFilter = true)] public static int WAYPOINT_GUARD_INDEX = -1;                 // Activate guard after index; -1 for no guard
-        [BDAPersistentSettingsField(RWPFilter = true)] public static int WAYPOINT_MAX_LAPS = 5;                     // Configurable max number of laps for the laps slider
+        [BDAPersistentSettingsField] public static float WAYPOINTS_ALTITUDE = 0f;                // Altitude above ground of the waypoints.
+        [BDAPersistentSettingsField] public static bool WAYPOINTS_ONE_AT_A_TIME = false;          // Send the craft one-at-a-time through the course.
+        [BDAPersistentSettingsField] public static bool WAYPOINTS_VISUALIZE = true;               // Add Waypoint models to indicate the path
+        [BDAPersistentSettingsField] public static bool WAYPOINTS_INFINITE_FUEL_AT_START = true;  // Don't consume fuel prior to the first waypoint.
+        [BDAPersistentSettingsField] public static float WAYPOINTS_SCALE = 0f;                   // Have model(or maybe WP radius proper) scale?
+        [BDAPersistentSettingsField] public static int WAYPOINT_COURSE_INDEX = 0;                 // Select from a set of courses
+        [BDAPersistentSettingsField] public static int WAYPOINT_LOOP_INDEX = 1;                   // Number of loops to generate
+        [BDAPersistentSettingsField] public static int WAYPOINT_GUARD_INDEX = -1;                 // Activate guard after index; -1 for no guard
+        [BDAPersistentSettingsField] public static int WAYPOINT_MAX_LAPS = 5;                     // Configurable max number of laps for the laps slider
         #endregion
 
         #region Heartbleed
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float HEART_BLEED_RATE = 0.01f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float HEART_BLEED_INTERVAL = 10f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float HEART_BLEED_THRESHOLD = 10f;
+        [BDAPersistentSettingsField] public static float HEART_BLEED_RATE = 0.01f;
+        [BDAPersistentSettingsField] public static float HEART_BLEED_INTERVAL = 10f;
+        [BDAPersistentSettingsField] public static float HEART_BLEED_THRESHOLD = 10f;
         #endregion
 
         #region Resource steal
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool RESOURCE_STEAL_RESPECT_FLOWSTATE_IN = true;     // Respect resource flow state in (stealing).
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool RESOURCE_STEAL_RESPECT_FLOWSTATE_OUT = false;   // Respect resource flow state out (stolen).
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float RESOURCE_STEAL_FUEL_RATION = 0.2f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float RESOURCE_STEAL_AMMO_RATION = 0.2f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float RESOURCE_STEAL_CM_RATION = 0f;
+        [BDAPersistentSettingsField] public static bool RESOURCE_STEAL_RESPECT_FLOWSTATE_IN = true;     // Respect resource flow state in (stealing).
+        [BDAPersistentSettingsField] public static bool RESOURCE_STEAL_RESPECT_FLOWSTATE_OUT = false;   // Respect resource flow state out (stolen).
+        [BDAPersistentSettingsField] public static float RESOURCE_STEAL_FUEL_RATION = 0.2f;
+        [BDAPersistentSettingsField] public static float RESOURCE_STEAL_AMMO_RATION = 0.2f;
+        [BDAPersistentSettingsField] public static float RESOURCE_STEAL_CM_RATION = 0f;
         #endregion
 
         #region Space Friction
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool SPACE_HACKS = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool SF_FRICTION = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool SF_GRAVITY = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool SF_REPULSOR = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float SF_REPULSOR_STRENGTH = 5f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float SF_DRAGMULT = 2f;
+        [BDAPersistentSettingsField] public static bool SPACE_HACKS = false;
+        [BDAPersistentSettingsField] public static bool SF_FRICTION = false;
+        [BDAPersistentSettingsField] public static bool SF_GRAVITY = false;
+        [BDAPersistentSettingsField] public static bool SF_REPULSOR = false;
+        [BDAPersistentSettingsField] public static float SF_REPULSOR_STRENGTH = 5f;
+        [BDAPersistentSettingsField] public static float SF_DRAGMULT = 2f;
         #endregion
 
         #region Mutator Mode
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool MUTATOR_APPLY_GLOBAL = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool MUTATOR_APPLY_KILL = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool MUTATOR_APPLY_TIMER = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float MUTATOR_DURATION = 0.5f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static List<string> MUTATOR_LIST = new List<string>();
-        [BDAPersistentSettingsField(RWPFilter = true)] public static int MUTATOR_APPLY_NUM = 1;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool MUTATOR_ICONS = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool MUTATOR_APPLY_GUNGAME = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float VENGEANCE_DELAY = 2.5f;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float VENGEANCE_YIELD = 1.5f;
+        [BDAPersistentSettingsField] public static bool MUTATOR_APPLY_GLOBAL = false;
+        [BDAPersistentSettingsField] public static bool MUTATOR_APPLY_KILL = false;
+        [BDAPersistentSettingsField] public static bool MUTATOR_APPLY_TIMER = false;
+        [BDAPersistentSettingsField] public static float MUTATOR_DURATION = 0.5f;
+        [BDAPersistentSettingsField] public static List<string> MUTATOR_LIST = new List<string>();
+        [BDAPersistentSettingsField] public static int MUTATOR_APPLY_NUM = 1;
+        [BDAPersistentSettingsField] public static bool MUTATOR_ICONS = false;
+        [BDAPersistentSettingsField] public static bool MUTATOR_APPLY_GUNGAME = false;
+        [BDAPersistentSettingsField] public static float VENGEANCE_DELAY = 2.5f;
+        [BDAPersistentSettingsField] public static float VENGEANCE_YIELD = 1.5f;
         #endregion
         #region GunGame
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool GG_PERSISTANT_PROGRESSION = false;
-        [BDAPersistentSettingsField(RWPFilter = true)] public static bool GG_CYCLE_LIST = false;
+        [BDAPersistentSettingsField] public static bool GG_PERSISTANT_PROGRESSION = false;
+        [BDAPersistentSettingsField] public static bool GG_CYCLE_LIST = false;
         //[BDAPersistentSettingsField] public static bool GG_ANNOUNCER = false;
 
         #endregion
@@ -429,8 +432,8 @@ namespace BDArmory.Settings
         #endregion
 
         #region Scoring categories
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float SCORING_HEADSHOT = 3;                     // Head-Shot Time Limit
-        [BDAPersistentSettingsField(RWPFilter = true)] public static float SCORING_KILLSTEAL = 5;                   // Kill-Steal Time Limit
+        [BDAPersistentSettingsField] public static float SCORING_HEADSHOT = 3;                     // Head-Shot Time Limit
+        [BDAPersistentSettingsField] public static float SCORING_KILLSTEAL = 5;                   // Kill-Steal Time Limit
         #endregion
 
         #region Evolution settings

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -42,18 +42,18 @@ namespace BDArmory.Settings
         //[BDAPersistentSettingsField] public static bool INSTAKILL = true; //Deprecated, only affects lasers; use an Instagib mutator isntead
         [BDAPersistentSettingsField] public static bool AI_TOOLBAR_BUTTON = true;                 // Show or hide the BDA AI toolbar button.
         [BDAPersistentSettingsField] public static bool VM_TOOLBAR_BUTTON = true;                 // Show or hide the BDA VM toolbar button.
-        [BDAPersistentSettingsField] public static bool INFINITE_AMMO = false;              //infinite Bullets/rockets/laserpower
-        [BDAPersistentSettingsField] public static bool INFINITE_ORDINANCE = false;         //infinite missiles/bombs (on ordinance w/ Reload Module)
-        [BDAPersistentSettingsField] public static bool LIMITED_ORDINANCE = false;         //MML ammo clamped to salvo size, no relaods
-        [BDAPersistentSettingsField] public static bool INFINITE_FUEL = false;              //Infinite propellant
-        [BDAPersistentSettingsField] public static bool INFINITE_EC = false;                          //Infinite electric charge
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool INFINITE_AMMO = false;              //infinite Bullets/rockets/laserpower
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool INFINITE_ORDINANCE = false;         //infinite missiles/bombs (on ordinance w/ Reload Module)
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool LIMITED_ORDINANCE = false;         //MML ammo clamped to salvo size, no relaods
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool INFINITE_FUEL = false;              //Infinite propellant
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool INFINITE_EC = false;                          //Infinite electric charge
         [BDAPersistentSettingsField] public static bool BULLET_HITS = true;
         [BDAPersistentSettingsField] public static bool EJECT_SHELLS = true;
         [BDAPersistentSettingsField] public static bool VESSEL_RELATIVE_BULLET_CHECKS = false;
         [BDAPersistentSettingsField] public static bool AIM_ASSIST = true;
         [BDAPersistentSettingsField] public static bool AIM_ASSIST_MODE = true;              // true = reticle follows bullet CPA position, false = reticle follows aiming position.
         [BDAPersistentSettingsField] public static bool DRAW_AIMERS = true;
-        [BDAPersistentSettingsField] public static bool RESTORE_KAL = true;                  // Restore the Part, Module and AxisField references on the KAL to make it work.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool RESTORE_KAL = true;                  // Restore the Part, Module and AxisField references on the KAL to make it work.
 
         [BDAPersistentSettingsField] public static bool REMOTE_SHOOTING = false;
         [BDAPersistentSettingsField] public static bool BOMB_CLEARANCE_CHECK = false;
@@ -62,17 +62,17 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static bool BULLET_DECALS = true;
         [BDAPersistentSettingsField] public static bool GAPLESS_PARTICLE_EMITTERS = true;         // Use gapless particle emitters.
         [BDAPersistentSettingsField] public static bool FLARE_SMOKE = true;                       // Flares leave a trail of smoke.
-        [BDAPersistentSettingsField] public static bool DISABLE_RAMMING = false;                  // Prevent craft from going into ramming mode when out of ammo.
-        [BDAPersistentSettingsField] public static bool DEFAULT_FFA_TARGETING = false;            // Free-for-all combat style instead of teams (changes target selection behaviour). This could be removed now.
-        [BDAPersistentSettingsField] public static bool RUNWAY_PROJECT = false;                    // Enable/disable Runway Project specific enhancements.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool DISABLE_RAMMING = false;                  // Prevent craft from going into ramming mode when out of ammo.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool DEFAULT_FFA_TARGETING = false;            // Free-for-all combat style instead of teams (changes target selection behaviour). This could be removed now.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool RUNWAY_PROJECT = false;                    // Enable/disable Runway Project specific enhancements.
         //[BDAPersistentSettingsField] public static bool DISABLE_KILL_TIMER = true;                //disables the kill timers.
         [BDAPersistentSettingsField] public static bool AUTO_ENABLE_VESSEL_SWITCHING = false;     // Automatically enables vessel switching on competition start.
-        [BDAPersistentSettingsField] public static bool AUTONOMOUS_COMBAT_SEATS = false;          // Enable/disable seats without kerbals.
-        [BDAPersistentSettingsField] public static bool DESTROY_UNCONTROLLED_WMS = true;         // Automatically destroy the WM if there's no kerbal or drone core controlling it.
-        [BDAPersistentSettingsField] public static bool RESET_HP = false;                         // Automatically reset HP of parts of vessels when they're spawned in flight mode.
-        [BDAPersistentSettingsField] public static bool RESET_ARMOUR = false;                     // Automatically reset Armor material of parts of vessels when they're spawned in flight mode.
-        [BDAPersistentSettingsField] public static bool RESET_HULL = false;                     // Automatically reset hull material of parts of vessels when they're spawned in flight mode.
-        [BDAPersistentSettingsField] public static int KERBAL_SAFETY = 1;                         // Try to save kerbals by ejecting/leaving seats and deploying parachutes.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool AUTONOMOUS_COMBAT_SEATS = false;          // Enable/disable seats without kerbals.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool DESTROY_UNCONTROLLED_WMS = true;         // Automatically destroy the WM if there's no kerbal or drone core controlling it.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool RESET_HP = false;                         // Automatically reset HP of parts of vessels when they're spawned in flight mode.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool RESET_ARMOUR = false;                     // Automatically reset Armor material of parts of vessels when they're spawned in flight mode.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool RESET_HULL = false;                     // Automatically reset hull material of parts of vessels when they're spawned in flight mode.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static int KERBAL_SAFETY = 1;                         // Try to save kerbals by ejecting/leaving seats and deploying parachutes.
         [BDAPersistentSettingsField] public static bool TRACE_VESSELS_DURING_COMPETITIONS = false; // Trace vessel positions and rotations during competitions.
         [BDAPersistentSettingsField] public static bool AUTO_LOG_TIME_SYNC = false;               // Log time synchronisation info automatically during competitions.
         [BDAPersistentSettingsField] public static float LOG_TIME_SYNC_INTERVAL = 0.2f;           // Interval for logging time synchronisation information (approx).
@@ -86,10 +86,10 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static bool DISPLAY_COMPETITION_STATUS = true;             //Display competition status
         [BDAPersistentSettingsField] public static bool DISPLAY_COMPETITION_STATUS_WITH_HIDDEN_UI = false; // Display the competition status when using the "hidden UI"
         [BDAPersistentSettingsField] public static bool SCROLL_ZOOM_PREVENTION = true;                 // Prevent scroll-zoom when over most BDA windows.
-        [BDAPersistentSettingsField] public static bool BULLET_WATER_DRAG = true;                       // do bullets/rockets get slowed down if fired into/under water
-        [BDAPersistentSettingsField] public static bool UNDERWATER_VISION = false;                       //If false, Subs and other submerged vessels fully visible to surface/air craft and vice versa without detectors?
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BULLET_WATER_DRAG = true;                       // do bullets/rockets get slowed down if fired into/under water
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool UNDERWATER_VISION = false;                       //If false, Subs and other submerged vessels fully visible to surface/air craft and vice versa without detectors?
         [BDAPersistentSettingsField] public static bool PERSISTENT_FX = false;
-        [BDAPersistentSettingsField] public static bool LEGACY_ARMOR = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool LEGACY_ARMOR = false;
         [BDAPersistentSettingsField] public static bool HACK_INTAKES = false;
         [BDAPersistentSettingsField] public static bool COMPETITION_CLOSE_SETTINGS_ON_COMPETITION_START = false; // Close the settings window when clicking the start competition button.
         [BDAPersistentSettingsField] public static bool AUTO_LOAD_TO_KSC = false;                      // Automatically load the last used save and go to the KSC.
@@ -111,22 +111,22 @@ namespace BDArmory.Settings
         #endregion
 
         #region General slider settings
-        [BDAPersistentSettingsField] public static int COMPETITION_DURATION = 0;                       // Competition duration in minutes (0=unlimited)
+        [BDAPersistentSettingsField(RWPFilter = true)] public static int COMPETITION_DURATION = 0;                       // Competition duration in minutes (0=unlimited)
         [BDAPersistentSettingsField] public static float COMPETITION_INITIAL_GRACE_PERIOD = 10;        // Competition initial grace period in seconds.
         [BDAPersistentSettingsField] public static float COMPETITION_FINAL_GRACE_PERIOD = 10;          // Competition final grace period in seconds.
-        [BDAPersistentSettingsField] public static float COMPETITION_KILL_TIMER = 15;                  // Competition kill timer in seconds.
-        [BDAPersistentSettingsField] public static float COMPETITION_KILLER_GM_FREQUENCY = 60;         // Competition killer GM timer in seconds.
-        [BDAPersistentSettingsField] public static float COMPETITION_KILLER_GM_GRACE_PERIOD = 150;     // Competition killer GM grace period in seconds.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float COMPETITION_KILL_TIMER = 15;                  // Competition kill timer in seconds.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float COMPETITION_KILLER_GM_FREQUENCY = 60;         // Competition killer GM timer in seconds.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float COMPETITION_KILLER_GM_GRACE_PERIOD = 150;     // Competition killer GM grace period in seconds.
         [BDAPersistentSettingsField] public static float COMPETITION_ALTITUDE_LIMIT_HIGH = 55;         // Altitude (high) in km at which to kill off craft.
         [BDAPersistentSettingsField] public static float COMPETITION_ALTITUDE_LIMIT_LOW = -39;          // Altitude (low) in km at which to kill off craft.
         [BDAPersistentSettingsField] public static bool COMPETITION_ALTITUDE__LIMIT_ASL = false;       // Does Killer GM use ASL or AGL for latitide ceiling/floor?
-        [BDAPersistentSettingsField] public static bool COMPETITION_GM_KILL_WEAPON = false;             // Competition GM will kill weaponless craft?
-        [BDAPersistentSettingsField] public static bool COMPETITION_GM_KILL_ENGINE = false;             // Competition GM will kill engineless craft?
-        [BDAPersistentSettingsField] public static bool COMPETITION_GM_KILL_DISABLED = false;           // Competition GM will kill craft that are disabled (no weapons or ammo, no engine [Pilot/VTOL/Ship/Sub] or no wheels [Surface])
-        [BDAPersistentSettingsField] public static float COMPETITION_GM_KILL_HP = 0;                    // Competition GM will kill craft with low HP craft?
-        [BDAPersistentSettingsField] public static float COMPETITION_GM_KILL_TIME = 0;                  // CompetitionGM Kill time
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool COMPETITION_GM_KILL_WEAPON = false;             // Competition GM will kill weaponless craft?
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool COMPETITION_GM_KILL_ENGINE = false;             // Competition GM will kill engineless craft?
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool COMPETITION_GM_KILL_DISABLED = false;           // Competition GM will kill craft that are disabled (no weapons or ammo, no engine [Pilot/VTOL/Ship/Sub] or no wheels [Surface])
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float COMPETITION_GM_KILL_HP = 0;                    // Competition GM will kill craft with low HP craft?
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float COMPETITION_GM_KILL_TIME = 0;                  // CompetitionGM Kill time
         [BDAPersistentSettingsField] public static float COMPETITION_NONCOMPETITOR_REMOVAL_DELAY = 30; // Competition non-competitor removal delay in seconds.
-        [BDAPersistentSettingsField] public static float COMPETITION_WAYPOINTS_GM_KILL_PERIOD = 60;    // Waypoint Competition GM kill period in seconds. Craft that don't pass a waypoint within this time are killed off.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float COMPETITION_WAYPOINTS_GM_KILL_PERIOD = 60;    // Waypoint Competition GM kill period in seconds. Craft that don't pass a waypoint within this time are killed off.
         [BDAPersistentSettingsField] public static float COMPETITION_DISTANCE = 1000;                  // Competition distance.
         [BDAPersistentSettingsField] public static float COMPETITION_INTRA_TEAM_SEPARATION_BASE = 800; // Intra-team separation (base value).
         [BDAPersistentSettingsField] public static float COMPETITION_INTRA_TEAM_SEPARATION_PER_MEMBER = 100; // Intra-team separation (per member value).
@@ -138,7 +138,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static int CAMERA_SWITCH_FREQUENCY = 10;                    // Controls the minimum time between automated camera switches
         [BDAPersistentSettingsField] public static int DEATH_CAMERA_SWITCH_INHIBIT_PERIOD = 2;         // Controls the delay before the next switch after the currently active vessel dies
         [BDAPersistentSettingsField] public static bool CAMERA_SWITCH_INCLUDE_MISSILES = false;        // Include missiles in the camera switching logic.
-        [BDAPersistentSettingsField] public static int KERBAL_SAFETY_INVENTORY = 2;                    // Controls how Kerbal Safety adjusts the inventory of kerbals.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static int KERBAL_SAFETY_INVENTORY = 2;                    // Controls how Kerbal Safety adjusts the inventory of kerbals.
         [BDAPersistentSettingsField] public static float TRIGGER_HOLD_TIME = 0.2f;
         [BDAPersistentSettingsField] public static float BDARMORY_UI_VOLUME = 0.35f;
         [BDAPersistentSettingsField] public static float BDARMORY_WEAPONS_VOLUME = 0.45f;
@@ -153,10 +153,10 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_SPREAD = 5f;
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_BIAS = 0.4f;
         [BDAPersistentSettingsField] public static float FIRE_RATE_OVERRIDE_HIT_MULTIPLIER = 2f;
-        [BDAPersistentSettingsField] public static float HP_THRESHOLD = 2000;                    //HP above this value will be scaled to a logarithmic value
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float HP_THRESHOLD = 2000;                    //HP above this value will be scaled to a logarithmic value
         [BDAPersistentSettingsField] public static float HP_CLAMP = 0;                           //HP will be clamped to this value
-        [BDAPersistentSettingsField] public static bool PWING_EDGE_LIFT = true;                  //Toggle lift on PWing edges for balance with stock wings/remove edge abuse
-        [BDAPersistentSettingsField] public static bool PWING_THICKNESS_AFFECT_MASS_HP = false;  //pWing thickness contributes to its mass calc instead of a static LiftArea derived value
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool PWING_EDGE_LIFT = true;                  //Toggle lift on PWing edges for balance with stock wings/remove edge abuse
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool PWING_THICKNESS_AFFECT_MASS_HP = false;  //pWing thickness contributes to its mass calc instead of a static LiftArea derived value
         [BDAPersistentSettingsField] public static float MAX_PWING_LIFT = 4.54f;                //Clamp pWing lift to this amount
         [BDAPersistentSettingsField] public static float MAX_SAS_TORQUE = 30;                   //Clamp vessel total non-cockpit torque to this
         [BDAPersistentSettingsField] public static bool NUMERIC_INPUT_SELF_UPDATE = true;             // Automatically update the display string in NumericInputField after attempting to parse the value.
@@ -165,23 +165,23 @@ namespace BDArmory.Settings
         #endregion
 
         #region Physics constants
-        [BDAPersistentSettingsField] public static float GLOBAL_LIFT_MULTIPLIER = 0.25f;
-        [BDAPersistentSettingsField] public static float GLOBAL_DRAG_MULTIPLIER = 6f;
-        [BDAPersistentSettingsField] public static float RECOIL_FACTOR = 0.75f;
-        [BDAPersistentSettingsField] public static float DMG_MULTIPLIER = 100f;
-        [BDAPersistentSettingsField] public static float BALLISTIC_DMG_FACTOR = 1.55f;
-        [BDAPersistentSettingsField] public static float HITPOINT_MULTIPLIER = 3.0f;
-        [BDAPersistentSettingsField] public static float EXP_DMG_MOD_BALLISTIC_NEW = 0.55f;     // HE bullet explosion damage multiplier
-        [BDAPersistentSettingsField] public static float EXP_PEN_RESIST_MULT = 2.50f;           // Armor HE penetration resistance multiplier
-        [BDAPersistentSettingsField] public static float EXP_DMG_MOD_MISSILE = 6.75f;           // Missile explosion damage multiplier
-        [BDAPersistentSettingsField] public static float EXP_DMG_MOD_ROCKET = 1f;               // Rocket explosion damage multiplier (FIXME needs tuning; Note: rockets used Ballistic mod before, but probably ought to be more like missiles)
-        [BDAPersistentSettingsField] public static float EXP_DMG_MOD_BATTLE_DAMAGE = 1f;        // Battle damage explosion damage multiplier (FIXME needs tuning; Note: CASE-0 explosions used Missile mod, while CASE-1, CASE-2 and fuel explosions used Ballistic mod)
-        [BDAPersistentSettingsField] public static float EXP_IMP_MOD = 0.25f;
-        [BDAPersistentSettingsField] public static float BUILDING_DMG_MULTIPLIER = 1f;
-        [BDAPersistentSettingsField] public static bool EXTRA_DAMAGE_SLIDERS = false;
-        [BDAPersistentSettingsField] public static float WEAPON_FX_DURATION = 15;               //how long do weapon secondary effects(EMP/choker/gravitic/etc) last
-        [BDAPersistentSettingsField] public static float ZOMBIE_DMG_MULT = 0.1f;
-        [BDAPersistentSettingsField] public static float ARMOR_MASS_MOD = 1f;                   //Armor mass multiplier
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float GLOBAL_LIFT_MULTIPLIER = 0.25f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float GLOBAL_DRAG_MULTIPLIER = 6f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float RECOIL_FACTOR = 0.75f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float DMG_MULTIPLIER = 100f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float BALLISTIC_DMG_FACTOR = 1.55f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float HITPOINT_MULTIPLIER = 3.0f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float EXP_DMG_MOD_BALLISTIC_NEW = 0.55f;     // HE bullet explosion damage multiplier
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float EXP_PEN_RESIST_MULT = 2.50f;           // Armor HE penetration resistance multiplier
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float EXP_DMG_MOD_MISSILE = 6.75f;           // Missile explosion damage multiplier
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float EXP_DMG_MOD_ROCKET = 1f;               // Rocket explosion damage multiplier (FIXME needs tuning; Note: rockets used Ballistic mod before, but probably ought to be more like missiles)
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float EXP_DMG_MOD_BATTLE_DAMAGE = 1f;        // Battle damage explosion damage multiplier (FIXME needs tuning; Note: CASE-0 explosions used Missile mod, while CASE-1, CASE-2 and fuel explosions used Ballistic mod)
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float EXP_IMP_MOD = 0.25f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float BUILDING_DMG_MULTIPLIER = 1f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool EXTRA_DAMAGE_SLIDERS = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float WEAPON_FX_DURATION = 15;               //how long do weapon secondary effects(EMP/choker/gravitic/etc) last
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float ZOMBIE_DMG_MULT = 0.1f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float ARMOR_MASS_MOD = 1f;                   //Armor mass multiplier
         #endregion
 
         #region FX
@@ -207,76 +207,76 @@ namespace BDArmory.Settings
         #endregion
 
         #region Game modes
-        [BDAPersistentSettingsField] public static bool PEACE_MODE = false;
-        [BDAPersistentSettingsField] public static bool TAG_MODE = false;
-        [BDAPersistentSettingsField] public static bool PAINTBALL_MODE = false;
-        [BDAPersistentSettingsField] public static bool GRAVITY_HACKS = false;
-        [BDAPersistentSettingsField] public static bool ALTITUDE_HACKS = false; //transfer to a RunWayRound number?
-        [BDAPersistentSettingsField] public static bool BATTLEDAMAGE = true;
-        [BDAPersistentSettingsField] public static bool HEART_BLEED_ENABLED = false;
-        [BDAPersistentSettingsField] public static bool RESOURCE_STEAL_ENABLED = false;
-        [BDAPersistentSettingsField] public static bool ASTEROID_FIELD = false;
-        [BDAPersistentSettingsField] public static int ASTEROID_FIELD_NUMBER = 100; // Number of asteroids
-        [BDAPersistentSettingsField] public static float ASTEROID_FIELD_ALTITUDE = 2f; // Km.
-        [BDAPersistentSettingsField] public static float ASTEROID_FIELD_RADIUS = 5f; // Km.
-        [BDAPersistentSettingsField] public static bool ASTEROID_FIELD_ANOMALOUS_ATTRACTION = false; // Asteroids are attracted to vessels.
-        [BDAPersistentSettingsField] public static float ASTEROID_FIELD_ANOMALOUS_ATTRACTION_STRENGTH = 0.2f; // Strength of the effect.
-        [BDAPersistentSettingsField] public static bool ASTEROID_RAIN = false;
-        [BDAPersistentSettingsField] public static int ASTEROID_RAIN_NUMBER = 100; // Number of asteroids
-        [BDAPersistentSettingsField] public static float ASTEROID_RAIN_DENSITY = 0.5f; // Arbitrary density scale.
-        [BDAPersistentSettingsField] public static float ASTEROID_RAIN_ALTITUDE = 2f; // Km.k
-        [BDAPersistentSettingsField] public static float ASTEROID_RAIN_RADIUS = 3f; // Km.
-        [BDAPersistentSettingsField] public static bool ASTEROID_RAIN_FOLLOWS_CENTROID = true;
-        [BDAPersistentSettingsField] public static bool ASTEROID_RAIN_FOLLOWS_SPREAD = true;
-        [BDAPersistentSettingsField] public static bool MUTATOR_MODE = false;
-        [BDAPersistentSettingsField] public static bool ZOMBIE_MODE = false;
-        [BDAPersistentSettingsField] public static bool DISCO_MODE = false;
-        [BDAPersistentSettingsField] public static bool NO_ENGINES = false;
-        [BDAPersistentSettingsField] public static bool WAYPOINTS_MODE = false;         // Waypoint section of Vessel Spawner Window.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool PEACE_MODE = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool TAG_MODE = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool PAINTBALL_MODE = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool GRAVITY_HACKS = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ALTITUDE_HACKS = false; //transfer to a RunWayRound number?
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BATTLEDAMAGE = true;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool HEART_BLEED_ENABLED = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool RESOURCE_STEAL_ENABLED = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ASTEROID_FIELD = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static int ASTEROID_FIELD_NUMBER = 100; // Number of asteroids
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float ASTEROID_FIELD_ALTITUDE = 2f; // Km.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float ASTEROID_FIELD_RADIUS = 5f; // Km.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ASTEROID_FIELD_ANOMALOUS_ATTRACTION = false; // Asteroids are attracted to vessels.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float ASTEROID_FIELD_ANOMALOUS_ATTRACTION_STRENGTH = 0.2f; // Strength of the effect.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ASTEROID_RAIN = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static int ASTEROID_RAIN_NUMBER = 100; // Number of asteroids
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float ASTEROID_RAIN_DENSITY = 0.5f; // Arbitrary density scale.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float ASTEROID_RAIN_ALTITUDE = 2f; // Km.k
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float ASTEROID_RAIN_RADIUS = 3f; // Km.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ASTEROID_RAIN_FOLLOWS_CENTROID = true;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ASTEROID_RAIN_FOLLOWS_SPREAD = true;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool MUTATOR_MODE = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ZOMBIE_MODE = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool DISCO_MODE = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool NO_ENGINES = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool WAYPOINTS_MODE = false;         // Waypoint section of Vessel Spawner Window.
         [BDAPersistentSettingsField] public static string PINATA_NAME = "Pinata";
         #endregion
 
         #region Battle Damage settings
-        [BDAPersistentSettingsField] public static bool BATTLEDAMAGE_TOGGLE = false;    // Main battle damage toggle.
-        [BDAPersistentSettingsField] public static float BD_DAMAGE_CHANCE = 5;          // Base chance per-hit to proc damage
-        [BDAPersistentSettingsField] public static bool BD_SUBSYSTEMS = true;           // Non-critical module damage?
-        [BDAPersistentSettingsField] public static bool BD_TANKS = true;                // Fuel tanks, batteries can leak/burn
-        [BDAPersistentSettingsField] public static float BD_TANK_LEAK_TIME = 20;        // Leak duration
-        [BDAPersistentSettingsField] public static float BD_TANK_LEAK_RATE = 1;         // Leak rate modifier
-        [BDAPersistentSettingsField] public static bool BD_AMMOBINS = true;             // Can ammo bins explode?
-        [BDAPersistentSettingsField] public static bool BD_VOLATILE_AMMO = false;       // Ammo bins guaranteed to explode when destroyed
-        [BDAPersistentSettingsField] public static bool BD_PROPULSION = true;           // Engine thrust reduction, fires
-        [BDAPersistentSettingsField] public static float BD_PROP_FLOOR = 20;            // Minimum thrust% damaged engines produce
-        [BDAPersistentSettingsField] public static float BD_PROP_FLAMEOUT = 25;         // Remaining HP% engines flameout
-        [BDAPersistentSettingsField] public static bool BD_PART_STRENGTH = false;        // Part strength - breakingForce/Torque - decreases as part takes damage
-        [BDAPersistentSettingsField] public static float BD_PROP_DAM_RATE = 1;          // Rate multiplier, 0.1-2
-        [BDAPersistentSettingsField] public static bool BD_INTAKES = true;              // Can intakes be damaged?
-        [BDAPersistentSettingsField] public static bool BD_GIMBALS = true;              // Can gimbals be disabled?
-        [BDAPersistentSettingsField] public static bool BD_AEROPARTS = true;            // Lift loss & added drag
-        [BDAPersistentSettingsField] public static float BD_LIFT_LOSS_RATE = 1;         // Rate multiplier
-        [BDAPersistentSettingsField] public static bool BD_CTRL_SRF = true;             // Disable ctrl srf actuatiors?
-        [BDAPersistentSettingsField] public static bool BD_COCKPITS = false;            // Control degredation
-        [BDAPersistentSettingsField] public static bool BD_PILOT_KILLS = false;         // Cockpit damage can kill pilots?
-        [BDAPersistentSettingsField] public static bool BD_FIRES_ENABLED = true;        // Can fires occur
-        [BDAPersistentSettingsField] public static bool BD_FIRE_DOT = true;             // Do fires do DoT
-        [BDAPersistentSettingsField] public static float BD_FIRE_DAMAGE = 5;            // Do fires do DoT
-        [BDAPersistentSettingsField] public static bool BD_FIRE_HEATDMG = true;         // Do fires add heat to parts/are fires able to cook off fuel/ammo?
-        [BDAPersistentSettingsField] public static bool BD_INTENSE_FIRES = false;       // Do fuel tank fires DoT get bigger over time?
-        [BDAPersistentSettingsField] public static bool BD_FIRE_FUELEX = true;          // Can fires detonate fuel tanks
-        [BDAPersistentSettingsField] public static float BD_FIRE_CHANCE_TRACER = 10;
-        [BDAPersistentSettingsField] public static float BD_FIRE_CHANCE_HE = 25;
-        [BDAPersistentSettingsField] public static float BD_FIRE_CHANCE_INCENDIARY = 90;
-        [BDAPersistentSettingsField] public static bool ALLOW_ZOMBIE_BD = false;          // Allow battle damage to proc when using zombie mode?
-        [BDAPersistentSettingsField] public static bool ENABLE_HOS = false;
-        [BDAPersistentSettingsField] public static List<string> HALL_OF_SHAME_LIST = new List<string>();
-        [BDAPersistentSettingsField] public static float HOS_FIRE = 0;
-        [BDAPersistentSettingsField] public static float HOS_MASS = 0;
-        [BDAPersistentSettingsField] public static float HOS_DMG = 0;
-        [BDAPersistentSettingsField] public static float HOS_THRUST = 0;
-        [BDAPersistentSettingsField] public static bool HOS_SAS = false;
-        [BDAPersistentSettingsField] public static bool HOS_ASTEROID = false;
-        [BDAPersistentSettingsField] public static string HOS_MUTATOR = "";
-        [BDAPersistentSettingsField] public static string HOS_BADGE = "";
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BATTLEDAMAGE_TOGGLE = false;    // Main battle damage toggle.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_DAMAGE_CHANCE = 5;          // Base chance per-hit to proc damage
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_SUBSYSTEMS = true;           // Non-critical module damage?
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_TANKS = true;                // Fuel tanks, batteries can leak/burn
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_TANK_LEAK_TIME = 20;        // Leak duration
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_TANK_LEAK_RATE = 1;         // Leak rate modifier
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_AMMOBINS = true;             // Can ammo bins explode?
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_VOLATILE_AMMO = false;       // Ammo bins guaranteed to explode when destroyed
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_PROPULSION = true;           // Engine thrust reduction, fires
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_PROP_FLOOR = 20;            // Minimum thrust% damaged engines produce
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_PROP_FLAMEOUT = 25;         // Remaining HP% engines flameout
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_PART_STRENGTH = false;        // Part strength - breakingForce/Torque - decreases as part takes damage
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_PROP_DAM_RATE = 1;          // Rate multiplier, 0.1-2
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_INTAKES = true;              // Can intakes be damaged?
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_GIMBALS = true;              // Can gimbals be disabled?
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_AEROPARTS = true;            // Lift loss & added drag
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_LIFT_LOSS_RATE = 1;         // Rate multiplier
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_CTRL_SRF = true;             // Disable ctrl srf actuatiors?
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_COCKPITS = false;            // Control degredation
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_PILOT_KILLS = false;         // Cockpit damage can kill pilots?
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_FIRES_ENABLED = true;        // Can fires occur
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_FIRE_DOT = true;             // Do fires do DoT
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_FIRE_DAMAGE = 5;            // Do fires do DoT
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_FIRE_HEATDMG = true;         // Do fires add heat to parts/are fires able to cook off fuel/ammo?
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_INTENSE_FIRES = false;       // Do fuel tank fires DoT get bigger over time?
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool BD_FIRE_FUELEX = true;          // Can fires detonate fuel tanks
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_FIRE_CHANCE_TRACER = 10;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_FIRE_CHANCE_HE = 25;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float BD_FIRE_CHANCE_INCENDIARY = 90;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ALLOW_ZOMBIE_BD = false;          // Allow battle damage to proc when using zombie mode?
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool ENABLE_HOS = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static List<string> HALL_OF_SHAME_LIST = new List<string>();
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float HOS_FIRE = 0;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float HOS_MASS = 0;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float HOS_DMG = 0;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float HOS_THRUST = 0;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool HOS_SAS = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool HOS_ASTEROID = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static string HOS_MUTATOR = "";
+        [BDAPersistentSettingsField(RWPFilter = true)] public static string HOS_BADGE = "";
         #endregion
 
         #region Remote logging
@@ -338,55 +338,55 @@ namespace BDArmory.Settings
         #endregion
 
         #region Waypoints
-        [BDAPersistentSettingsField] public static float WAYPOINTS_ALTITUDE = 0f;                // Altitude above ground of the waypoints.
-        [BDAPersistentSettingsField] public static bool WAYPOINTS_ONE_AT_A_TIME = false;          // Send the craft one-at-a-time through the course.
-        [BDAPersistentSettingsField] public static bool WAYPOINTS_VISUALIZE = true;               // Add Waypoint models to indicate the path
-        [BDAPersistentSettingsField] public static bool WAYPOINTS_INFINITE_FUEL_AT_START = true;  // Don't consume fuel prior to the first waypoint.
-        [BDAPersistentSettingsField] public static float WAYPOINTS_SCALE = 0f;                   // Have model(or maybe WP radius proper) scale?
-        [BDAPersistentSettingsField] public static int WAYPOINT_COURSE_INDEX = 0;                 // Select from a set of courses
-        [BDAPersistentSettingsField] public static int WAYPOINT_LOOP_INDEX = 1;                   // Number of loops to generate
-        [BDAPersistentSettingsField] public static int WAYPOINT_GUARD_INDEX = -1;                 // Activate guard after index; -1 for no guard
-        [BDAPersistentSettingsField] public static int WAYPOINT_MAX_LAPS = 5;                     // Configurable max number of laps for the laps slider
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float WAYPOINTS_ALTITUDE = 0f;                // Altitude above ground of the waypoints.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool WAYPOINTS_ONE_AT_A_TIME = false;          // Send the craft one-at-a-time through the course.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool WAYPOINTS_VISUALIZE = true;               // Add Waypoint models to indicate the path
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool WAYPOINTS_INFINITE_FUEL_AT_START = true;  // Don't consume fuel prior to the first waypoint.
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float WAYPOINTS_SCALE = 0f;                   // Have model(or maybe WP radius proper) scale?
+        [BDAPersistentSettingsField(RWPFilter = true)] public static int WAYPOINT_COURSE_INDEX = 0;                 // Select from a set of courses
+        [BDAPersistentSettingsField(RWPFilter = true)] public static int WAYPOINT_LOOP_INDEX = 1;                   // Number of loops to generate
+        [BDAPersistentSettingsField(RWPFilter = true)] public static int WAYPOINT_GUARD_INDEX = -1;                 // Activate guard after index; -1 for no guard
+        [BDAPersistentSettingsField(RWPFilter = true)] public static int WAYPOINT_MAX_LAPS = 5;                     // Configurable max number of laps for the laps slider
         #endregion
 
         #region Heartbleed
-        [BDAPersistentSettingsField] public static float HEART_BLEED_RATE = 0.01f;
-        [BDAPersistentSettingsField] public static float HEART_BLEED_INTERVAL = 10f;
-        [BDAPersistentSettingsField] public static float HEART_BLEED_THRESHOLD = 10f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float HEART_BLEED_RATE = 0.01f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float HEART_BLEED_INTERVAL = 10f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float HEART_BLEED_THRESHOLD = 10f;
         #endregion
 
         #region Resource steal
-        [BDAPersistentSettingsField] public static bool RESOURCE_STEAL_RESPECT_FLOWSTATE_IN = true;     // Respect resource flow state in (stealing).
-        [BDAPersistentSettingsField] public static bool RESOURCE_STEAL_RESPECT_FLOWSTATE_OUT = false;   // Respect resource flow state out (stolen).
-        [BDAPersistentSettingsField] public static float RESOURCE_STEAL_FUEL_RATION = 0.2f;
-        [BDAPersistentSettingsField] public static float RESOURCE_STEAL_AMMO_RATION = 0.2f;
-        [BDAPersistentSettingsField] public static float RESOURCE_STEAL_CM_RATION = 0f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool RESOURCE_STEAL_RESPECT_FLOWSTATE_IN = true;     // Respect resource flow state in (stealing).
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool RESOURCE_STEAL_RESPECT_FLOWSTATE_OUT = false;   // Respect resource flow state out (stolen).
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float RESOURCE_STEAL_FUEL_RATION = 0.2f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float RESOURCE_STEAL_AMMO_RATION = 0.2f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float RESOURCE_STEAL_CM_RATION = 0f;
         #endregion
 
         #region Space Friction
-        [BDAPersistentSettingsField] public static bool SPACE_HACKS = false;
-        [BDAPersistentSettingsField] public static bool SF_FRICTION = false;
-        [BDAPersistentSettingsField] public static bool SF_GRAVITY = false;
-        [BDAPersistentSettingsField] public static bool SF_REPULSOR = false;
-        [BDAPersistentSettingsField] public static float SF_REPULSOR_STRENGTH = 5f;
-        [BDAPersistentSettingsField] public static float SF_DRAGMULT = 2f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool SPACE_HACKS = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool SF_FRICTION = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool SF_GRAVITY = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool SF_REPULSOR = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float SF_REPULSOR_STRENGTH = 5f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float SF_DRAGMULT = 2f;
         #endregion
 
         #region Mutator Mode
-        [BDAPersistentSettingsField] public static bool MUTATOR_APPLY_GLOBAL = false;
-        [BDAPersistentSettingsField] public static bool MUTATOR_APPLY_KILL = false;
-        [BDAPersistentSettingsField] public static bool MUTATOR_APPLY_TIMER = false;
-        [BDAPersistentSettingsField] public static float MUTATOR_DURATION = 0.5f;
-        [BDAPersistentSettingsField] public static List<string> MUTATOR_LIST = new List<string>();
-        [BDAPersistentSettingsField] public static int MUTATOR_APPLY_NUM = 1;
-        [BDAPersistentSettingsField] public static bool MUTATOR_ICONS = false;
-        [BDAPersistentSettingsField] public static bool MUTATOR_APPLY_GUNGAME = false;
-        [BDAPersistentSettingsField] public static float VENGEANCE_DELAY = 2.5f;
-        [BDAPersistentSettingsField] public static float VENGEANCE_YIELD = 1.5f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool MUTATOR_APPLY_GLOBAL = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool MUTATOR_APPLY_KILL = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool MUTATOR_APPLY_TIMER = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float MUTATOR_DURATION = 0.5f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static List<string> MUTATOR_LIST = new List<string>();
+        [BDAPersistentSettingsField(RWPFilter = true)] public static int MUTATOR_APPLY_NUM = 1;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool MUTATOR_ICONS = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool MUTATOR_APPLY_GUNGAME = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float VENGEANCE_DELAY = 2.5f;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float VENGEANCE_YIELD = 1.5f;
         #endregion
         #region GunGame
-        [BDAPersistentSettingsField] public static bool GG_PERSISTANT_PROGRESSION = false;
-        [BDAPersistentSettingsField] public static bool GG_CYCLE_LIST = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool GG_PERSISTANT_PROGRESSION = false;
+        [BDAPersistentSettingsField(RWPFilter = true)] public static bool GG_CYCLE_LIST = false;
         //[BDAPersistentSettingsField] public static bool GG_ANNOUNCER = false;
 
         #endregion
@@ -428,8 +428,8 @@ namespace BDArmory.Settings
         #endregion
 
         #region Scoring categories
-        [BDAPersistentSettingsField] public static float SCORING_HEADSHOT = 3;                     // Head-Shot Time Limit
-        [BDAPersistentSettingsField] public static float SCORING_KILLSTEAL = 5;                   // Kill-Steal Time Limit
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float SCORING_HEADSHOT = 3;                     // Head-Shot Time Limit
+        [BDAPersistentSettingsField(RWPFilter = true)] public static float SCORING_KILLSTEAL = 5;                   // Kill-Steal Time Limit
         #endregion
 
         #region Evolution settings

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -48,6 +48,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField(RWPFilter = true)] public static bool INFINITE_FUEL = false;              //Infinite propellant
         [BDAPersistentSettingsField(RWPFilter = true)] public static bool INFINITE_EC = false;                          //Infinite electric charge
         [BDAPersistentSettingsField] public static bool BULLET_HITS = true;
+        [BDAPersistentSettingsField] public static bool WATER_HIT_FX = true;
         [BDAPersistentSettingsField] public static bool EJECT_SHELLS = true;
         [BDAPersistentSettingsField] public static bool VESSEL_RELATIVE_BULLET_CHECKS = false;
         [BDAPersistentSettingsField] public static bool AIM_ASSIST = true;

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -345,6 +345,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static int WAYPOINT_COURSE_INDEX = 0;                 // Select from a set of courses
         [BDAPersistentSettingsField] public static int WAYPOINT_LOOP_INDEX = 1;                   // Number of loops to generate
         [BDAPersistentSettingsField] public static int WAYPOINT_GUARD_INDEX = -1;                 // Activate guard after index; -1 for no guard
+        [BDAPersistentSettingsField] public static int WAYPOINT_MAX_LAPS = 5;                     // Configurable max number of laps for the laps slider
         #endregion
 
         #region Heartbleed

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -380,6 +380,8 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static int MUTATOR_APPLY_NUM = 1;
         [BDAPersistentSettingsField] public static bool MUTATOR_ICONS = false;
         [BDAPersistentSettingsField] public static bool MUTATOR_APPLY_GUNGAME = false;
+        [BDAPersistentSettingsField] public static float VENGEANCE_DELAY = 2.5f;
+        [BDAPersistentSettingsField] public static float VENGEANCE_YIELD = 1.5f;
         #endregion
         #region GunGame
         [BDAPersistentSettingsField] public static bool GG_PERSISTANT_PROGRESSION = false;

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -274,6 +274,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static float HOS_DMG = 0;
         [BDAPersistentSettingsField] public static float HOS_THRUST = 0;
         [BDAPersistentSettingsField] public static bool HOS_SAS = false;
+        [BDAPersistentSettingsField] public static bool HOS_ASTEROID = false;
         [BDAPersistentSettingsField] public static string HOS_MUTATOR = "";
         [BDAPersistentSettingsField] public static string HOS_BADGE = "";
         #endregion

--- a/BDArmory/Settings/RWPSettings.cs
+++ b/BDArmory/Settings/RWPSettings.cs
@@ -108,16 +108,25 @@ namespace BDArmory.Settings
       Debug.Log($"[BDArmory.RWPSettings]: Storing {(temp ? "temporary" : "base")} settings.");
       var settings = temp ? tempSettings : storedSettings;
       settings.Clear();
-      var fields = typeof(BDArmorySettings).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
-      foreach (var field in fields)
-      {
-        if (field.Name.EndsWith("_SETTINGS_TOGGLE")) continue; // Don't toggle the section headers.
-        if (field.Name.StartsWith("RUNWAY_PROJECT")) continue; // Skip settings beginning with RWP (toggle and slider) to avoid recursion.
-        if (field.Name.StartsWith("VESSEL_SPAWN_")) continue; // Skip spawn settings so they are the same between RWP and non-RWP.
-        if (field.Name.StartsWith("TOURNAMENT_")) continue; // Skip tournament settings so they are the same between RWP and non-RWP.
-        settings.Add(field.Name, field.GetValue(null));
-      }
-      if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.RWPSettings]: Stored settings: " + string.Join(", ", settings.Select(kvp => $"{kvp.Key}={kvp.Value}")));
+            
+            var fields = typeof(BDArmorySettings).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+            foreach (var field in fields)
+            {
+                //if (field.Name.EndsWith("_SETTINGS_TOGGLE")) continue; // Don't toggle the section headers.
+                //if (field.Name.StartsWith("RUNWAY_PROJECT")) continue; // Skip settings beginning with RWP (toggle and slider) to avoid recursion.
+                //if (field.Name.StartsWith("VESSEL_SPAWN_")) continue; // Skip spawn settings so they are the same between RWP and non-RWP.
+                //if (field.Name.StartsWith("TOURNAMENT_")) continue; // Skip tournament settings so they are the same between RWP and non-RWP.
+                if (!field.IsDefined(typeof(BDAPersistentSettingsField), false)) continue;
+
+                BDAPersistentSettingsField attr = field.GetCustomAttribute<BDAPersistentSettingsField>();
+                if (!attr.RWPFilter)
+                {
+                    //Debug.Log($"[BDArmory.RWPSettings]: {field.Name} is non-RWP setting, skipping...");
+                    continue;
+                }
+
+                settings.Add(field.Name, field.GetValue(null));
+            }
     }
 
     /// <summary>

--- a/BDArmory/Targeting/TargetInfo.cs
+++ b/BDArmory/Targeting/TargetInfo.cs
@@ -147,11 +147,13 @@ namespace BDArmory.Targeting
                 {
                     return true;
                 }
-                else if (weaponManager && weaponManager.vessel.isCommandable) //Fix for GLOC'd pilots. IsControllable merely checks if plane has pilot; Iscommandable checks if they're conscious
+                else if (weaponManager)
                 {
-                    return true;
+                    return weaponManager.vessel.isCommandable; //isn't debris / has command part
+                    //return weaponManager.vessel.IsControllable; //vessel has probecore & EC/pilot && pilot is conscious
+                    //enable this if you want exceedingly honorable pilots who hold fire if their target has GLOC'ed themselves
+                    // GLOC'ed craft now go neutral stick, so they no longer get locked in a perma-stun deathloop                    
                 }
-
                 return false;
             }
         }

--- a/BDArmory/UI/BDAEditorArmorWindow.cs
+++ b/BDArmory/UI/BDAEditorArmorWindow.cs
@@ -136,7 +136,7 @@ namespace BDArmory.UI
             hullGUI = new GUIContent[HullInfo.materials.Count];
             for (int i = 0; i < HullInfo.materials.Count; i++)
             {
-                GUIContent gui = new GUIContent(HullInfo.materials[i].name);
+                GUIContent gui = new GUIContent(HullInfo.materials[i].localizedName );
                 hullGUI[i] = gui;
             }
 

--- a/BDArmory/UI/BDATargetManager.cs
+++ b/BDArmory/UI/BDATargetManager.cs
@@ -340,7 +340,7 @@ namespace BDArmory.UI
                             if (afterburner) heatSourcePosition = thrustTransform.position + thrustTransform.forward.normalized * 3f;
                             partRay = new Ray(heatSourcePosition, sensorPosition - heatSourcePosition); //trace from heatsource to IR sensor
                             occludedPlumeHeatScore = GetOccludedSensorScore(v, closestPart, heatSourcePosition, 0.72f * heatScore, partRay, hits, distance, thrustTransform, true, propEngine, frontAspectModifier);
-                            heatScore = Mathf.Max(occludedPartHeatScore, occludedPlumeHeatScore); // 
+                            heatScore = Mathf.Max(occludedPartHeatScore, occludedPlumeHeatScore); 
                         }
                         else
                         {
@@ -356,14 +356,13 @@ namespace BDArmory.UI
                 heatScore *= vesselcamo.thermalReductionFactor;
                 heatScore = Mathf.Max(heatScore, occludedPlumeHeatScore); //Fancy heatsinks/thermoptic camo isn't going to magically cool the engine plume
             }
-            if (BDArmorySettings.DEBUG_RADAR) Debug.Log("[BDArmory.BDATargetManager] final heatScore: " + heatScore);
+            if (BDArmorySettings.DEBUG_RADAR) Debug.Log("[BDArmory.BDATargetManager] final heatSignature: " + heatScore);
             return new Tuple<float, Part>(heatScore, IRPart);
         }
 
         static float GetOccludedSensorScore(Vessel v, Part closestPart, Vector3 heatSourcePosition, float heatScore, Ray partRay, RaycastHit[] hits, float distance, Transform thrustTransform = null, bool enginePlume = false, bool propEngine = false, float frontAspectModifier = 1f, bool occludeHeat = true)
         {
             var layerMask = (int)(LayerMasks.Parts | LayerMasks.EVA | LayerMasks.Wheels);
-
             var hitCount = Physics.RaycastNonAlloc(partRay, hits, distance, layerMask);
             if (hitCount == hits.Length)
             {
@@ -397,8 +396,8 @@ namespace BDArmory.UI
             }
             if (BDArmorySettings.DEBUG_RADAR) Debug.Log("[IRSTdebugging] occlusion found: " + (1 + OcclusionFactor) + "; " + DebugCount + " occluding parts");
             if (OcclusionFactor > 0) heatScore = Mathf.Max(lastHeatscore, heatScore / (1 + OcclusionFactor));
-            if ((OcclusionFactor > 0) || enginePlume || propEngine) heatScore *= frontAspectModifier; // Apply front aspect modifier when heat is being evaluated outside ~50 deg cone of engine exhaust
-
+            //if ((OcclusionFactor > 0) || enginePlume || propEngine) heatScore *= frontAspectModifier; // Apply front aspect modifier when heat is being evaluated outside ~50 deg cone of engine exhaust
+            if ((OcclusionFactor > 0) || propEngine) heatScore *= frontAspectModifier; //enginePlume getting assigned frontAspectMod regardless of orientation? if outside 50deg exhaust cone would already have an OcclusioNFactor > 0
             return heatScore;
         }
 
@@ -524,7 +523,7 @@ namespace BDArmory.UI
                         tInfo = vessel.gameObject.AddComponent<TargetInfo>();
                     }
                     else
-                        return finalData;
+                        return finalData; //shouldn't this be continue, so a non-target, non-WM vessel doesn't prevent scanning viable vessels in the area?
                 }
                 // If no weaponManager or no target or the target is not a missile with engines on..??? and the target weighs less than 50kg, abort.
                 if (mf == null ||
@@ -547,8 +546,8 @@ namespace BDArmory.UI
                         continue;
                 }
 
-                float angle = Vector3.Angle(vessel.CoM - ray.origin, ray.direction);
-
+                //float angle = Vector3.Angle(vessel.CoM - ray.origin, ray.direction); at very close ranges for very narrow sensor Fovs this will cause a problem if the heatsource is an engine plume
+                float angle = Vector3.Angle((priorHeatTarget.exists ? priorHeatTarget.position : vessel.CoM) - ray.origin, ray.direction);
                 if ((angle < scanRadius) || (uncagedLock && !priorHeatTarget.exists)) // Allow allAspect=true missiles to find target outside of seeker FOV before launch
                 {
                     if (RadarUtils.TerrainCheck(ray.origin, vessel.transform.position))
@@ -567,8 +566,9 @@ namespace BDArmory.UI
                     if ((priorHeatScore > 0f) && (angle < scanRadius))
                         score *= GetSeekerBias(angle, Vector3.Angle(vessel.Velocity(), priorHeatTarget.velocity), lockedSensorFOVBias, lockedSensorVelocityBias);
                     score *= Mathf.Clamp(Vector3.Angle(vessel.transform.position - ray.origin, -VectorUtils.GetUpDirection(ray.origin)) / 90, 0.5f, 1.5f);
-                    if ((finalScore > 0f) && (score > 0f) && (priorHeatScore > 0)) // If we were passed a target heat score, look for the most similar non-zero heat score after picking a target
-                    {
+                    //if ((finalScore > 0f) && (score > 0f) && (priorHeatScore > 0)) 
+                    if (score > 0f && priorHeatScore > 0) // If we were passed a target heat score, look for the most similar non-zero heat score after picking a target
+                    { //finalScore will always be 0? only thing that modifies it is below this?
                         if (Mathf.Abs(score - priorHeatScore) < Mathf.Abs(finalScore - priorHeatScore))
                         {
                             finalScore = score;
@@ -602,7 +602,6 @@ namespace BDArmory.UI
             if (finalScore < highpassThreshold)
             {
                 finalData = TargetSignatureData.noTarget;
-
                 if (flareSuccess) // return matching flare
                     return flareData;
                 else //else return the target:

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -3245,6 +3245,7 @@ namespace BDArmory.UI
                             GUI.Label(SLeftSliderRect(++line, 2f), $"{StringUtils.Localize("Thrust")}:  ({(float)Math.Round(BDArmorySettings.HOS_THRUST, 1)}%) Engine Thrust", leftLabel);
                             BDArmorySettings.HOS_THRUST = (GUI.HorizontalSlider(SRightSliderRect(line), (float)Math.Round(BDArmorySettings.HOS_THRUST, 1), 0, 200));
                             BDArmorySettings.HOS_SAS = GUI.Toggle(SLeftRect(++line), BDArmorySettings.HOS_SAS, "Remove Reaction Wheels");
+                            BDArmorySettings.HOS_ASTEROID = GUI.Toggle(SLeftRect(++line), BDArmorySettings.HOS_ASTEROID, "Hunted by Asteroids");
                             GUI.Label(SLeftRect(++line), StringUtils.Localize("--Shame badge--"));
                             HoSTag = GUI.TextField(SLeftRect(++line, 1, true), HoSTag, textFieldStyle);
                             BDArmorySettings.HOS_BADGE = HoSTag;
@@ -3256,6 +3257,7 @@ namespace BDArmory.UI
                             BDArmorySettings.HOS_DMG = 100;
                             BDArmorySettings.HOS_THRUST = 100;
                             BDArmorySettings.HOS_SAS = false;
+                            BDArmorySettings.HOS_ASTEROID = false;
                             //partloss = false; //- would need special module, but could also be a mutator mode
                             //timebomb = false //same
                             //might be more elegant to simply have this use Mutator framework and load the HoS craft with a select mutator(s) instead... Something to look into later, maybe, but ideally this shouldn't need to be used in the first place.

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -1835,6 +1835,18 @@ namespace BDArmory.UI
                     moduleLines += 0.1f;
 
                     numberOfModules = 0;
+
+                    if (ActiveWeaponManager.radars.Count > 0)
+                    {
+                        numberOfModules++;
+                        string Radarlabel = StringUtils.Localize("#LOC_BDArmory_DynamicRadar", (ActiveWeaponManager.targetRandom ? StringUtils.Localize("#LOC_BDArmory_false") : StringUtils.Localize("#LOC_BDArmory_true")));//"Dynamic Radar vs ARMs: True, False
+                        if (GUI.Button(new Rect(leftIndent, +(moduleLines * entryHeight), columnWidth - 2 * leftIndent, entryHeight), Radarlabel, ActiveWeaponManager.targetRandom ? BDGuiSkin.box : BDGuiSkin.button))
+                        {
+                            ActiveWeaponManager.DynamicRadarOverride = !ActiveWeaponManager.DynamicRadarOverride;
+                        }
+                        moduleLines += 1.1f;
+                    }
+
                     //RWR
                     if (ActiveWeaponManager.rwr)
                     {
@@ -3360,8 +3372,11 @@ namespace BDArmory.UI
                             BDArmorySettings.MUTATOR_APPLY_GUNGAME = GUI.Toggle(SLeftRect(++line, 1f), BDArmorySettings.MUTATOR_APPLY_GUNGAME, StringUtils.Localize("#LOC_BDArmory_Settings_MutatorGungame"));
                             BDArmorySettings.MUTATOR_APPLY_GLOBAL = false;
                             BDArmorySettings.MUTATOR_APPLY_TIMER = false;
-                            BDArmorySettings.GG_PERSISTANT_PROGRESSION = GUI.Toggle(SLeftRect(++line), BDArmorySettings.GG_PERSISTANT_PROGRESSION, StringUtils.Localize("#LOC_BDArmory_settings_gungame_progression"));
-                            BDArmorySettings.GG_CYCLE_LIST = GUI.Toggle(SRightRect(line), BDArmorySettings.GG_CYCLE_LIST, StringUtils.Localize("#LOC_BDArmory_settings_gungame_cycle"));
+                            if (BDArmorySettings.MUTATOR_APPLY_GUNGAME)
+                            {
+                                BDArmorySettings.GG_PERSISTANT_PROGRESSION = GUI.Toggle(SLeftRect(++line, 1f), BDArmorySettings.GG_PERSISTANT_PROGRESSION, StringUtils.Localize("#LOC_BDArmory_settings_gungame_progression"));
+                                BDArmorySettings.GG_CYCLE_LIST = GUI.Toggle(SRightRect(line, 1f), BDArmorySettings.GG_CYCLE_LIST, StringUtils.Localize("#LOC_BDArmory_settings_gungame_cycle"));
+                            }
                             if (GUI.Button(SLeftRect(++line), $"{StringUtils.Localize("#LOC_BDArmory_reset")} {StringUtils.Localize("#LOC_BDArmory_Weapons")}")) SpawnUtilsInstance.Instance.gunGameProgress.Clear(); // Clear gun-game progress.
                             if (!MutatorInfo.gunGameConfigured) MutatorInfo.SetupGunGame();
                         }

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -2390,6 +2390,7 @@ namespace BDArmory.UI
                     BDArmorySettings.BULLET_DECALS = BDArmorySettings.BULLET_HITS;
                     BDArmorySettings.EJECT_SHELLS = BDArmorySettings.BULLET_HITS;
                     BDArmorySettings.SHELL_COLLISIONS = BDArmorySettings.BULLET_HITS;
+                    BDArmorySettings.WATER_HIT_FX = BDArmorySettings.BULLET_HITS;
                 }
                 else
                 {
@@ -2397,12 +2398,10 @@ namespace BDArmory.UI
                     if (BDArmorySettings.BULLET_HITS)
                     {
                         BDArmorySettings.BULLET_DECALS = GUI.Toggle(SLeftRect(++line, 1), BDArmorySettings.BULLET_DECALS, StringUtils.Localize("#LOC_BDArmory_Settings_BulletHoleDecals"));//"Bullet Hole Decals"
-                        if (BDArmorySettings.BULLET_HITS)
-                        {
-                            GUI.Label(SLeftSliderRect(++line, 1), $"{StringUtils.Localize("#LOC_BDArmory_Settings_MaxBulletHoles")}:  ({BDArmorySettings.MAX_NUM_BULLET_DECALS})", leftLabel); // Max Bullet Holes
-                            if (BDArmorySettings.MAX_NUM_BULLET_DECALS != (BDArmorySettings.MAX_NUM_BULLET_DECALS = Mathf.RoundToInt(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.MAX_NUM_BULLET_DECALS, 1f, 999f))))
-                                BulletHitFX.AdjustDecalPoolSizes(BDArmorySettings.MAX_NUM_BULLET_DECALS);
-                        }
+                        GUI.Label(SLeftSliderRect(++line, 1), $"{StringUtils.Localize("#LOC_BDArmory_Settings_MaxBulletHoles")}:  ({BDArmorySettings.MAX_NUM_BULLET_DECALS})", leftLabel); // Max Bullet Holes
+                        if (BDArmorySettings.MAX_NUM_BULLET_DECALS != (BDArmorySettings.MAX_NUM_BULLET_DECALS = Mathf.RoundToInt(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.MAX_NUM_BULLET_DECALS, 1f, 999f))))
+                            BulletHitFX.AdjustDecalPoolSizes(BDArmorySettings.MAX_NUM_BULLET_DECALS);
+                        BDArmorySettings.WATER_HIT_FX = GUI.Toggle(SLeftRect(++line, 1), BDArmorySettings.WATER_HIT_FX, StringUtils.Localize("#LOC_BDArmory_Settings_WaterHitFX"));//"Water Hit FX"
                     }
                     BDArmorySettings.EJECT_SHELLS = GUI.Toggle(SLeftRect(++line), BDArmorySettings.EJECT_SHELLS, StringUtils.Localize("#LOC_BDArmory_Settings_EjectShells"));//"Eject Shells"
                     if (BDArmorySettings.EJECT_SHELLS)
@@ -3701,7 +3700,7 @@ namespace BDArmory.UI
 
                 GUI.Label(SLeftSliderRect(++line), $"{StringUtils.Localize("#LOC_BDArmory_Settings_WeaponVolume")}: {(BDArmorySettings.BDARMORY_WEAPONS_VOLUME * 100):0}", leftLabel);//Weapon Volume
                 float weaponVol = BDArmorySettings.BDARMORY_WEAPONS_VOLUME;
-                weaponVol = GUI.HorizontalSlider(SRightSliderRect(line), weaponVol, 0f, 1f);
+                weaponVol = GUI.HorizontalSlider(SRightSliderRect(line), weaponVol, 0f, 2f);
                 if (uiVol != BDArmorySettings.BDARMORY_WEAPONS_VOLUME && OnVolumeChange != null)
                 {
                     OnVolumeChange();

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -750,7 +750,7 @@ namespace BDArmory.UI
                 if (scoreData != null) // This probably won't work if running waypoints in continuous spawning mode, but that probably doesn't work anyway!
                 {
                     if (BDArmorySettings.WAYPOINT_GUARD_INDEX >= 0 && currentScore > 0) VSEntryString.Append($" ({currentScore} hits)");
-                    VSEntryString.Append($"  ({scoreData.totalWPReached:0}, {scoreData.totalWPTime:0.0}s, {scoreData.totalWPDeviation:0.00}m), ");
+                    VSEntryString.Append($"  ({scoreData.totalWPReached:0}, {scoreData.totalWPTime:0.00}s, {scoreData.totalWPDeviation:0.00}m), ");
                 }
             }
             else

--- a/BDArmory/UI/VesselSpawnerWindow.cs
+++ b/BDArmory/UI/VesselSpawnerWindow.cs
@@ -586,7 +586,7 @@ namespace BDArmory.UI
                     BDArmorySettings.WAYPOINTS_ALTITUDE = BDAMath.RoundToUnit(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.WAYPOINTS_ALTITUDE, 0, 1000f), 50f);
 
                     GUI.Label(SLeftSliderRect(++line), $"{StringUtils.Localize("#LOC_BDArmory_WP_MaxLaps")}: {BDArmorySettings.WAYPOINT_LOOP_INDEX:F0}", leftLabel); //max Laps
-                    BDArmorySettings.WAYPOINT_LOOP_INDEX = Mathf.RoundToInt(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.WAYPOINT_LOOP_INDEX, 1, 5));
+                    BDArmorySettings.WAYPOINT_LOOP_INDEX = Mathf.RoundToInt(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.WAYPOINT_LOOP_INDEX, 1, BDArmorySettings.WAYPOINT_MAX_LAPS));
 
                     GUI.Label(SLeftSliderRect(++line), $"{StringUtils.Localize("#LOC_BDArmory_WP_GuardActivate")}: {(BDArmorySettings.WAYPOINT_GUARD_INDEX < 0 ? "Never" : $"{StringUtils.Localize("#LOC_BDArmory_WP_Waypoint")} {BDArmorySettings.WAYPOINT_GUARD_INDEX.ToString("F0")}")}", leftLabel); //Activate Guard After
                     BDArmorySettings.WAYPOINT_GUARD_INDEX = Mathf.RoundToInt(GUI.HorizontalSlider(SRightSliderRect(line), BDArmorySettings.WAYPOINT_GUARD_INDEX, -1, WaypointCourses.highestWaypointIndex));

--- a/BDArmory/Utils/FARUtils.cs
+++ b/BDArmory/Utils/FARUtils.cs
@@ -235,10 +235,10 @@ namespace BDArmory.Utils
                         float width = ((float)PWType.GetField("sharedBaseWidthRoot", BindingFlags.Public | BindingFlags.Instance).GetValue(module) + (float)PWType.GetField("sharedBaseWidthTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module));
                         int edgeLeadingType = Mathf.RoundToInt((float)PWType.GetField("sharedEdgeTypeLeading", BindingFlags.Public | BindingFlags.Instance).GetValue(module));
                         int edgeTrailingType = Mathf.RoundToInt((float)PWType.GetField("sharedEdgeTypeTrailing", BindingFlags.Public | BindingFlags.Instance).GetValue(module));
-                        float edgeWidth = ((!ctrlSrf && edgeLeadingType >= 2 ? 
+                        float edgeWidth = ((ctrlSrf || edgeLeadingType >= 2 ? 
                             ((float)PWType.GetField("sharedEdgeWidthLeadingTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module) +
                         (float)PWType.GetField("sharedEdgeWidthLeadingRoot", BindingFlags.Public | BindingFlags.Instance).GetValue(module)) : 0)     
-                        + (!ctrlSrf && edgeTrailingType >= 2 ? ((float)PWType.GetField("sharedEdgeWidthTrailingTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module) +
+                        + (ctrlSrf || edgeTrailingType >= 2 ? ((float)PWType.GetField("sharedEdgeWidthTrailingTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module) +
                         (float)PWType.GetField("sharedEdgeWidthTrailingRoot", BindingFlags.Public | BindingFlags.Instance).GetValue(module)) : 0));
                         float thickness = 0.18f;
                         float adjustedThickness = 0.18f;
@@ -262,7 +262,7 @@ namespace BDArmory.Utils
                         if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.FARUtils]: Found volume of {aeroVolume} for {part.name}.");
 
                         //if (PWAssyVersion != "0.44.0.0") //PWings now have edge colliders, unnecessary
-                        if ((!BDArmorySettings.PWING_EDGE_LIFT) && !ctrlSrf) //if part !controlsurface, remove lift/mass from edges to bring inline with stock boards
+                        if (!BDArmorySettings.PWING_EDGE_LIFT && !ctrlSrf) //if part !controlsurface, remove lift/mass from edges to bring inline with stock boards
                         {
 							aeroVolume = (0.786f * length * (width / 2) * Mathf.Clamp(adjustedThickness, 0, 0.275f)); //original .7 was based on errorneous 2x4 wingboard dimensions; stock reference wing area is 1.875x3.75m
 							liftCoeff = (length * (width / 2f)) / 3.52f;
@@ -279,7 +279,7 @@ namespace BDArmory.Utils
                         }
                         if (BDArmorySettings.PWING_THICKNESS_AFFECT_MASS_HP)
                         {
-                            liftCoeff *= (1 - ((adjustedThickness - 0.188f) / ((width + (BDArmorySettings.PWING_EDGE_LIFT ? edgeWidth : 0)) / 2))); //adjust lift coeff based on Thickness to Chord Ratio. Loggins lift nerf for spherical/near-spherical wing crossections
+                            liftCoeff *= (1 - ((adjustedThickness - 0.188f) / ((width + ((BDArmorySettings.PWING_EDGE_LIFT || ctrlSrf) ? edgeWidth : 0)) / 2))); //adjust lift coeff based on Thickness to Chord Ratio. Loggins lift nerf for spherical/near-spherical wing crossections
 							if (liftCoeff < 0) liftCoeff = 0;
                             if (HighLogic.LoadedSceneIsFlight) if (Mathf.Abs(Vector3.Dot(part.vessel.ReferenceTransform.up, part.transform.right)) > 0.85) liftCoeff /= 2; //something something a wing rotated 90deg would only be generating body lift due to airfoil now perpendicular to airflow. Loggins pWing body nerf
                             if (HighLogic.LoadedSceneIsEditor) if (Mathf.Abs(Vector3.Dot(EditorLogic.fetch.vesselRotation * Vector3d.up, part.transform.right)) > 0.85) liftCoeff /= 2;
@@ -378,9 +378,9 @@ namespace BDArmory.Utils
                     int edgeLeadingType = Mathf.RoundToInt((float)PWType.GetField("sharedEdgeTypeLeading", BindingFlags.Public | BindingFlags.Instance).GetValue(module));
                     int edgeTrailingType = Mathf.RoundToInt((float)PWType.GetField("sharedEdgeTypeTrailing", BindingFlags.Public | BindingFlags.Instance).GetValue(module));
 
-                    if (BDArmorySettings.PWING_EDGE_LIFT) width += (ctrlSrf ? 0 : (edgeLeadingType >= 2 ? (((float)PWType.GetField("sharedEdgeWidthLeadingTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module) +
+                    if (BDArmorySettings.PWING_EDGE_LIFT) width += ((ctrlSrf || edgeLeadingType >= 2 ? (((float)PWType.GetField("sharedEdgeWidthLeadingTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module) +
                     (float)PWType.GetField("sharedEdgeWidthLeadingRoot", BindingFlags.Public | BindingFlags.Instance).GetValue(module)) / 2) : 0)
-                    + (!ctrlSrf && edgeTrailingType >= 2 ? (((float)PWType.GetField("sharedEdgeWidthTrailingTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module) +
+                    + (ctrlSrf || edgeTrailingType >= 2 ? (((float)PWType.GetField("sharedEdgeWidthTrailingTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module) +
                     (float)PWType.GetField("sharedEdgeWidthTrailingRoot", BindingFlags.Public | BindingFlags.Instance).GetValue(module)) / 2) : 0));
 
                     float area = (2 * (length * width)) + (2 * (width * thickness)) + (2 * (length * thickness));

--- a/BDArmory/Utils/FARUtils.cs
+++ b/BDArmory/Utils/FARUtils.cs
@@ -235,9 +235,9 @@ namespace BDArmory.Utils
                         float width = ((float)PWType.GetField("sharedBaseWidthRoot", BindingFlags.Public | BindingFlags.Instance).GetValue(module) + (float)PWType.GetField("sharedBaseWidthTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module));
                         int edgeLeadingType = Mathf.RoundToInt((float)PWType.GetField("sharedEdgeTypeLeading", BindingFlags.Public | BindingFlags.Instance).GetValue(module));
                         int edgeTrailingType = Mathf.RoundToInt((float)PWType.GetField("sharedEdgeTypeTrailing", BindingFlags.Public | BindingFlags.Instance).GetValue(module));
-                        float edgeWidth = ((ctrlSrf || edgeLeadingType >= 2 ? 
+                        float edgeWidth = ((!ctrlSrf && edgeLeadingType >= 2 ? 
                             ((float)PWType.GetField("sharedEdgeWidthLeadingTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module) +
-                        (float)PWType.GetField("sharedEdgeWidthLeadingRoot", BindingFlags.Public | BindingFlags.Instance).GetValue(module)) : 0)     
+                        (float)PWType.GetField("sharedEdgeWidthLeadingRoot", BindingFlags.Public | BindingFlags.Instance).GetValue(module)) : 0)                            
                         + (ctrlSrf || edgeTrailingType >= 2 ? ((float)PWType.GetField("sharedEdgeWidthTrailingTip", BindingFlags.Public | BindingFlags.Instance).GetValue(module) +
                         (float)PWType.GetField("sharedEdgeWidthTrailingRoot", BindingFlags.Public | BindingFlags.Instance).GetValue(module)) : 0));
                         float thickness = 0.18f;

--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -718,7 +718,7 @@ namespace BDArmory.Weapons.Missiles
                 }
                 else // No target, look straight ahead
                 {
-                    lookRay = new Ray(transform.position, vessel.srf_vel_direction);
+                    lookRay = new Ray(transform.position, MissileReferenceTransform.forward);
                 }
 
                 // Prevent seeker from looking past maxOffBoresight
@@ -727,7 +727,6 @@ namespace BDArmory.Weapons.Missiles
                     lookRay = new Ray(lookRay.origin, Vector3.RotateTowards(lookRay.direction, GetForwardTransform(), (offBoresightAngle - maxOffBoresight) * Mathf.Deg2Rad, 0));
 
                 DrawDebugLine(lookRay.origin, lookRay.origin + lookRay.direction * 10000, Color.magenta);
-
                 // Update heat target
                 if (activeRadarRange < 0)
                     heatTarget = BDATargetManager.GetAcousticTarget(SourceVessel, vessel, lookRay, predictedHeatTarget, lockedSensorFOV / 2, heatThreshold, lockedSensorFOVBias, lockedSensorVelocityBias,

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -1667,7 +1667,26 @@ namespace BDArmory.Weapons
                     }
                 }
             }
+            if (BDArmorySettings.RUNWAY_PROJECT_ROUND == 65)
+            {
+                if (HighLogic.LoadedSceneIsFlight)
+                {
+                    using (var engines = VesselModuleRegistry.GetModuleEngines(vessel).GetEnumerator())
+                        while (engines.MoveNext())
+                        {
+                            if (engines.Current == null) continue;
+                            MultiModeEngine mme = engines.Current.part.FindModuleImplementing<MultiModeEngine>();
+
+                            if (mme && engines.Current.engineID == "Dry") continue;
+                            float engineThrust = engines.Current.maxThrust * (mme != null ? 2 : 1); //AB velCurves tend to be around 2x at ~300m/s, will add extra thrust after initial jousts, but AB engines also capable of faster accel/energy recovery
+                            S6R5dynamicRecoil += Mathf.Max(0f, engineThrust * (engines.Current.thrustPercentage / 100f)); 
+                            Debug.Log("[BDArmory.ModuleWeapon]: S6R5 DynamicRecoil set to : " + Mathf.CeilToInt(S6R5dynamicRecoil * 2));
+                        }
+                }
+            }
         }
+
+private float S6R5dynamicRecoil;
 
         void OnDestroy()
         {
@@ -2072,9 +2091,13 @@ namespace BDArmory.Weapons
                                 //recoil
                                 if (hasRecoil)
                                 {
+                                    if (BDArmorySettings.RUNWAY_PROJECT_ROUND == 65)
+                                        part.rb.AddForceAtPosition(-fireTransform.forward * ((S6R5dynamicRecoil * 2) / (roundsPerMinute/60)),
+                                        fireTransform.position, ForceMode.Impulse);
+                                    else
                                     //doesn't take propellant gass mass into account; GAU-8 should be 44kN, yields 29.9; Vulc should be 14.2, yields ~10.4; GAU-22 16.5, yields 11.9
                                     //Adding a mult of 1.4 brings the GAU8 to 41.8, Vulc to 14.5, GAU-22 to 16.6; not exact, but a reasonably close approximation that looks to scale consistantly across ammos
-                                    part.rb.AddForceAtPosition(((-fireTransform.forward) * (bulletVelocity * (bulletMass * ProjectileCount) / 1000) * 1.4f * BDArmorySettings.RECOIL_FACTOR * recoilReduction),
+                                    part.rb.AddForceAtPosition((-fireTransform.forward * (bulletVelocity * (bulletMass * ProjectileCount) / 1000) * 1.4f * BDArmorySettings.RECOIL_FACTOR * recoilReduction),
                                         fireTransform.position, ForceMode.Impulse);
                                 }
 


### PR DESCRIPTION
-Tweaks to the CourseBuilder; ability to insert gates, camera changes.
-Tweaks to NukeFX lightFX.
-GLOC AI fix so AIs no longer do perma-stun death spirals and instead go dead stick.
-RWP S6R5 thrust-scaled gun recoil mode.
-Add ability to set if radar should shut off for incoming HARMs.
-Add user-customizable max Waypoint Laps.
-Add user-customizable Vengeance Mutator yield and delay.
-WP telemetry now displays time to hundredths of a second.
-Fix kinetic damage to unarmored parts receiving a armor damage reduction.
-Fix AutoTune infinite fuel implementation not working for Firespitter helicopter engines.
-Fix NRE when AI trying to fire a Modular Missile.
-[BDAPersistantSettingField] changed to [BDAPersistantSettingField(RWPFilter = foo)] to permit per-setting filtering of RWPsettings' storing/resetting of BDA settings on KSP load instead of hardcoded blacklist.
-Add offset weapon alignment support so AI can now correctly use Schrage Muzik-esque canted guns/B-wing-esque heavily offset guns where guns are not on/aligned with vessel centerline.