### PR TITLE
Evolution engine bugfix for variants being mutated incorrectly

### DIFF
--- a/BDArmory/Evolution/BDAEvolution.cs
+++ b/BDArmory/Evolution/BDAEvolution.cs
@@ -109,6 +109,9 @@ namespace BDArmory.Evolution
 
         private EvolutionState evolutionState = null;
 
+        // Current active variant group (used to render in EvolutionWindow or similar)
+        public VariantGroup ActiveVariantGroup() {return evolutionState.groups.Last();}
+
         private VariantEngine engine = null;
 
         // Spawn settings

--- a/BDArmory/Evolution/BDAEvolution.cs
+++ b/BDArmory/Evolution/BDAEvolution.cs
@@ -378,6 +378,12 @@ namespace BDArmory.Evolution
             var seedName = LoadSeedCraft();
             engine.Configure(craft, weightMapFile);
 
+            // add the original
+            // Note: should be called first before variants are created since there appears to be some mutation operations that are not fully isolated (debugging WIP)
+            // Saving first also allows avoidance of needing to use craft.CreateCopy() for the reference craft
+            var referenceName = string.Format("R{0}", groupId);
+            SaveVariant(craft, referenceName);
+
             // generate dipolar variants for all primary axes
             var mutations = engine.GenerateMutations(BDArmorySettings.EVOLUTION_MUTATIONS_PER_HEAT);
             List<Variant> variants = new List<Variant>();
@@ -390,10 +396,6 @@ namespace BDArmory.Evolution
                 variants.Add(mutation.GetVariant(id.ToString(), name));
                 SaveVariant(newVariant, name);
             }
-
-            // add the original
-            var referenceName = string.Format("R{0}", groupId);
-            SaveVariant(craft.CreateCopy(), referenceName);
 
             // select random adversary
             LoadAdversaryCraft();

--- a/BDArmory/Evolution/BDAEvolution.cs
+++ b/BDArmory/Evolution/BDAEvolution.cs
@@ -419,6 +419,11 @@ namespace BDArmory.Evolution
         {
             var info = new DirectoryInfo(seedDirectory);
             var seeds = info.GetFiles("*.craft").ToList();
+            // TODO:
+            // Pre-existing seed files that are overwritten keep the old creation time
+            // (e.g. if the evolution program is stopped and restarted or started again on a new save) of seeds 
+            // Need to check to make sure previous seed name doesn't exist when saving to avoid this
+            // (can't use file modification time since LastWriteTime is only available on windows NT file systems)
             var latestSeed = seeds.OrderBy(e => e.CreationTimeUtc).Last().Name;
             Debug.Log(string.Format("[BDArmory.BDAEvolution]: Evolution using latest seed: {0}", latestSeed));
             ConfigNode node = ConfigNode.Load(string.Format("{0}/{1}", seedDirectory, latestSeed));

--- a/BDArmory/Evolution/BDAEvolution.cs
+++ b/BDArmory/Evolution/BDAEvolution.cs
@@ -389,8 +389,7 @@ namespace BDArmory.Evolution
             List<Variant> variants = new List<Variant>();
             foreach (var mutation in mutations)
             {
-                ConfigNode newVariant = craft.CreateCopy();
-                mutation.Apply(newVariant, engine);
+                ConfigNode newVariant = mutation.Apply(craft, engine);
                 var id = nextVariantId;
                 var name = GetNextVariantName();
                 variants.Add(mutation.GetVariant(id.ToString(), name));

--- a/BDArmory/Evolution/ControlSurfaceAxisNudgeMutation.cs
+++ b/BDArmory/Evolution/ControlSurfaceAxisNudgeMutation.cs
@@ -27,14 +27,16 @@ namespace BDArmory.Evolution
             this.direction = direction;
         }
 
-        public void Apply(ConfigNode craft, VariantEngine engine)
+        public ConfigNode Apply(ConfigNode craft, VariantEngine engine)
         {
+            ConfigNode mutatedCraft = craft.CreateCopy();
             Debug.Log("[BDArmory.ControlSurfaceAxisNudgeMutation]: Evolution ControlSurfaceNudgeMutation applying");
-            List<ConfigNode> matchingNodes = engine.FindModuleNodes(craft, moduleName);
+            List<ConfigNode> matchingNodes = engine.FindModuleNodes(mutatedCraft, moduleName);
             foreach (var node in matchingNodes)
             {
-                MutateIfNeeded(node, craft, engine);
+                MutateIfNeeded(node, mutatedCraft, engine);
             }
+            return mutatedCraft;
         }
 
         public Variant GetVariant(string id, string name)

--- a/BDArmory/Evolution/ControlSurfaceAxisNudgeMutation.cs
+++ b/BDArmory/Evolution/ControlSurfaceAxisNudgeMutation.cs
@@ -62,7 +62,7 @@ namespace BDArmory.Evolution
             }
             if ((axisMask & MASK_YAW) == MASK_YAW)
             {
-                if (node.HasValue("ignoreRoll") && node.GetValue("ignoreRoll") == "False")
+                if (node.HasValue("ignoreYaw") && node.GetValue("ignoreYaw") == "False")
                 {
                     shouldMutate = true;
                 }

--- a/BDArmory/Evolution/ControlSurfaceNudgeMutation.cs
+++ b/BDArmory/Evolution/ControlSurfaceNudgeMutation.cs
@@ -25,15 +25,23 @@ namespace BDArmory.Evolution
             this.direction = direction;
         }
 
