### PR TITLE
Bugfixes and Additions

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -13,7 +13,8 @@
 - Sensors:
 	- Add support for slaving turrets via targeting cameras.
 	- Fix 'Slave Turret' button occasionally locking the turret to the vessel's origin point or non-target point in space.
-	- Locking a target will no longer automatically slave active turrets to the target when manually controlling a craft. To slave turrets to a locked radar/camera, use the 'Slave Turret' button. 
+	- Locking a target will no longer automatically slave active turrets to the target when manually controlling a craft. To slave turrets to a locked radar/camera, use the 'Slave Turret' button.
+	- Fix bug that allowed radars to lock on below the radar horizon when the appropriate settings are toggled.
 - Weapons:
 	- Add a "Yaw Standby Angle" slider to gun turrets.
 	- Multi-barreled guns now no longer swap to the next ammo type in the belt until after all barrels have fired.
@@ -26,6 +27,7 @@
 		- Fix check for multi-mode engines being ignited and having fuel.
 		- Fix maddog ARH missile launches not turning on seeker.
 		- Add WeaveUseAGMDescentRatio and WeaveRandomRange to weave guidance, when WeaveUseAGMDescentRatio is true it forces the use of agmDescentRatio to allow for sea-skimming weave missiles. WeaveRandomRange is a float that allows for randomization of weave maneuver parameters.
+		- Fix certain missiles becoming ghost-like entities that ignored bullets and interceptor missiles when fired from MultiMissileLaunchers with "ignoreLauncherColliders = true".
 - Competition:
 	- Add a "defaults" button to the scoring window to reset score weights to their default values.
 	- Updated parsing and plotting scripts.

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -2513,7 +2513,7 @@ namespace BDArmory.Radar
         /// </summary>
         public static bool TerrainCheck(Vector3 start, Vector3 end, CelestialBody body, bool ignoreSetting = false)
         {
-            if (!(BDArmorySettings.CHECK_WATER_TERRAIN || ignoreSetting))
+            if (!BDArmorySettings.CHECK_WATER_TERRAIN || ignoreSetting)
                 return Physics.Linecast(start, end, (int)LayerMasks.Scenery);
 
             if (!Physics.Linecast(start, end, (int)LayerMasks.Scenery))

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -2615,8 +2615,11 @@ namespace BDArmory.Radar
                 sqrRange = (float)(a * u * u);
 
                 // If the point of intersection is further than the range we're checking then just ignore this
-                if (range < 0 && u > 1.0)
-                    return false;
+                if (range < 0)
+                {
+                    if (u > 1.0)
+                        return false;
+                }
                 else if (sqrRange > range * range)
                     return false;
 

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -2511,9 +2511,9 @@ namespace BDArmory.Radar
         /// <summary>
         /// Helper method: check if line intersects terrain OR water
         /// </summary>
-        public static bool TerrainCheck(Vector3 start, Vector3 end, CelestialBody body, bool ignoreSetting = false)
+        public static bool TerrainCheck(Vector3 start, Vector3 end, CelestialBody body, bool forceIgnoreWater = false)
         {
-            if (!BDArmorySettings.CHECK_WATER_TERRAIN || ignoreSetting)
+            if (!BDArmorySettings.CHECK_WATER_TERRAIN || forceIgnoreWater)
                 return Physics.Linecast(start, end, (int)LayerMasks.Scenery);
 
             if (!Physics.Linecast(start, end, (int)LayerMasks.Scenery))
@@ -2529,7 +2529,7 @@ namespace BDArmory.Radar
         /// <summary>
         /// Helper method: check if line intersects terrain and gives range and angle of intersection. Note this check goes to up to sqrRange, though the boolean behavior is still restricted to between start and end
         /// </summary>
-        public static bool TerrainCheck(Vector3 start, Vector3 end, CelestialBody body, float range, out float R, out float angle, bool ignoreSetting = false)
+        public static bool TerrainCheck(Vector3 start, Vector3 end, CelestialBody body, float range, out float R, out float angle, bool forceWaterCheck = false)
         {
             angle = 0f;
             if (!BDArmorySettings.IGNORE_TERRAIN_CHECK)
@@ -2551,7 +2551,7 @@ namespace BDArmory.Radar
                 }
                 else
                 {
-                    if (!(BDArmorySettings.CHECK_WATER_TERRAIN || ignoreSetting))
+                    if (!(BDArmorySettings.CHECK_WATER_TERRAIN || forceWaterCheck))
                     {
                         R = float.MaxValue;
                         return false;

--- a/BDArmory/WeaponMounts/ModuleTurret.cs
+++ b/BDArmory/WeaponMounts/ModuleTurret.cs
@@ -373,8 +373,7 @@ namespace BDArmory.WeaponMounts
         }
         void OnStandbyAngleChanged(BaseField field = null, object obj = null)
         {
-            standbyLocalRotation = Quaternion.AngleAxis(yawStandbyAngle, Vector3.up);
-            if (yawTransform != null) yawTransform.localRotation = standbyLocalRotation;
+            SetStandbyAngle();
             foreach (Part symmetryPart in part.symmetryCounterparts)
             {
                 ModuleTurret symmetryTurret = symmetryPart.FindModuleImplementing<ModuleTurret>();
@@ -387,8 +386,14 @@ namespace BDArmory.WeaponMounts
                     symmetryTurret.yawStandbyAngle = yawStandbyAngle;
                 }
 
-                symmetryTurret.OnStandbyAngleChanged();
+                symmetryTurret.SetStandbyAngle();
             }
+        }
+
+        void SetStandbyAngle()
+        {
+            standbyLocalRotation = Quaternion.AngleAxis(yawStandbyAngle, Vector3.up);
+            if (yawTransform != null) yawTransform.localRotation = standbyLocalRotation;
         }
     }
     public class BDAScaleByDistance : PartModule

--- a/BDArmory/WeaponMounts/ModuleTurret.cs
+++ b/BDArmory/WeaponMounts/ModuleTurret.cs
@@ -5,6 +5,7 @@ using BDArmory.Extensions;
 using BDArmory.Settings;
 using BDArmory.UI;
 using BDArmory.Utils;
+using BDArmory.Weapons.Missiles;
 
 namespace BDArmory.WeaponMounts
 {
@@ -36,7 +37,7 @@ namespace BDArmory.WeaponMounts
         public float yawRange;
 
         [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "#LOC_BDArmory_YawStandbyAngle"),
-         UI_FloatRange(minValue = -90f, maxValue = 90f, stepIncrement = 0.5f, scene = UI_Scene.All)]
+         UI_FloatRange(minValue = -90f, maxValue = 90f, stepIncrement = 0.5f, scene = UI_Scene.All, affectSymCounterparts = UI_Scene.None)]
         public float yawStandbyAngle = 0;
         Quaternion standbyLocalRotation = Quaternion.identity;
 
