### PR TITLE
Radar + Missile + Guidance Fixes

### DIFF
--- a/BDArmory/Guidances/MissileGuidance.cs
+++ b/BDArmory/Guidances/MissileGuidance.cs
@@ -193,7 +193,7 @@ namespace BDArmory.Guidances
             // Set up PIP vector
             Vector3 predictedImpactPoint = AIUtils.PredictPosition(targetPosition, targetVelocity, Vector3.zero, leadTime + TimeWarp.fixedDeltaTime);
 
-            float sinTarget = Vector3.Dot((targetPosition - ml.vessel.CoM).normalized, -upDirection); //Vector3.Dot((targetPosition - ml.vessel.CoM), -upDirection) / R;
+            float sinTarget = Vector3.Dot((predictedImpactPoint - ml.vessel.CoM).normalized, -upDirection); //Vector3.Dot((targetPosition - ml.vessel.CoM), -upDirection) / R;
 
             // If still in boost phase
             if ((loftState < MissileBase.LoftStates.Midcourse) && (R > midcourseRange) && (sinTarget < Mathf.Sin(loftTermAngle * Mathf.Deg2Rad)) && (-sinTarget < Mathf.Sin(loftAngle * Mathf.Deg2Rad)))

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -1316,9 +1316,10 @@ namespace BDArmory.Radar
         /// <summary>
         /// Determine for a vesselposition relative to the radar position how much effect the ground clutter factor will have.
         /// </summary>
