### PR TITLE
make sure unguidedWeapon resets properly

### DIFF
--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -6988,8 +6988,8 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
                             }
                             ml.targetGPSCoords = designatedINSCoords;
                             ml.TargetAcquired = true;
-                            designatedINSCoords = Vector3d.zero;
                         }
+                        designatedINSCoords = Vector3d.zero;
                         break;
                     }
                 default:

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -6981,14 +6981,15 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
                                 {
                                     dumbfire = true;
                                     validTarget = true;
+                                    ml.TargetAcquired = false;
                                 }
                                 else
                                 {
                                     designatedINSCoords = VectorUtils.WorldPositionToGeoCoords(ml.MissileReferenceTransform.position + ml.MissileReferenceTransform.forward * 10000, vessel.mainBody);
                                     ml.targetGPSCoords = designatedINSCoords;
+                                    ml.TargetAcquired = true;
                                 }
-                            }                            
-                            ml.TargetAcquired = true;
+                            }  
                         }
                         designatedINSCoords = Vector3d.zero;
                         break;

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -6973,6 +6973,7 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
                             {
                                 Vector3 TargetLead = MissileGuidance.GetAirToAirFireSolution(ml, targetVessel.CoM, targetVessel.Velocity());
                                 designatedINSCoords = VectorUtils.WorldPositionToGeoCoords(TargetLead, targetVessel.mainBody);
+                                ml.targetGPSCoords = designatedINSCoords;
                             }
                             else
                             {
@@ -6984,9 +6985,9 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
                                 else
                                 {
                                     designatedINSCoords = VectorUtils.WorldPositionToGeoCoords(ml.MissileReferenceTransform.position + ml.MissileReferenceTransform.forward * 10000, vessel.mainBody);
+                                    ml.targetGPSCoords = designatedINSCoords;
                                 }
-                            }
-                            ml.targetGPSCoords = designatedINSCoords;
+                            }                            
                             ml.TargetAcquired = true;
                         }
                         designatedINSCoords = Vector3d.zero;

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2550,8 +2550,8 @@ UI_FloatRange(minValue = 0.1f, maxValue = 10f, stepIncrement = 0.1f, scene = UI_
                         {
                             FireCurrentMissile(ml, true);
                         }
-                        unguidedWeapon = false;
                     }
+                    unguidedWeapon = false;
                 }
                 guardFiringMissile = false;
             }

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -39,6 +39,7 @@ IMPROVEMENTS / FIXES
 		- Fix heatseeking Missiles with very narrow sensorFOVs losing lock right before impact with a target.
 		- Fix manually fired INS missiles using GPS coords if set.
 		- Fix issue with AI fired radar missiles getting stuck and not firing if the first missile fired could not get a lock.
+		- Fix an issue with unguided INS bomb guidance.
 - RWP:
 	- Add S6R5 dynamic recoil gamemode; recoil scales with vessel thrust.
 - ModIntegration:

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -37,6 +37,8 @@ IMPROVEMENTS / FIXES
 		- Nuke LightFX radius now set by effective blast range, not thermalRadius value.
 		- Fix NRE when AI tries to fire Modular Missiles.
 		- Fix heatseeking Missiles with very narrow sensorFOVs losing lock right before impact with a target.
+		- Fix manually fired INS missiles using GPS coords if set.
+		- Fix issue with AI fired radar missiles getting stuck and not firing if the first missile fired could not get a lock.
 - RWP:
 	- Add S6R5 dynamic recoil gamemode; recoil scales with vessel thrust.
 - ModIntegration:


### PR DESCRIPTION
Fix situation where a multiMissileLauncher radar missile that couldn't get a lock and attempts unguided launch wouldn't reset the ``unguidedWeapon`` bool at the end of GuardMissileRoutine, causing future missiles to be improperly considered unguided for the purposes of launch authorization.