### PR TITLE
Auto-disable gimbal for RCS/reverse engines on OAI

### DIFF
--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -1803,7 +1803,7 @@ namespace BDArmory.Control
                     reverseEngines.Add(engine);
                     reverseThrust += engine.MaxThrustOutputVac(true);
                     var gimbal = engine.part.FindModuleImplementing<ModuleGimbal>();
-                    if (gimbal != null) gimbal.gimbalRange = 0; gimbal.gimbalLock = true; // Disable gimbal on reverse/RCS engines since they don't work for directions other than forward
+                    if (gimbal != null) gimbal.gimbalLimiter = 0; gimbal.gimbalLock = true; // Disable gimbal on reverse/RCS engines since they don't work for directions other than forward
                 }
                 else if (EngineRCSRotation || EngineRCSTranslation)
                 {
@@ -1821,7 +1821,7 @@ namespace BDArmory.Control
                         if (engine.independentThrottlePercentage == 0) engine.independentThrottlePercentage = 100;
                     }
                     var gimbal = engine.part.FindModuleImplementing<ModuleGimbal>();
-                    if (gimbal != null) gimbal.gimbalRange = 0; gimbal.gimbalLock = true; // Disable gimbal on reverse/RCS engines since they don't work for directions other than forward
+                    if (gimbal != null) gimbal.gimbalLimiter = 0; gimbal.gimbalLock = true; // Disable gimbal on reverse/RCS engines since they don't work for directions other than forward
                     fc.rcsEngines = rcsEngines;
                 }
             }

--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -1802,6 +1802,8 @@ namespace BDArmory.Control
                 {
                     reverseEngines.Add(engine);
                     reverseThrust += engine.MaxThrustOutputVac(true);
+                    var gimbal = engine.part.FindModuleImplementing<ModuleGimbal>();
+                    if (gimbal != null) gimbal.gimbalLock = true; // Disable gimbal on reverse/RCS engines since they don't work for directions other than forward
                 }
                 else if (EngineRCSRotation || EngineRCSTranslation)
                 {
@@ -1818,6 +1820,8 @@ namespace BDArmory.Control
                         engine.thrustPercentage = 0; //activate and set to 0 thrust so they're ready when needed
                         if (engine.independentThrottlePercentage == 0) engine.independentThrottlePercentage = 100;
                     }
+                    var gimbal = engine.part.FindModuleImplementing<ModuleGimbal>();
+                    if (gimbal != null) gimbal.gimbalLock = true; // Disable gimbal on reverse/RCS engines since they don't work for directions other than forward
                     fc.rcsEngines = rcsEngines;
                 }
             }

--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -1803,7 +1803,11 @@ namespace BDArmory.Control
                     reverseEngines.Add(engine);
                     reverseThrust += engine.MaxThrustOutputVac(true);
                     var gimbal = engine.part.FindModuleImplementing<ModuleGimbal>();
-                    if (gimbal != null) gimbal.gimbalLimiter = 0; gimbal.gimbalLock = true; // Disable gimbal on reverse/RCS engines since they don't work for directions other than forward
+                    if (gimbal != null) // Disable gimbal on reverse/RCS engines since they don't work for directions other than forward
+                    {
+                        gimbal.gimbalRange = 0;
+                        gimbal.gimbalLock = true;
+                    }
                 }
                 else if (EngineRCSRotation || EngineRCSTranslation)
                 {
@@ -1821,7 +1825,11 @@ namespace BDArmory.Control
                         if (engine.independentThrottlePercentage == 0) engine.independentThrottlePercentage = 100;
                     }
                     var gimbal = engine.part.FindModuleImplementing<ModuleGimbal>();
-                    if (gimbal != null) gimbal.gimbalLimiter = 0; gimbal.gimbalLock = true; // Disable gimbal on reverse/RCS engines since they don't work for directions other than forward
+                    if (gimbal != null) // Disable gimbal on reverse/RCS engines since they don't work for directions other than forward
+                    {
+                        gimbal.gimbalRange = 0;
+                        gimbal.gimbalLock = true;
+                    }
                     fc.rcsEngines = rcsEngines;
                 }
             }

--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -1803,7 +1803,7 @@ namespace BDArmory.Control
                     reverseEngines.Add(engine);
                     reverseThrust += engine.MaxThrustOutputVac(true);
                     var gimbal = engine.part.FindModuleImplementing<ModuleGimbal>();
-                    if (gimbal != null) gimbal.gimbalLock = true; // Disable gimbal on reverse/RCS engines since they don't work for directions other than forward
+                    if (gimbal != null) gimbal.gimbalRange = 0; gimbal.gimbalLock = true; // Disable gimbal on reverse/RCS engines since they don't work for directions other than forward
                 }
                 else if (EngineRCSRotation || EngineRCSTranslation)
                 {
@@ -1821,7 +1821,7 @@ namespace BDArmory.Control
                         if (engine.independentThrottlePercentage == 0) engine.independentThrottlePercentage = 100;
                     }
                     var gimbal = engine.part.FindModuleImplementing<ModuleGimbal>();
-                    if (gimbal != null) gimbal.gimbalLock = true; // Disable gimbal on reverse/RCS engines since they don't work for directions other than forward
+                    if (gimbal != null) gimbal.gimbalRange = 0; gimbal.gimbalLock = true; // Disable gimbal on reverse/RCS engines since they don't work for directions other than forward
                     fc.rcsEngines = rcsEngines;
                 }
             }

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,4 +1,6 @@
 ﻿IMPROVEMENTS / FIXES
+- AI:
+	- Orbital AI now automatically disables gimbal on reverse thrust and RCS engines (gimbal directions for these are incorrect).
 - UI:
 	- Improve prevention of click-through of various windows in the editor.
 	- Open sections of the AI GUI now remain open when switching between flight and editor.


### PR DESCRIPTION
- Automatically disable gimbal on reverse/RCS engines for OAI since gimbal doesn't work for directions other than forward