-        public void Apply(ConfigNode craft, VariantEngine engine)
+        public ConfigNode Apply(ConfigNode craft, VariantEngine engine)
         {
+            ConfigNode mutatedCraft = craft.CreateCopy();
+
+            // Build node map of copy
+            Dictionary<string, ConfigNode> mutationNodeMap = engine.BuildNodeMap(mutatedCraft);
+
+            // Apply mutation to all symmetric parts
             Debug.Log("[BDArmory.ControlSurfaceNudgeMutation]: Evolution ControlSurfaceNudgeMutation applying");
             Dictionary<string, ConfigNode> matchingNodeMap = new Dictionary<string, ConfigNode>();
             foreach (var partName in partNames)
             {
-                matchingNodeMap[partName] = engine.GetNode(partName);
+                matchingNodeMap[partName] = engine.GetNode(partName, mutationNodeMap);
             }
-            MutateMap(matchingNodeMap, craft, engine);
+            MutateMap(matchingNodeMap, mutatedCraft, engine);
+
+            return mutatedCraft;
         }
 
         public Variant GetVariant(string id, string name)

--- a/BDArmory/Evolution/EngineGimbalAxisNudgeMutation.cs
+++ b/BDArmory/Evolution/EngineGimbalAxisNudgeMutation.cs
@@ -26,14 +26,16 @@ namespace BDArmory.Evolution
             this.direction = direction;
         }
 
-        public void Apply(ConfigNode craft, VariantEngine engine)
+        public ConfigNode Apply(ConfigNode craft, VariantEngine engine)
         {
+            ConfigNode mutatedCraft = craft.CreateCopy();
             Debug.Log("[BDArmory.EngineGimbalAxisNudgeMutation]: Evolution EngineGimbalNudgeMutation applying");
-            List<ConfigNode> matchingModules = engine.FindModuleNodes(craft, moduleName);
+            List<ConfigNode> matchingModules = engine.FindModuleNodes(mutatedCraft, moduleName);
             foreach (var node in matchingModules)
             {
-                MutateIfNeeded(node, craft, engine);
+                MutateIfNeeded(node, mutatedCraft, engine);
             }
+            return mutatedCraft;
         }
 
         public Variant GetVariant(string id, string name)

--- a/BDArmory/Evolution/EngineGimbalNudgeMutation.cs
+++ b/BDArmory/Evolution/EngineGimbalNudgeMutation.cs
@@ -24,15 +24,23 @@ namespace BDArmory.Evolution
             this.direction = direction;
         }
 