@@ -375,6 +376,20 @@ namespace BDArmory.WeaponMounts
         {
             standbyLocalRotation = Quaternion.AngleAxis(yawStandbyAngle, Vector3.up);
             if (yawTransform != null) yawTransform.localRotation = standbyLocalRotation;
+            foreach (Part symmetryPart in part.symmetryCounterparts)
+            {
+                ModuleTurret symmetryTurret = symmetryPart.FindModuleImplementing<ModuleTurret>();
+                if (part.symMethod == SymmetryMethod.Mirror)
+                {
+                    symmetryTurret.yawStandbyAngle = -yawStandbyAngle;
+                }
+                else
+                {
+                    symmetryTurret.yawStandbyAngle = yawStandbyAngle;
+                }
+
+                symmetryTurret.OnStandbyAngleChanged();
+            }
         }
     }
     public class BDAScaleByDistance : PartModule

--- a/BDArmory/WeaponMounts/ModuleTurret.cs
+++ b/BDArmory/WeaponMounts/ModuleTurret.cs
@@ -369,29 +369,29 @@ namespace BDArmory.WeaponMounts
             yawStandbyAngleEd.maxValue = yawRange / 2f;
             yawStandbyAngle = Mathf.Clamp(yawStandbyAngle, yawStandbyAngleEd.minValue, yawStandbyAngleEd.maxValue);
             yawStandbyAngleEd.onFieldChanged = OnStandbyAngleChanged;
+            GameEvents.onEditorPartPlaced.Add(OnEditorPartPlaced);
             SetStandbyAngle();
         }
+
+        void OnEditorPartPlaced(Part p = null) { if (p == part) OnStandbyAngleChanged(); }
+
         void OnStandbyAngleChanged(BaseField field = null, object obj = null)
         {
-            if (standbyLocalRotation != null)
-            {
-                foreach (Part symmetryPart in part.symmetryCounterparts)
-                {
-                    ModuleTurret symmetryTurret = symmetryPart.FindModuleImplementing<ModuleTurret>();
-                    if (part.symMethod == SymmetryMethod.Mirror)
-                    {
-                        symmetryTurret.yawStandbyAngle = -yawStandbyAngle;
-                    }
-                    else
-                    {
-                        symmetryTurret.yawStandbyAngle = yawStandbyAngle;
-                    }
-
-                    symmetryTurret.SetStandbyAngle();
-                }
-            }
             SetStandbyAngle();
+            foreach (Part symmetryPart in part.symmetryCounterparts)
+            {
+                ModuleTurret symmetryTurret = symmetryPart.FindModuleImplementing<ModuleTurret>();
+                if (part.symMethod == SymmetryMethod.Mirror)
+                {
+                    symmetryTurret.yawStandbyAngle = -yawStandbyAngle;
+                }
+                else
+                {
+                    symmetryTurret.yawStandbyAngle = yawStandbyAngle;
+                }
 
+                symmetryTurret.SetStandbyAngle();
+            }
         }
 
         void SetStandbyAngle()

