### PR TITLE
Fractional ammo fix

### DIFF
--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -8516,7 +8516,7 @@ namespace BDArmory.Control
                             {
                                 if (resource.Current == null) continue;
                                 if (resource.Current.resourceName != ammoName) continue;
-                                if (resource.Current.amount > 0)
+                                if (resource.Current.amount >= weapon.requestResourceAmount)
                                 {
                                     return true;
                                 }


### PR DESCRIPTION
- Fix weapons not showing as out of ammo when only fractional amounts of ammo are left.