### PR TITLE
Ammo tweaks

### DIFF
--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -1706,7 +1706,7 @@ namespace BDArmory.Bullets
 
                     if (sBullet.tntMass > 0)// || sBullet.beehive)
                     {
-                        pBullet.explModelPath = explModelPath;
+                        pBullet.explModelPath = sBullet.tntMass > 0.5f ? explModelPath : "BDArmory/Models/explosion/30mmExplosion";
                         pBullet.explSoundPath = explSoundPath;
                         pBullet.tntMass = sBullet.tntMass;
                         if (!sBullet.nuclear)

--- a/BDArmory/Ammo/PooledRocket.cs
+++ b/BDArmory/Ammo/PooledRocket.cs
@@ -1150,7 +1150,7 @@ namespace BDArmory.Bullets
 
                     if (sBullet.tntMass > 0)// || sBullet.beehive)
                     {
-                        pBullet.explModelPath = explModelPath;
+                        pBullet.explModelPath = sBullet.tntMass > 0.5f ? explModelPath : "BDArmory/Models/explosion/30mmExplosion";
                         pBullet.explSoundPath = explSoundPath;
                         pBullet.tntMass = sBullet.tntMass;
                         string HEtype = sBullet.explosive;
@@ -1169,7 +1169,7 @@ namespace BDArmory.Bullets
                                 break;
                         }
                         pBullet.detonationRange = detonationRange;
-                        pBullet.defaultDetonationRange = 1000;
+                        //pBullet.defaultDetonationRange = 1000;
                         pBullet.timeToDetonation = detonationRange / Mathf.Max(1, currentVelocity.magnitude); // Only a short time remaining to the target.
                         pBullet.fuzeType = sFuze;
                     }
@@ -1180,7 +1180,16 @@ namespace BDArmory.Bullets
                         pBullet.HEType = PooledBullet.PooledBulletTypes.Slug;
                     }
                     pBullet.EMP = sBullet.EMP;