--- a/BDArmory/WeaponMounts/ModuleTurret.cs
+++ b/BDArmory/WeaponMounts/ModuleTurret.cs
@@ -5,7 +5,6 @@ using BDArmory.Extensions;
 using BDArmory.Settings;
 using BDArmory.UI;
 using BDArmory.Utils;
-using BDArmory.Weapons.Missiles;
 
 namespace BDArmory.WeaponMounts
 {

--- a/BDArmory/WeaponMounts/ModuleTurret.cs
+++ b/BDArmory/WeaponMounts/ModuleTurret.cs
@@ -38,7 +38,7 @@ namespace BDArmory.WeaponMounts
         [KSPField(isPersistant = true, guiActive = false, guiActiveEditor = true, guiName = "#LOC_BDArmory_YawStandbyAngle"),
          UI_FloatRange(minValue = -90f, maxValue = 90f, stepIncrement = 0.5f, scene = UI_Scene.All, affectSymCounterparts = UI_Scene.None)]
         public float yawStandbyAngle = 0;
-        Quaternion standbyLocalRotation = Quaternion.identity;
+        Quaternion standbyLocalRotation;// = Quaternion.identity;
 
         [KSPField(isPersistant = true)] public float minPitchLimit = 400;
         [KSPField(isPersistant = true)] public float maxPitchLimit = 400;
@@ -369,25 +369,29 @@ namespace BDArmory.WeaponMounts
             yawStandbyAngleEd.maxValue = yawRange / 2f;
             yawStandbyAngle = Mathf.Clamp(yawStandbyAngle, yawStandbyAngleEd.minValue, yawStandbyAngleEd.maxValue);
             yawStandbyAngleEd.onFieldChanged = OnStandbyAngleChanged;
-            OnStandbyAngleChanged();
+            SetStandbyAngle();
         }
         void OnStandbyAngleChanged(BaseField field = null, object obj = null)
         {
-            SetStandbyAngle();
-            foreach (Part symmetryPart in part.symmetryCounterparts)
+            if (standbyLocalRotation != null)
             {
-                ModuleTurret symmetryTurret = symmetryPart.FindModuleImplementing<ModuleTurret>();
-                if (part.symMethod == SymmetryMethod.Mirror)
+                foreach (Part symmetryPart in part.symmetryCounterparts)
                 {
-                    symmetryTurret.yawStandbyAngle = -yawStandbyAngle;
-                }
-                else
-                {
-                    symmetryTurret.yawStandbyAngle = yawStandbyAngle;
-                }
+                    ModuleTurret symmetryTurret = symmetryPart.FindModuleImplementing<ModuleTurret>();
+                    if (part.symMethod == SymmetryMethod.Mirror)
+                    {
+                        symmetryTurret.yawStandbyAngle = -yawStandbyAngle;
+                    }
+                    else
+                    {
+                        symmetryTurret.yawStandbyAngle = yawStandbyAngle;
+                    }
 
-                symmetryTurret.SetStandbyAngle();
+                    symmetryTurret.SetStandbyAngle();
+                }
             }
+            SetStandbyAngle();
+
         }
 
         void SetStandbyAngle()

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -2387,14 +2387,15 @@ namespace BDArmory.Weapons.Missiles
         {
             yield return new WaitForSecondsFixed(0.5f); //wait half sec after boost motor fires, then set crashTolerance to 1. Torps have already waited until splashdown before this is called.
             part.crashTolerance = 1;
-            var missileCOL = part.collider;
             if (useSimpleDragTemp)
             {
                 yield return new WaitForSecondsFixed((clearanceLength * 1.2f) / 2);
                 part.dragModel = Part.DragModel.DEFAULT;
                 useSimpleDragTemp = false;
             }
-            if (missileCOL) missileCOL.enabled = true;
+            var childColliders = part.GetComponentsInChildren<Collider>(includeInactive: false);
+            foreach (var col in childColliders)
+                col.enabled = true;
 
         }
         IEnumerator BoostRoutine()


### PR DESCRIPTION
- Fix radar terrain check issues with regards to water on certain radars
- Improve water check by using doubles since body center is going to be far from the camera, important for cases like RSS
- Fix certain missile colliders disabled by MultiMissileLauncher's ignoreLauncherColliders setting not being re-enabled after launch, resulting in ghost-like missiles for some models
- Implement yawStandbyAngle mirroring for mirror symmetry
- Fix ambiguous variable names in RadarUtils that could potentially have caused confusion