### PR TITLE
Left aligned and tabbed VesselSwitcher text & All VESSELNAMING part tags get updated when parent vessel gets renamed

### DIFF
--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -121,6 +121,8 @@ namespace BDArmory.UI
         public static GUIStyle ButtonStyle;
         public static GUIStyle SelectedButtonStyle;
         public static GUIStyle CloseButtonStyle;
+        public static GUIStyle LButtonStyle;
+        public static GUIStyle LBoxStyle;
 
         //toolbar gui
         public static bool hasAddedButton = false;
@@ -477,6 +479,9 @@ namespace BDArmory.UI
             //setup gui styles
             CloseButtonStyle = new GUIStyle(BDGuiSkin.button) { alignment = TextAnchor.MiddleCenter }; // Configure this one separately since it's static.
             CloseButtonStyle.hover.textColor = Color.red;
+
+            LButtonStyle = new GUIStyle(BDGuiSkin.button) { alignment = TextAnchor.MiddleLeft };
+            LBoxStyle = new GUIStyle(BDGuiSkin.box) { alignment = TextAnchor.MiddleLeft };
 
             ButtonStyle = new GUIStyle(BDGuiSkin.button);
             SelectedButtonStyle = new GUIStyle(BDGuiSkin.button);

--- a/BDArmory/UI/LoadedVesselSwitcher.cs
+++ b/BDArmory/UI/LoadedVesselSwitcher.cs
@@ -685,7 +685,7 @@ namespace BDArmory.UI
                 _offset = _buttonHeight;
             }
             Rect buttonRect = new Rect(_margin + _offset, height, vesselButtonWidth, _buttonHeight);
-            GUIStyle vButtonStyle = team == "IT" ? (wm.vessel.isActiveVessel ? ItVesselSelected : ItVessel) : wm.vessel.isActiveVessel ? BDArmorySetup.BDGuiSkin.box : BDArmorySetup.BDGuiSkin.button;
+            GUIStyle vButtonStyle = team == "IT" ? (wm.vessel.isActiveVessel ? ItVesselSelected : ItVessel) : wm.vessel.isActiveVessel ? BDArmorySetup.LBoxStyle : BDArmorySetup.LButtonStyle;
 
             VSEntryString.Clear();
             string vesselName = wm.vessel.vesselName;
@@ -762,13 +762,13 @@ namespace BDArmory.UI
                 if (currentRamScore > 0) VSEntryString.Append($", {currentRamScore} ram");
                 if (BDArmorySettings.TAG_MODE)
                     VSEntryString.Append($", {(ContinuousSpawning.Instance.vesselsSpawningContinuously ? currentTagTime : currentTagScore):0.0} tag");
-                VSEntryString.Append(")");
+                VSEntryString.Append(")".PadRight(Math.Max(32-VSEntryString.Length,0)));
             }
 
             if (wm.AI != null && wm.AI.currentStatus != null)
             {
                 // postStatus += " " + wm.AI.currentStatus;
-                VSEntryString.Append($" {wm.AI.currentStatus}");
+                VSEntryString.Append($"\t{wm.AI.currentStatus.PadRight(Math.Max(32, wm.AI.currentStatus.Length))}");
             }
             float targetDistance = 5000;
             if (wm.currentTarget != null)
@@ -796,19 +796,19 @@ namespace BDArmory.UI
             if (wm.incomingThreatVessel != null)
             {
                 incomingThreat = true;
-                targetName = $"<<<{wm.incomingThreatVessel.vesselName}";
+                targetName = $" <<<{wm.incomingThreatVessel.vesselName}";
                 targetVessel = wm.incomingThreatVessel;
             }
             else if (wm.currentTarget)
             {
-                targetName = $">>>{wm.currentTarget.Vessel.vesselName}";
+                targetName = $" >>>{wm.currentTarget.Vessel.vesselName}";
                 targetVessel = wm.currentTarget.Vessel;
             }
 
             if (targetName != "")
             {
                 // postStatus += " " + targetName;
-                VSEntryString.Append($" {targetName}");
+                VSEntryString.Append($"\t{targetName}");
             }
 
             /*if (cameraScores.ContainsKey(vesselName))

--- a/BDArmory/VesselSpawning/VesselSpawnerBase.cs
+++ b/BDArmory/VesselSpawning/VesselSpawnerBase.cs
@@ -334,11 +334,11 @@ namespace BDArmory.VesselSpawning
             if (vessel.parts.Count > 0 && count > 0)
             {
                 var appendix = "_" + count;
-                foreach (var part in vessel.Parts.Where(p => p?.vesselNaming?.vesselName.Length > 2))
+                foreach (var part in vessel.Parts.Where(p => p?.vesselNaming?.vesselName.Length > 0))
                 {
                     if (!part.vesselNaming.vesselName.EndsWith(appendix))
                     {
-                        if (BDArmorySettings.DEBUG_SPAWNING) Debug.Log($"[BDArmory.VesselSpawnerBase(KB1)]: VESSELNAMING = {part.vesselNaming.vesselName}; Updating to {part.vesselNaming.vesselName}{appendix}");
+                        if (BDArmorySettings.DEBUG_SPAWNING) Debug.Log($"[BDArmory.VesselSpawnerBase]: VESSELNAMING = {part.vesselNaming.vesselName}; Updating to {part.vesselNaming.vesselName}{appendix}");
                         part.vesselNaming.vesselName = part.vesselNaming.vesselName + appendix;
                     }
                 }


### PR DESCRIPTION
![Screenshot 2025-02-04 225120](https://github.com/user-attachments/assets/9560cb53-ef81-41f5-8ba1-e52a08618887)
Much easier to read

1)  For any vessel that has been renamed at spawn time (count > 0)
2) When parts are loaded, looks for any parts with VESSELNAMING, and append the same _<num> to it, just like was done to rename the vessel.

This way, all child crafts that may detach, already have their VESSELNAMING changed to the same index of the parent vessel that was appended during spawn.  VESSELNAMING should no longer cause KSP to rename the vessel from what BDA changed it to.