### PR TITLE
Multi-Craft Radar Stuff + Some FX Stuff

### DIFF
--- a/BDArmory/Ammo/PooledRocket.cs
+++ b/BDArmory/Ammo/PooledRocket.cs
@@ -158,7 +158,7 @@ namespace BDArmory.Bullets
             transform.rotation = transform.parent.rotation;
             startTime = Time.time;
             armingTime = isSubProjectile ? 0 : BDAMath.Sqrt(4 * blastRadius * rocketMass / thrust); // d = a/2 * t^2 for initial 0 relative velocity
-            if (FlightGlobals.getAltitudeAtPos(currentPosition) < 0)
+            if (FlightGlobals.currentMainBody.ocean && FlightGlobals.getAltitudeAtPos(currentPosition) < 0)
             {
                 startUnderwater = true;
             }
@@ -314,12 +314,12 @@ namespace BDArmory.Bullets
 
             if (BDArmorySettings.BULLET_WATER_DRAG)
             {
-                if (FlightGlobals.getAltitudeAtPos(currentPosition) > 0 && startUnderwater)
+                if (FlightGlobals.currentMainBody.ocean && FlightGlobals.getAltitudeAtPos(currentPosition) > 0 && startUnderwater)
                 {
                     startUnderwater = false;
                     if (BDArmorySettings.waterHitEffect) FXMonger.Splash(currentPosition, caliber);
                 }
-                if (FlightGlobals.getAltitudeAtPos(currentPosition) <= 0 && !startUnderwater)
+                if (FlightGlobals.currentMainBody.ocean && FlightGlobals.getAltitudeAtPos(currentPosition) <= 0 && !startUnderwater)
                 {
                     if (tntMass > 0) //look into fuze options similar to bullets?
                     {

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -66,6 +66,7 @@
   - Weapons fire SFX maximum distance it can be heard now scales based on weapon caliber
 	- Added fuzeDelay and fuzeSensitivity functionality to bullets. Now, for penetrating and delay fuzes you can specify the fuze delay in seconds, and the fuze sensitivity in mm for penetrating fuzes, by listing them with commas, I.E. "fuzeType = Penetrating,0.01,20" for a 0.01 s delay which will be set off by 20 mm of armor (currently material differences are not considered).
 	- Fix bullet behavior when hitting parts with multiple colliders embedded in each other, bullets should now only hit such a part once, unless it exits the part and then hits the part again. Note the system in place cannot catch cases where another part is clipped in such a part.
+	- Fix phantom water on planets without oceans
 	- Added stack attachment nodes to all turret bases.
 	- Sanity-checked turret bulkhead sizes.
 	- Missiles:
@@ -109,6 +110,10 @@
 			- Fix certain missiles becoming ghost-like entities that ignored bullets and interceptor missiles when fired from MultiMissileLaunchers with "ignoreLauncherColliders = true".
 			- Added "Lofted Aimpoint" toggle to Missile Turrets, with the accompanying "Loft Velocity Factor". When toggled on, the turret will aim above the target to provide some lofting to the missile trajectory (though this requires the usage of pronav and a gain schedule). "Loft Velocity Factor" is used to scale the missile's "optimimumVelocity" for the ballistic simulation, a lower "Loft Velocity Factor" results in a higher loft angle.
 			- Added new "deployBlocksPitch", "deployBlocksYaw" and "deployBlocksReload" booleans to Missile Turrets, when toggled on, the turret will have to finish it's deploy animation before pitching/yawing, and will have to retract for reloading (respecting the pitch and yaw toggles as well).
+- Effects:
+	- Add splash effects to underwater explosions (very WIP, feedback on size, behavior etc. would be appreciated)
+	- Bullet hits now attached to whatever collider they hit, so bullet hits on animated parts, like turrets, will now move with them
+	- Fix floating bullet hits from explosions (note this does NOT fix decals floating due to collider issues, that's a problem with the part model)
 - GameModes:
 	- Don't spawn new asteroids in asteroid rain mode while in high time-warp.
 - Competition:

--- a/BDArmory/FX/BulletHitFX.cs
+++ b/BDArmory/FX/BulletHitFX.cs
@@ -34,7 +34,10 @@ namespace BDArmory.FX
             parentPart = hitPart;
             // parentPartName = parentPart.name;
             // parentVesselName = parentPart.vessel.vesselName;
-            transform.SetParent(hitPart.transform);
+            // I assume the hit.collider should always exist, in any case, perform a null check for the
+            // transform and use it for SetParent if possible in order to account for things like turrets
+            // and other moving parts
+            transform.SetParent(hit.collider.transform ? hit.collider.transform : hitPart.transform);
             transform.position = hit.point + offset;
             transform.rotation = Quaternion.FromToRotation(Vector3.forward, hit.normal);
             parentPart.OnJustAboutToDie += OnParentDestroy;

--- a/BDArmory/FX/BulletHitFX.cs
+++ b/BDArmory/FX/BulletHitFX.cs
@@ -28,7 +28,7 @@ namespace BDArmory.FX
             return ObjectPool.CreateObjectPool(template, BDArmorySettings.MAX_NUM_BULLET_DECALS, false, true, 0, true);
         }
 
-        public void AttachAt(Part hitPart, RaycastHit hit, Vector3 offset)
+        public void AttachAt(Part hitPart, RaycastHit hit, Vector3 offset, bool applyVelCorrection)
         {
             if (hitPart is null) return;
             parentPart = hitPart;
@@ -37,8 +37,8 @@ namespace BDArmory.FX
             // I assume the hit.collider should always exist, in any case, perform a null check for the
             // transform and use it for SetParent if possible in order to account for things like turrets
             // and other moving parts
-            transform.SetParent(hit.collider.transform ? hit.collider.transform : hitPart.transform);
-            transform.position = hit.point + offset;
+            transform.SetParent(hit.collider.transform ?? hitPart.transform);
+            transform.position = hit.point + (applyVelCorrection ? offset + (hitPart.rb.velocity + BDKrakensbane.FrameVelocityV3f) * TimeWarp.fixedDeltaTime : offset);
             transform.rotation = Quaternion.FromToRotation(Vector3.forward, hit.normal);
             parentPart.OnJustAboutToDie += OnParentDestroy;
             parentPart.OnJustAboutToBeDestroyed += OnParentDestroy;
@@ -218,7 +218,7 @@ namespace BDArmory.FX
             }
         }
 
-        public static void SpawnDecal(RaycastHit hit, Part hitPart, float caliber, float penetrationfactor, string team)
+        public static void SpawnDecal(RaycastHit hit, Part hitPart, float caliber, float penetrationfactor, string team, bool applyVelCorrection)
         {
             if (!BDArmorySettings.BULLET_DECALS) return;
             ObjectPool decalPool_;
@@ -256,7 +256,7 @@ namespace BDArmory.FX
             if (decalFront != null && hitPart != null)
             {
                 var decal = decalFront.GetComponentInChildren<Decal>();
-                decal.AttachAt(hitPart, hit, new Vector3(0.25f, 0f, 0f));
+                decal.AttachAt(hitPart, hit, new Vector3(0.25f, 0f, 0f), applyVelCorrection);
 
                 if (BDArmorySettings.PAINTBALL_MODE)
                 {
@@ -273,7 +273,7 @@ namespace BDArmory.FX
                 if (decalBack != null && hitPart != null)
                 {
                     var decal = decalBack.GetComponentInChildren<Decal>();
-                    decal.AttachAt(hitPart, hit, new Vector3(-0.25f, 0f, 0f));
+                    decal.AttachAt(hitPart, hit, new Vector3(-0.25f, 0f, 0f), applyVelCorrection);
                 }
             }
         }
@@ -427,7 +427,7 @@ namespace BDArmory.FX
             }
         }
 
-        public static void CreateBulletHit(Part hitPart, Vector3 position, RaycastHit hit, Vector3 normalDirection, bool ricochet, float caliber, float penetrationfactor, string team)
+        public static void CreateBulletHit(Part hitPart, Vector3 position, RaycastHit hit, Vector3 normalDirection, bool ricochet, float caliber, float penetrationfactor, string team, bool applyVelCorrection = false)
         {
             if (decalPool_large == null || decalPool_small == null)
                 SetupShellPool();
@@ -438,7 +438,7 @@ namespace BDArmory.FX
 
             if ((hitPart != null) && caliber != 0 && !hitPart.IgnoreDecal())
             {
-                SpawnDecal(hit, hitPart, caliber, penetrationfactor, team); //No bullet decals for laser or ricochet                
+                SpawnDecal(hit, hitPart, caliber, penetrationfactor, team, applyVelCorrection); //No bullet decals for laser or ricochet                
             }
 
             GameObject newExplosion = (caliber <= 30 || BDArmorySettings.PAINTBALL_MODE) ? bulletHitFXPool.GetPooledObject() : penetrationFXPool.GetPooledObject();

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -147,6 +147,12 @@ namespace BDArmory.FX
             //LightFx = gameObject.GetComponent<Light>();
             //LightFx.range = BDArmorySettings.LIGHTFX ? 0 : Range * 3f;
             //LightFx.intensity = BDArmorySettings.LIGHTFX ? 0 : 8f; // Reset light intensity.
+            if (BDArmorySettings.waterHitEffect && FlightGlobals.currentMainBody.ocean)
+            {
+                Vector3 up = VectorUtils.GetUpDirection(Position, out double alt);
+                if (alt < 0 && (Power > 100f || alt < 2f * Range))
+                    FXMonger.Splash(Position - up * (float)alt, 20f * Power);
+            }
 
             audioSource = gameObject.GetComponent<AudioSource>();
             // if (ExSound == null)

--- a/BDArmory/FX/ExplosionFX.cs
+++ b/BDArmory/FX/ExplosionFX.cs
@@ -1103,7 +1103,7 @@ namespace BDArmory.FX
 
                                 if (penetrationFactor > 0)
                                 {
-                                    BulletHitFX.CreateBulletHit(part, eventToExecute.HitPoint, eventToExecute.Hit, eventToExecute.Hit.normal, true, Caliber, penetrationFactor > 0 ? penetrationFactor : 0f, null);
+                                    BulletHitFX.CreateBulletHit(part, eventToExecute.HitPoint, eventToExecute.Hit, eventToExecute.Hit.normal, true, Caliber, penetrationFactor > 0 ? penetrationFactor : 0f, null, true);
                                     damage = part.AddBallisticDamage(warheadType == WarheadTypes.ShapedCharge ? Power * 0.0555f : ProjMass, Caliber, 1f, penetrationFactor, dmgMult,
                                         warheadType switch
                                         {

--- a/BDArmory/Radar/VesselRadarData.cs
+++ b/BDArmory/Radar/VesselRadarData.cs
@@ -306,6 +306,7 @@ namespace BDArmory.Radar
         public bool linkCapabilityDirty;
         public bool rangeCapabilityDirty;
         public bool radarsReady;
+        public bool queueLinks = false;
 
         private void Awake()
         {
@@ -747,6 +748,9 @@ namespace BDArmory.Radar
                 UpdateRangeCapability();
                 rangeCapabilityDirty = false;
             }
+
+            if (queueLinks && canReceiveRadarData)
+                LinkAllRadars();
 
             drawGUI = (HighLogic.LoadedSceneIsFlight && FlightGlobals.ready && !vessel.packed && rCount + iCount > 0 &&
                        vessel.isActiveVessel && BDArmorySetup.GAME_UI_ENABLED && !MapView.MapIsEnabled);
@@ -1520,6 +1524,7 @@ namespace BDArmory.Radar
                     LinkVRD(v.Current);
             }
             v.Dispose();
+            queueLinks = false;
         }
 
         public void RemoveDataFromRadar(ModuleRadar radar)

--- a/BDArmory/Utils/VectorUtils.cs
+++ b/BDArmory/Utils/VectorUtils.cs
@@ -298,6 +298,27 @@ namespace BDArmory.Utils
             return (position - FlightGlobals.currentMainBody.position).normalized;
         }
 
+        /// <summary>
+        /// Get the up direction and altitude at a position.
+        /// Note: If the position is a vessel's position, then this is the same as vessel.up and vessel.altitude, which are precomputed. Use those instead!
+        /// </summary>
+        /// <param name="position"></param>
+        /// <param name="altitude"></param>
+        /// <returns>The normalized up direction at the position.</returns>
+        public static Vector3 GetUpDirection(Vector3 position, out double altitude)
+        {
+            if (FlightGlobals.currentMainBody == null)
+            {
+                altitude = 0;
+                return Vector3.up;
+            }
+            Vector3 upDir;
+            (altitude, upDir) = (position - FlightGlobals.currentMainBody.position).MagNorm();
+            altitude -= FlightGlobals.currentMainBody.Radius;
+
+            return upDir;
+        }
+
         public static bool SphereRayIntersect(Ray ray, Vector3 sphereCenter, double sphereRadius, out double distance)
         {
             Vector3 o = ray.origin;

--- a/BDArmory/Utils/VesselModuleRegistry.cs
+++ b/BDArmory/Utils/VesselModuleRegistry.cs
@@ -1173,6 +1173,7 @@ namespace BDArmory.Utils
                     if (BDACompetitionMode.Instance.competitionIsActive)
                         BDACompetitionMode.Instance.AddToCompetitionWhenReady(WM, false); // We've already set the AI/WM state, so don't go weapons-free when adding them to the competition.
                     IsFighter = true; // Detached craft are "fighters".
+                    WM.CheckMissiles();
                     WM.ParentWM = null; // Clear the parent WM at the end of frame in case the WM is not on the root part since losing the root part will trigger OnLoadVessel again.
                 }
             }

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -845,6 +845,7 @@ namespace BDArmory.Weapons.Missiles
             }
             if (warheadType == WarheadTypes.Kinetic && blastPower > 0) warheadType = WarheadTypes.Legacy;
 
