### PR TITLE
Bugfixes for windows post build instructions

### DIFF
--- a/BDArmory/BDArmory.csproj
+++ b/BDArmory/BDArmory.csproj
@@ -883,12 +883,12 @@
       @echo set lpath vars from "%25GIT_PATH%25_LocalDev\LocalDev" storage...
       set /p KSP_DIR=&lt;"%25GIT_PATH%25_LocalDev\ksp_dir.txt"
       set /p PDB2MDB_EXE=&lt;"%25GIT_PATH%25_LocalDev\pdb2mdb_exe.txt"
-      set /p ZA_DIR=&lt;"%25GIT_PATH%25_LocalDev\7za_dir.txt"
+      set /p ZA_EXE=&lt;"%25GIT_PATH%25_LocalDev\7za_exe.txt"
       set /p DIST_DIR=&lt;"%25GIT_PATH%25_LocalDev\dist_dir.txt"
 
       @echo Copying assemblies to Distribution $(Targetname) files...
       if not exist "$(ProjectDir)Distribution\GameData\%25ModName%25\Plugins\" mkdir "$(ProjectDir)Distribution\GameData\%25ModName%25\Plugins\"
-      del "$(ProjectDir)Distribution/GameData/${ModName}/Plugins/"BDArmory*
+      del "$(ProjectDir)Distribution/GameData\%25ModName%25\Plugins\"BDArmory*
       xcopy /E /Y "$(TargetDir)"BDArmory*.dll "$(ProjectDir)Distribution\GameData\%25ModName%25\Plugins\"
 
       if $(ConfigurationName) == Debug (
@@ -899,11 +899,11 @@
       @echo deleting previous build ...
       if exist "%25DIST_DIR%25\%25ModName%25.*.zip" del "%25DIST_DIR%25\%25ModName%25.*.zip"
       @echo packaging new build...
-      call "%25ZA_DIR%25\7za.exe" a -tzip -r  "%25DIST_DIR%25\%25ModName%25.@(VersionNumber)_%25DATE:~4,2%25%25DATE:~7,2%25%25DATE:~10,4%25%25time:~0,2%25%25time:~3,2%25.zip" "$(ProjectDir)Distribution\*.*"
+      call "%25ZA_EXE%25" a -tzip -r  "%25DIST_DIR%25\%25ModName%25.@(VersionNumber)_%25DATE:~4,2%25%25DATE:~7,2%25%25DATE:~10,4%25%25time:~0,2%25%25time:~3,2%25.zip" "$(ProjectDir)Distribution\*.*"
 
       @echo Deploy $(ProjectDir) Distribution files to test env:  %25KSP_DIR%25\GameData...
       @echo copying:"$(ProjectDir)Distribution\GameData" to "%25KSP_DIR%25\GameData" 
-      xcopy /E /Y "$(ProjectDir)Distribution\GameData" "%25KSP_DIR%25\GameData"
+      xcopy /E /Y "$(ProjectDir)Distribution\GameData" "%25KSP_DIR%25\GameData\"
 
 
       @echo Build/deploy complete!

--- a/BDArmory/BDArmory.csproj
+++ b/BDArmory/BDArmory.csproj
@@ -888,7 +888,7 @@
 
       @echo Copying assemblies to Distribution $(Targetname) files...
       if not exist "$(ProjectDir)Distribution\GameData\%25ModName%25\Plugins\" mkdir "$(ProjectDir)Distribution\GameData\%25ModName%25\Plugins\"
-      del "$(ProjectDir)Distribution/GameData\%25ModName%25\Plugins\"BDArmory*
+      del "$(ProjectDir)Distribution/GameData/%25ModName%25/Plugins/"BDArmory*
       xcopy /E /Y "$(TargetDir)"BDArmory*.dll "$(ProjectDir)Distribution\GameData\%25ModName%25\Plugins\"
 
       if $(ConfigurationName) == Debug (


### PR DESCRIPTION
- Small bugfixes in the windows_NT post build instructions.
- Changed the 7zip command to remove the hardcoded 7za.exe executable name since the command line executable for windows installs may be named 7z.exe, 7zr.exe or other names by default: https://www.7-zip.org/download.html