-        public void Apply(ConfigNode craft, VariantEngine engine)
+        public ConfigNode Apply(ConfigNode craft, VariantEngine engine)
         {
+            ConfigNode mutatedCraft = craft.CreateCopy();
+
+            // Build node map of copy
+            Dictionary<string, ConfigNode> mutationNodeMap = engine.BuildNodeMap(mutatedCraft);
+
+            // Apply mutation to all symmetric parts
             Debug.Log("[BDArmory.EngineGimbalNudgeMutation]: Evolution EngineGimbalNudgeMutation applying");
             Dictionary<string, ConfigNode> matchingNodeMap = new Dictionary<string, ConfigNode>();
             foreach (var partName in partNames)
             {
-                matchingNodeMap[partName] = engine.GetNode(partName);
+                matchingNodeMap[partName] = engine.GetNode(partName, mutationNodeMap);
             }
-            MutateMap(matchingNodeMap, craft, engine);
+            MutateMap(matchingNodeMap, mutatedCraft, engine);
+
+            return mutatedCraft;
         }
 
         public Variant GetVariant(string id, string name)

--- a/BDArmory/Evolution/EvolutionWindow.cs
+++ b/BDArmory/Evolution/EvolutionWindow.cs
@@ -5,6 +5,7 @@ using KSP.Localization;
 using BDArmory.Settings;
 using BDArmory.UI;
 using BDArmory.Utils;
+using System.Linq;
 
 namespace BDArmory.Evolution
 {
@@ -165,6 +166,19 @@ namespace BDArmory.Evolution
             }
             GUI.Label(new Rect(_margin + 2 * fifth, offset, 3 * fifth, _lineHeight), statusLine);
             offset += _lineHeight;