-                    pBullet.nuclear = sBullet.nuclear;
+                    if (pBullet.nuclear) // Inherit the parent shell's nuke models.
+                    {
+                        pBullet.flashModelPath = flashModelPath;
+                        pBullet.shockModelPath = shockModelPath;
+                        pBullet.blastModelPath = blastModelPath;
+                        pBullet.plumeModelPath = plumeModelPath;
+                        pBullet.debrisModelPath = debrisModelPath;
+                        pBullet.blastSoundPath = blastSoundPath;
+                    }
+                    pBullet.beehive = false; // No sub-sub-munitions.
                     //pBullet.beehive = sBullet.beehive;
                     //pBullet.subMunitionType = BulletInfo.bullets[sBullet.subMunitionType]; //submunitions of submunitions is a bit silly, and they'd be detonating immediately, due to inherited detonationRange
                     //pBullet.homing = BulletInfo.homing;

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -8516,7 +8516,7 @@ namespace BDArmory.Control
                             {
                                 if (resource.Current == null) continue;
                                 if (resource.Current.resourceName != ammoName) continue;
-                                if (resource.Current.amount > 0)
+                                if (resource.Current.amount >= weapon.requestResourceAmount)
                                 {
                                     return true;
                                 }

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,10 +1,20 @@
-﻿IMPROVEMENTS / FIXES
+﻿- AI:
+	Fix AI not going into Ramming mode when guns possess ammo, but not enough to meet resourceRequestAmount of mounted weapons.
+- Weapons:
+	- Weapons will now properly report Ammo Depleted when ammo remaining is less than amount required to fire.
+	- Fix weapons refusing to fire when one shot left when using multiple ammo boxes with differing starting ammo amounts due to floating point errors.
+	- Explosive beehive submunition explosion FX now scaled based on submunition tntMass, not parent HE VFX.
+	- Fix weapons with reload animations adding an extra 1-20s to the reload time, based on fire anim length.
+	- Add new 'postFireChargeAnim' field for weapons with charge animations to specify if the animation should play in reverse to deactivate the weapon after firing.
+	- Missiles:
+		-Add 'cruiseRangeTrigger' field to Missiles. Missiles using this will delay firing Cruise motor until within set distance to target.
+
+IMPROVEMENTS / FIXES
 - Armor:
 	- Add a max armor limit slider (under General Slider Settings) to limit the max thickness of armor. Default: unclamped.
 - UI:
 	- Team Icon text now scales with icon scale.
 - AI:
-	Fix AI not going into Ramming mode when guns possess ammo, but not enough to meet resourceRequestAmount.
 	Orbital AI:
 		-Adds ability to use sidemounted engiens as RCS thrusters.
 		-Adds Zero-throttle firing range setting that will override maneuvering orientation in favor of pointing ship in attack Vector direction within set distance.
@@ -17,19 +27,12 @@
 - Game Modes:
 	- When resetting asteroid fields, destroy those that have switched SoI as they don't reset properly.
 - Weapons:
-	-Optimizations to bullets, should be a slight performance incrase when firing lots of bullets.
+	- Optimizations to bullets, should be a slight performance increase when firing lots of bullets.
 	- Beehive submunitions with proximity/flak fuzes now properly set fuxe distance based on pellet tntMass, not parent shell's.
 	- Fix nuclear/explosive beehive submnitions not inheriting velocity when detonating on space.
 	- Fix APS going rapid-fire when running out of ammo.
 	- Fix HEAT bullets being reported as Missile damage in the Score parser.
 	- Fix issue with velocity calc that would result in penetrating rounds slowly drifing away from a hit ship in space.
-	- Weapons will now properly report Ammo Depleted when ammo remaining is less than amount required to fire.
-	- Fix weapons refusing to fire when one shot left when using multiple ammo boxes with differeing starting ammo amounts due to floating point errors.
-	- Explosive beehive submunition explosion FX now scaled based on submunition tntMass, not parent HE VFX.
-	- Fix weapons with reload animations adding an extra 1-20s to the reload time, absed on fire anim length.
-	- Add new 'postFireDecharge' field for weaposn with charge animations to specify if the animation should play in reverse to uncharge the weapon after firing.
-	- Missiles:
-		-Add 'cruiseRangeTrigger' field to Missiles. Missiles using this will delay firing Cruise motor until within set distance to target.
 1.7.0.0
 IMPROVEMENTS / FIXES
 - General:

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -4,6 +4,7 @@
 - UI:
 	- Team Icon text now scales with icon scale.
 - AI:
+	Fix AI not going into Ramming mode when guns possess ammo, but not enough to meet resourceRequestAmount.
 	Orbital AI:
 		-Adds ability to use sidemounted engiens as RCS thrusters.
 		-Adds Zero-throttle firing range setting that will override maneuvering orientation in favor of pointing ship in attack Vector direction within set distance.
@@ -21,7 +22,12 @@
 	- Fix nuclear/explosive beehive submnitions not inheriting velocity when detonating on space.
 	- Fix APS going rapid-fire when running out of ammo.
 	- Fix HEAT bullets being reported as Missile damage in the Score parser.
-	-Fix issue with velocity calc that would result in penetrating rounds slowly drifing away from a hit ship in space.
+	- Fix issue with velocity calc that would result in penetrating rounds slowly drifing away from a hit ship in space.
+	- Weapons will now properly report Ammo Depleted when ammo remaining is less than amount required to fire.
+	- Fix weapons refusing to fire when one shot left when using multiple ammo boxes with differeing starting ammo amounts due to floating point errors.
+	- Explosive beehive submunition explosion FX now scaled based on submunition tntMass, not parent HE VFX.
+	- Missiles:
+		-Add 'cruiseRangeTrigger' field to Missiles. Missiles using this will delay firing Cruise motor until within set distance to target.
 1.7.0.0
 IMPROVEMENTS / FIXES
 - General:

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,6 +1,12 @@
+﻿﻿IMPROVEMENTS / FIXES
 ﻿- AI:
 	Fix AI not going into Ramming mode when guns possess ammo, but not enough to meet resourceRequestAmount of mounted weapons.
+- UI:
+	- Improve prevention of click-through of various windows in the editor.
+	- Open sections of the AI GUI now remain open when switching between flight and editor.
 - Weapons:
+	- Adjust bullet tracers to lead up to their current position instead of from their previous position.
+	- Reduce bullet tracer visual glitching due to krakensbane adjustments.
 	- Weapons will now properly report Ammo Depleted when ammo remaining is less than amount required to fire.
 	- Fix weapons refusing to fire when one shot left when using multiple ammo boxes with differing starting ammo amounts due to floating point errors.
 	- Explosive beehive submunition explosion FX now scaled based on submunition tntMass, not parent HE VFX.
@@ -8,31 +14,58 @@
 	- Add new 'postFireChargeAnim' field for weapons with charge animations to specify if the animation should play in reverse to deactivate the weapon after firing.
 	- Missiles:
 		-Add 'cruiseRangeTrigger' field to Missiles. Missiles using this will delay firing Cruise motor until within set distance to target.
+- RWP:
+	- For S6R10, GM kill craft that lack propulsion and are significantly beyond the asteroid field radius.
 
+
+v1.7.1.0
 IMPROVEMENTS / FIXES
+- General:
+	- Add a SimpleRepaint MM patch to ignore incompatible parts.
+	- Fix typos and duplicates in the changelog.
 - Armor:
 	- Add a max armor limit slider (under General Slider Settings) to limit the max thickness of armor. Default: unclamped.
 - UI:
 	- Team Icon text now scales with icon scale.
 - AI:
-	Orbital AI:
-		-Adds ability to use sidemounted engiens as RCS thrusters.
-		-Adds Zero-throttle firing range setting that will override maneuvering orientation in favor of pointing ship in attack Vector direction within set distance.
-		-AI now takes target acceleration/velocity into account when accelerating to engagement speed/killing velocity.
+	- Orbital AI:
+		- Adds ability to use controllable sidemounted engines as RCS thrusters.
+		- Add toggles to disable use of RCS for translation and rotation.
+		- Adds Zero-throttle firing range setting that will override maneuvering orientation in favor of pointing ship in attack Vector direction within set distance.
+		- AI now takes target acceleration/velocity into account when accelerating to engagement speed/killing velocity.
+		- Adjustments to the hasPropulsion check to properly detect when a vessel no longer has propulsion.
 - Detectors / Countermeasures:
 	- Allow higher precision for CM intervals and delays in the WM right-click menu.
+	- Fix invalid C# syntax in the TWS radar .cfg file.
 - Competition:
 	- Auto-generated tournaments use the last used world.
-	- Disable waiting for terrain to settle if the spawn altitude is >10km.
+	- Fix ramming scoring to also work for orbital AI.
 - Game Modes:
-	- When resetting asteroid fields, destroy those that have switched SoI as they don't reset properly.
+	- Sanitise the waypoint course index in the vessel spawner window in case the course list has changed.
+	- Asteroid Field:
+		- When resetting asteroid fields, destroy those that have switched SoI as they don't reset properly.
+		- Adjust the asteroid attraction to be 20% of the field radius instead of hard-coded to 1km.
+		- Fix asteroids not spawning at the correct location in orbit.
+		- Limit motion-reduction force applied to asteroids to a linear function above 1500m/s and the maximum centroidFactor for re-centering asteroids to avoid yeeting them when the average velocity suddenly changes due to vessels dying.
+		- Limit growth of the asteroid pool to twice the requested field size to prevent infinitely growing pool size when there are issues generating new asteroids.
 - Weapons:
 	- Optimizations to bullets, should be a slight performance increase when firing lots of bullets.
 	- Beehive submunitions with proximity/flak fuzes now properly set fuxe distance based on pellet tntMass, not parent shell's.
-	- Fix nuclear/explosive beehive submnitions not inheriting velocity when detonating on space.
+	- Fix nuclear/explosive beehive submunitions not inheriting velocity when detonating on space.
+	- Fix beehive ammo with nuclear submunitions not being able to get the explosion models.
 	- Fix APS going rapid-fire when running out of ammo.
 	- Fix HEAT bullets being reported as Missile damage in the Score parser.
 	- Fix issue with velocity calc that would result in penetrating rounds slowly drifing away from a hit ship in space.
+	- Fix laser hit position not accounting for Krakensbane.
+	- Fix EC usage requirements not appearing in infocards when weapons are using deprecated ECPerShot.
+	- Missiles:
+		- Update the KKV model with fixed textures thanks to Stardust.
+		- Don't evade missiles fired from teammates unless the missile is locked on to craft or craft is in the flight path of the missile.
+		- Log an error if the missile exhaust prefab doesn't exist without breaking OnStart.
+- Spawning:
+	- Disable waiting for terrain to settle if the spawn altitude is >10km.
+	- Add a couple of 30s timeouts to spawning initialisation to avoid a potential soft-lock.
+  
 1.7.0.0
 IMPROVEMENTS / FIXES
 - General:

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -26,6 +26,8 @@
 	- Weapons will now properly report Ammo Depleted when ammo remaining is less than amount required to fire.
 	- Fix weapons refusing to fire when one shot left when using multiple ammo boxes with differeing starting ammo amounts due to floating point errors.
 	- Explosive beehive submunition explosion FX now scaled based on submunition tntMass, not parent HE VFX.
+	- Fix weapons with reload animations adding an extra 1-20s to the reload time, absed on fire anim length.
+	- Add new 'postFireDecharge' field for weaposn with charge animations to specify if the animation should play in reverse to uncharge the weapon after firing.
 	- Missiles:
 		-Add 'cruiseRangeTrigger' field to Missiles. Missiles using this will delay firing Cruise motor until within set distance to target.
 1.7.0.0

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -5668,13 +5668,14 @@ namespace BDArmory.Weapons
         {
             guiStatusString = "Reloading";
             hasCharged = false;
-            float netReloadTime = ReloadTime - (60 / roundsPerMinute) - (postFireDecharge && ChargeTime > 0 ? ChargeTime : 0);
-            yield return new WaitForSecondsFixed(60 / roundsPerMinute); //wait for fire anim to finish.
+            float timeGap = 60 / roundsPerMinute * TimeWarp.CurrentRate
+            float netReloadTime = ReloadTime - timeGap - (postFireDecharge && ChargeTime > 0 ? ChargeTime : 0);
+            yield return new WaitForSecondsFixed(Mathf.Min(timeGap, fireState[0].length / fireAnimSpeed)); //wait for fire anim to finish.
             for (int i = 0; i < fireState.Length; i++)
             {
                 fireState[i].normalizedTime = 0;
                 fireState[i].speed = 0;
-                fireState[i].enabled = false;
+                fireState[i].enabled = false;                
             }
             if (hasChargeAnimation && postFireDecharge)
             {

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -547,7 +547,7 @@ namespace BDArmory.Weapons
         [KSPField]
         public bool ChargeEachShot = true;
         [KSPField]
-        public bool postFireDecharge = false;
+        public bool postFireChargeAnim = false;
         bool hasCharged = false;
         [KSPField]
         public float chargeHoldLength = 1;
@@ -1747,9 +1747,12 @@ namespace BDArmory.Weapons
                         if (pe) EffectBehaviour.RemoveParticleEmitter(pe);
             foreach (var pe in part.FindModelComponents<KSPParticleEmitter>())
                 if (pe) EffectBehaviour.RemoveParticleEmitter(pe);
-            for (int i = 0; i < laserRenderers.Length; i++)
+            if (laserRenderers != null)
             {
-                laserRenderers[i].enabled = false;
+                for (int i = 0; i < laserRenderers.Length; i++)
+                {
+                    laserRenderers[i].enabled = false;
+                }
             }
             BDArmorySetup.OnVolumeChange -= UpdateVolume;
             WeaponNameWindow.OnActionGroupEditorOpened.Remove(OnActionGroupEditorOpened);
@@ -5668,9 +5671,9 @@ namespace BDArmory.Weapons
         {
             guiStatusString = "Reloading";
             hasCharged = false;
-            float timeGap = 60 / roundsPerMinute * TimeWarp.CurrentRate
+            float timeGap = 60 / roundsPerMinute * TimeWarp.CurrentRate;
             float netReloadTime = ReloadTime - timeGap - (postFireDecharge && ChargeTime > 0 ? ChargeTime : 0);
-            yield return new WaitForSecondsFixed(Mathf.Min(timeGap, fireState[0].length / fireAnimSpeed)); //wait for fire anim to finish.
+            yield return new WaitForSecondsFixed(Mathf.Min(timeGap, hasFireAnimation ? fireState[0].length / fireAnimSpeed : 0)); //wait for fire anim to finish.
             for (int i = 0; i < fireState.Length; i++)
             {
                 fireState[i].normalizedTime = 0;


### PR DESCRIPTION
-Fix reload timer length.
-Fix how reload code interacts with chargeable weapons.
-Fix guns not firing when floating point errors result in < 1 ammo due to fractional ammo consumption across multiple boxes, 
-Fix AI getting stuck and not recognizing out of Ammo when vessels have fractional ammo left.
-Set submunitions to use smaller explosionFX unless their tntmass warrants using the parent weapon's (presumably larger, if HE shells also used) config'd explosionFX