+            // Get maxOffboresight here because MMLs won't have the correct value for this if this is done in SetFields()
             string maxOffboresightString = ConfigNodeUtils.FindPartModuleConfigNodeValue(part.partInfo.partConfig, "MissileLauncher", "maxOffBoresight");
             if (!string.IsNullOrEmpty(maxOffboresightString)) // Use the default value from the MM patch.
             {
@@ -964,6 +965,7 @@ namespace BDArmory.Weapons.Missiles
                 Fields["dropTime"].guiActiveEditor = true;
             }
 
+            // Moved mFA setting here instead of OnStart() to account for the need for this to be set for MMLs as well
             if (maxOffBoresight < 360 && missileType.ToLower() == "missile" || missileType.ToLower() == "torpedo")
             {
                 UI_FloatRange mFA = (UI_FloatRange)Fields["missileFireAngle"].uiControlEditor;

--- a/BDArmory/Weapons/Missiles/ModuleMissileRearm.cs
+++ b/BDArmory/Weapons/Missiles/ModuleMissileRearm.cs
@@ -192,6 +192,7 @@ UI_ProgressBar(affectSymCounterparts = UI_Scene.None, controlEnabled = false, sc
 
             if (MML != null && !MML.isClusterMissile)
             {
+                // Parse maxOffboresight here instead of in MML since we're getting the partPrefab here anyways
                 string maxOffboresightString = ConfigNodeUtils.FindPartModuleConfigNodeValue(missilePart.partPrefab.partInfo.partConfig, "MissileLauncher", "maxOffBoresight");
                 if (!string.IsNullOrEmpty(maxOffboresightString)) // Use the default value from the MM patch.
                 {

--- a/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MultiMissileLauncher.cs
@@ -356,9 +356,12 @@ namespace BDArmory.Weapons.Missiles
 
         public void updateMaxOffBoresight(float maxOffBoresight)
         {
+            // Need to update the maxOffBoresight value with the value from ModuleMissileRearm
+            // except for in the case of this being a cluster missile
             if (isClusterMissile)
                 return;
 
+            // Have to wait until missileLauncher is loaded before doing this
             StartCoroutine(UpdateMaxOffBoresightRoutine(maxOffBoresight));
         }
 


### PR DESCRIPTION
- Swap VRD for radars as necessary due to any multi-craft launches and add enabled radars to the VRD
- Only perform `LinkAllRadars()` once (reducing unnecessary code execution). NOTE: as a side effect it delays the `LinkAllRadars()` execution by one FixedUpdate
- Give multi-craft child craft command of any launched missiles using an on-board radar
- `BulletHitFX` now applied to whatever collider it hits instead of to the part's base transform ensuring they move with any animated part
- Account for vessel velocity in `BulletHitFX`, specifically for those applied by `ExplosionFX` as these are delayed by one frame
- Add ocean checks for splash effects and underwater logic, because bullets and rockets can't splash / go underwater if there isn't any water to begin with
- Add splash effects to underwater explosions (WIP, based it off of bullet logic but the size of the splash might need tuning) primarily for ASW stuff. Maybe needs depth based scaling?