+
+            // Display configuration of each variant currently running
+            if (status == EvolutionStatus.RunningTournament)
+            {
+                foreach (var variant in evolution.ActiveVariantGroup().variants)
+                {
+                    // Print a line for the first mutated part to represent that variant. (we don't want one line per symmetry part here, only one line per variant)
+                    var part = variant.mutatedParts.First();
+                    GUI.Label(new Rect(_margin, offset, 5 * fifth, _lineHeight), string.Format("{0}:, {2}: {3}, from: {5} to: {4}, part_id: {1}", variant.name, part.partName, part.moduleName, part.paramName, part.value, part.referenceValue));
+                    offset += _lineHeight;
+                }
+            }
+
             GUI.Label(new Rect(_margin, offset, fifth, _lineHeight), $"{StringUtils.Localize("#LOC_BDArmory_Evolution_Group")}: ");
             GUI.Label(new Rect(_margin + fifth, offset, fifth, _lineHeight), evolution.GroupId.ToString());
             GUI.Label(new Rect(_margin + 2 * fifth, offset, fifth, _lineHeight), $"{StringUtils.Localize("#LOC_BDArmory_Evolution_Heat")}: ");

--- a/BDArmory/Evolution/PilotAIMutation.cs
+++ b/BDArmory/Evolution/PilotAIMutation.cs
@@ -17,9 +17,10 @@ namespace BDArmory.Evolution
             this.value = value;
         }
 
-        public void Apply(ConfigNode craft, VariantEngine engine)
+        public ConfigNode Apply(ConfigNode craft, VariantEngine engine)
         {
-            List<ConfigNode> matchingNodes = engine.FindModuleNodes(craft, moduleName);
+            ConfigNode mutatedCraft = craft.CreateCopy();
+            List<ConfigNode> matchingNodes = engine.FindModuleNodes(mutatedCraft, moduleName);
             if( matchingNodes.Count == 1 )
             {
                 var node = matchingNodes[0];
@@ -27,7 +28,7 @@ namespace BDArmory.Evolution
                 float.TryParse(node.GetValue(paramName), out existingValue);
                 if( engine.MutateNode(node, paramName, value) )
                 {
-                    ConfigNode partNode = engine.FindParentPart(craft, node);
+                    ConfigNode partNode = engine.FindParentPart(mutatedCraft, node);
                     string partName = partNode.GetValue("part");
                     mutatedParts.Add(new MutatedPart(partName, moduleName, paramName, existingValue, value));
                 }
@@ -36,6 +37,7 @@ namespace BDArmory.Evolution
             {
                 Debug.Log("[BDArmory.PilotAIMutation]: Evolution PilotAIMutation wrong number of pilot modules");
             }
+            return mutatedCraft;
         }
 
         public Variant GetVariant(string id, string name)

--- a/BDArmory/Evolution/PilotAINudgeMutation.cs
+++ b/BDArmory/Evolution/PilotAINudgeMutation.cs
@@ -20,10 +20,11 @@ namespace BDArmory.Evolution
             this.direction = direction;
         }
 
-        public void Apply(ConfigNode craft, VariantEngine engine)
+        public ConfigNode Apply(ConfigNode craft, VariantEngine engine)
         {
+            ConfigNode mutatedCraft = craft.CreateCopy();
             Debug.Log("[BDArmory.PilotAINudgeMutation]: Evolution PilotAINudgeMutation applying");
-            List<ConfigNode> matchingNodes = engine.FindModuleNodes(craft, "BDModulePilotAI");
+            List<ConfigNode> matchingNodes = engine.FindModuleNodes(mutatedCraft, "BDModulePilotAI");
             if (matchingNodes.Count == 1)
             {
                 Debug.Log("[BDArmory.PilotAINudgeMutation]: Evolution PilotAINudgeMutation found module");
@@ -33,11 +34,11 @@ namespace BDArmory.Evolution
                 Debug.Log(string.Format("Evolution PilotAINudgeMutation found existing value {0}", existingValue));
                 if (engine.NudgeNode(node, paramName, modifier) )
                 {
-                    ConfigNode partNode = engine.FindParentPart(craft, node);
+                    ConfigNode partNode = engine.FindParentPart(mutatedCraft, node);
                     if( partNode == null )
                     {
                         Debug.Log("[BDArmory.PilotAINudgeMutation]: Evolution PilotAINudgeMutation failed to find parent part for module");
-                        return;
+                        return mutatedCraft;
                     }
                     string partName = partNode.GetValue("part");
                     var value = existingValue * (1 + modifier);
@@ -53,6 +54,7 @@ namespace BDArmory.Evolution
             {
                 Debug.Log("[BDArmory.PilotAINudgeMutation]: Evolution PilotAINudgeMutation wrong number of pilot modules");
             }
+            return mutatedCraft;
         }
 
         public Variant GetVariant(string id, string name)

--- a/BDArmory/Evolution/VariantMutation.cs
+++ b/BDArmory/Evolution/VariantMutation.cs
@@ -5,7 +5,7 @@ namespace BDArmory.Evolution
 {
     public interface VariantMutation
     {
-        public void Apply(ConfigNode craft, VariantEngine engine);
+        public ConfigNode Apply(ConfigNode craft, VariantEngine engine);
         public Variant GetVariant(string id, string name);
     }
 }

--- a/BDArmory/Evolution/WeaponManagerMutation.cs
+++ b/BDArmory/Evolution/WeaponManagerMutation.cs
@@ -21,9 +21,10 @@ namespace BDArmory.Evolution
             this.direction = direction;
         }
 
-        public void Apply(ConfigNode craft, VariantEngine engine)
+        public ConfigNode Apply(ConfigNode craft, VariantEngine engine)
         {
-            List<ConfigNode> matchingNodes = engine.FindModuleNodes(craft, moduleName);
+            ConfigNode mutatedCraft = craft.CreateCopy();
+            List<ConfigNode> matchingNodes = engine.FindModuleNodes(mutatedCraft, moduleName);
             if( matchingNodes.Count == 1 )
             {
                 var node = matchingNodes[0];
@@ -31,7 +32,7 @@ namespace BDArmory.Evolution
                 float.TryParse(node.GetValue(paramName), out existingValue);
                 if( engine.MutateNode(node, paramName, value) )
                 {
-                    ConfigNode partNode = engine.FindParentPart(craft, node);
+                    ConfigNode partNode = engine.FindParentPart(mutatedCraft, node);
                     string partName = partNode.GetValue("part");
                     mutatedParts.Add(new MutatedPart(partName, moduleName, paramName, existingValue, value));
                 }
@@ -40,6 +41,7 @@ namespace BDArmory.Evolution
             {
                 Debug.Log("[BDArmory.WeaponManagerMutation]: Evolution WeaponManagerMutation wrong number of weapon managers");
             }
+            return mutatedCraft;
         }
 
         public Variant GetVariant(string id, string name)

--- a/BDArmory/Evolution/WeaponManagerNudgeMutation.cs
+++ b/BDArmory/Evolution/WeaponManagerNudgeMutation.cs
@@ -21,10 +21,11 @@ namespace BDArmory.Evolution
             this.direction = direction;
         }
 
-        public void Apply(ConfigNode craft, VariantEngine engine)
+        public ConfigNode Apply(ConfigNode craft, VariantEngine engine)
         {
+            ConfigNode mutatedCraft = craft.CreateCopy();
             Debug.Log("[BDArmory.WeaponManagerNudgeMutation]: Evolution WeaponManagerNudgeMutation applying");
-            List<ConfigNode> matchingNodes = engine.FindModuleNodes(craft, "MissileFire");
+            List<ConfigNode> matchingNodes = engine.FindModuleNodes(mutatedCraft, "MissileFire");
             if (matchingNodes.Count == 1)
             {
                 Debug.Log("[BDArmory.WeaponManagerNudgeMutation]: Evolution WeaponManagerNudgeMutation found module");
@@ -34,11 +35,11 @@ namespace BDArmory.Evolution
                 Debug.Log(string.Format("[BDArmory.WeaponManagerNudgeMutation]: Evolution WeaponManagerNudgeMutation found existing value {0} = {1}", paramName, existingValue));
                 if (engine.NudgeNode(node, paramName, modifier))
                 {
-                    ConfigNode partNode = engine.FindParentPart(craft, node);
+                    ConfigNode partNode = engine.FindParentPart(mutatedCraft, node);
                     if( partNode == null )
                     {
                         Debug.Log("[BDArmory.WeaponManagerNudgeMutation]: Evolution WeaponManagerNudgeMutation failed to find parent part for module");
-                        return;
+                        return mutatedCraft;
                     }
                     string partName = partNode.GetValue("part");
                     var value = existingValue * (1 + modifier);
@@ -54,6 +55,7 @@ namespace BDArmory.Evolution
             {
                 Debug.Log("[BDArmory.WeaponManagerNudgeMutation]: Evolution WeaponManagerNudgeMutation wrong number of weapon managers");
             }
+            return mutatedCraft;
         }
 
         public Variant GetVariant(string id, string name)

--- a/BDArmory/Settings/RWPSettings.cs
+++ b/BDArmory/Settings/RWPSettings.cs
@@ -42,16 +42,20 @@ namespace BDArmory.Settings
         {"OUT_OF_AMMO_KILL_TIME", 60},
         {"BATTLEDAMAGE", true},
       }},
+      {17, new(){}},
+      {33, new(){}},
       // Round specific overrides (also overrides global settings).
       {42, new(){ // Fly the Unfriendly Skies
         {"VESSEL_SPAWN_FILL_SEATS", 3},
       }},
+      {44, new(){}},
       {46, new(){ // Vertigo to Jool
         {"NO_ENGINES", true},
       }},
       {50, new(){ // Mach-ing Bird
         {"WAYPOINTS_MODE", true},
       }},
+      {53, new(){}},
       {55, new(){ // Boonta Eve Classic
         {"WAYPOINTS_MODE", true},
       }},
@@ -107,7 +111,11 @@ namespace BDArmory.Settings
         {"MUTATOR_LIST", new List<string>{ "Vengeance" }},
         {"VENGEANCE_DELAY", 3},
         {"VENGEANCE_YIELD", 1.5},
-      }}
+      }},
+      {66, new(){
+        {"OUT_OF_AMMO_KILL_TIME", 0},
+      }},
+      {67, new(){}},
     };
     public static Dictionary<int, int> RWPRoundToIndex = new() { { 0, 0 } }, RWPIndexToRound = new() { { 0, 0 } }; // Helpers for the UI slider.
     static readonly HashSet<string> currentFilter = [];


### PR DESCRIPTION
- Fixes https://github.com/BrettRyland/BDArmory/issues/638
- Adds a short description of the parameter being modified for each variant to the evolution window when a tournament is in progress (this can be removed on request; it was how the bug above was originally discovered)