-        public static float GetRadarGroundClutterModifier(float clutterFactor, Transform referenceTransform, Vector3 position, Vector3 vesselposition, TargetInfo ti)
+        public static float GetRadarGroundClutterModifier(float clutterFactor, Vector3 position, Vector3 vesselposition, TargetInfo ti)
         {
-            Vector3 upVector = referenceTransform.up;
+            //Vector3 upVector = referenceTransform.up;
+            Vector3 upVector = VectorUtils.GetUpDirection(position);
 
             //ground clutter factor when looking down:
             Vector3 targetDirection = (vesselposition - position);
@@ -1426,7 +1427,7 @@ namespace BDArmory.Radar
                         if (radar.sonarMode != ModuleRadar.SonarModes.passive)
                         {
                             signature = (BDArmorySettings.ASPECTED_RCS) ? GetVesselRadarSignatureAtAspect(ti, ray.origin) : ti.radarModifiedSignature;
-                            signature *= GetRadarGroundClutterModifier(radar.radarGroundClutterFactor, radar.referenceTransform, ray.origin, loadedvessels.Current.CoM, ti);
+                            signature *= GetRadarGroundClutterModifier(radar.radarGroundClutterFactor, ray.origin, loadedvessels.Current.CoM, ti);
                             signature *= GetStandoffJammingModifier(radar.vessel, radar.weaponManager.Team, ray.origin, loadedvessels.Current, signature);
                             if (radar.vessel.Splashed && loadedvessels.Current.Splashed) signature *= GetVesselBubbleFactor(radar.transform.position, loadedvessels.Current);
                         }
@@ -1620,7 +1621,7 @@ namespace BDArmory.Radar
                         if (radar.sonarMode != ModuleRadar.SonarModes.passive)    //radar or active soanr
                         {
                             signature = (BDArmorySettings.ASPECTED_RCS) ? GetVesselRadarSignatureAtAspect(ti, position) : ti.radarModifiedSignature;
-                            signature *= GetRadarGroundClutterModifier(radar.radarGroundClutterFactor, referenceTransform, position, loadedvessels.Current.CoM, ti);
+                            signature *= GetRadarGroundClutterModifier(radar.radarGroundClutterFactor, position, loadedvessels.Current.CoM, ti);
                             if (radar.vessel.Splashed && loadedvessels.Current.Splashed) signature *= GetVesselBubbleFactor(radar.transform.position, loadedvessels.Current);
                         }
                         else //passive sonar
@@ -1756,7 +1757,7 @@ namespace BDArmory.Radar
                 // get vessel's radar signature
                 TargetInfo ti = GetVesselRadarSignature(lockedVessel);
                 float signature = (BDArmorySettings.ASPECTED_RCS) ? GetVesselRadarSignatureAtAspect(ti, ray.origin) : ti.radarModifiedSignature;
-                signature *= GetRadarGroundClutterModifier(radar.radarGroundClutterFactor, radar.referenceTransform, ray.origin, lockedVessel.CoM, ti);
+                signature *= GetRadarGroundClutterModifier(radar.radarGroundClutterFactor, ray.origin, lockedVessel.CoM, ti);
                 signature *= ti.radarLockbreakFactor;    //multiply lockbreak factor from active ecm
                 if (radar.weaponManager is not null) signature *= GetStandoffJammingModifier(radar.vessel, radar.weaponManager.Team, ray.origin, lockedVessel, signature);
                 if (radar.vessel.Splashed && lockedVessel.Splashed) signature *= GetVesselBubbleFactor(radar.transform.position, lockedVessel);
@@ -1841,7 +1842,7 @@ namespace BDArmory.Radar
 
                         signature *= Mathf.Clamp(Vector3.Angle(loadedvessels.Current.transform.position - referenceTransform.position, -VectorUtils.GetUpDirection(referenceTransform.position)) / 90, 0.5f, 1.5f);
                         //ground will mask thermal sig                        
-                        signature *= (GetRadarGroundClutterModifier(irst.GroundClutterFactor, irst.referenceTransform, position, loadedvessels.Current.CoM, tInfo) * (tInfo.isSplashed ? 12 : 1));
+                        signature *= (GetRadarGroundClutterModifier(irst.GroundClutterFactor, position, loadedvessels.Current.CoM, tInfo) * (tInfo.isSplashed ? 12 : 1));
                         //cold ocean on the other hand...
 
                         // evaluate range

--- a/BDArmory/Utils/VectorUtils.cs
+++ b/BDArmory/Utils/VectorUtils.cs
@@ -294,7 +294,7 @@ namespace BDArmory.Utils
         public static Vector3 GetUpDirection(Vector3 position)
         {
             if (FlightGlobals.currentMainBody == null) return Vector3.up;
-            return (position - FlightGlobals.currentMainBody.transform.position).normalized;
+            return (position - FlightGlobals.currentMainBody.position).normalized;
         }
 
         public static bool SphereRayIntersect(Ray ray, Vector3 sphereCenter, double sphereRadius, out double distance)

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -2095,9 +2095,9 @@ namespace BDArmory.Weapons.Missiles
 
         bool checkCruiseRangeTrigger()
         {
-            float sqrRange = (this.TargetPosition - this.part.rb.position).sqrMagnitude;
+            float sqrRange = (TargetPosition - part.rb.position).sqrMagnitude;
 
-            if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileLauncher]: Check cruise range trigger range: {Mathf.Sqrt(sqrRange)}");
+            if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileLauncher]: Check cruise range trigger range: {BDAMath.Sqrt(sqrRange)}");
 
             if (sqrRange < cruiseRangeTrigger * cruiseRangeTrigger)
             {
@@ -2113,8 +2113,6 @@ namespace BDArmory.Weapons.Missiles
 
             cruiseTerminationFrames = 0;
             return false;
-
-            //return ((this.TargetPosition - this.part.rb.position).sqrMagnitude < cruiseRangeTrigger * cruiseRangeTrigger);
         }
 
         IEnumerator DeployAnimRoutine()

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -2088,7 +2088,7 @@ namespace BDArmory.Weapons.Missiles
             if (animStates != null) StartCoroutine(FlightAnimRoutine());
             yield return new WaitForSecondsFixed(cruiseDelay);
             if (cruiseRangeTrigger > 0)
-                yield return new WaitUntilFixed(this.checkCruiseRangeTrigger);
+                yield return new WaitUntilFixed(checkCruiseRangeTrigger);
                 
             yield return StartCoroutine(CruiseRoutine());
         }


### PR DESCRIPTION
- Fix radar lookdown modifier function, previously was using vessel up vector rather than planet up vector
- Fix the cruise range based trigger issue where it triggered too early during vessel switching
- Kappa guidance termination based on predicted rather than current position