### PR TITLE
EMP Paintball fix

### DIFF
--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -1108,9 +1108,9 @@ namespace BDArmory.Bullets
                 {
                     emp = (ModuleDrainEC)hitPart.vessel.rootPart.AddModule("ModuleDrainEC");
                     var MB = hitPart.vessel.rootPart.FindModuleImplementing<MissileBase>();
-                    if (MB != null) emp.EMPThreshold = 10;
+                    if (MB != null) emp.isMissile = true;
                 }
-                emp.incomingDamage += (caliber * Mathf.Clamp(bulletMass - tntMass, 0.1f, 101)); //soft EMP caps at 100; can always add a EMP amount value to bulletcfg later, but this should work for now
+                emp.incomingDamage += (caliber * Mathf.Clamp(bulletMass - tntMass, 0.1f, 101)) * BDArmorySettings.DMG_MULTIPLIER; //soft EMP caps at 100; can always add a EMP amount value to bulletcfg later, but this should work for now
                 emp.softEMP = true;
             }
             if (impulse != 0 && hitPart.rb != null)

--- a/BDArmory/Ammo/PooledRocket.cs
+++ b/BDArmory/Ammo/PooledRocket.cs
@@ -1042,9 +1042,9 @@ namespace BDArmory.Bullets
                                             {
                                                 MDEC = (ModuleDrainEC)partHit.vessel.rootPart.AddModule("ModuleDrainEC");
                                                 var MB = partHit.vessel.rootPart.FindModuleImplementing<MissileBase>();
-                                                if (MB != null) MDEC.EMPThreshold = 10;
+                                                if (MB != null) MDEC.isMissile = true;
                                             }
-                                            MDEC.incomingDamage = (25 - distance) * 5; //this way craft at edge of blast might only get disabled instead of bricked
+                                            MDEC.incomingDamage = (25 - distance) * 5 * BDArmorySettings.DMG_MULTIPLIER; //this way craft at edge of blast might only get disabled instead of bricked
                                             MDEC.softEMP = false; //can bypass EMP damage cap                                            
                                         }
                                         if (choker)

--- a/BDArmory/Weapons/ModuleEMP.cs
+++ b/BDArmory/Weapons/ModuleEMP.cs
@@ -48,9 +48,9 @@ namespace BDArmory.Weapons
                         {
                             emp = (ModuleDrainEC)v.rootPart.AddModule("ModuleDrainEC");
                             var MB = v.rootPart.FindModuleImplementing<MissileBase>();
-                            if (MB != null) emp.EMPThreshold = 10;
+                            if (MB != null) emp.isMissile = true;
                         }
-                        emp.incomingDamage += ((proximity - (float)targetDistance) * 10); //this way craft at edge of blast might only get disabled instead of bricked
+                        emp.incomingDamage += ((proximity - (float)targetDistance) * 10) * BDArmorySettings.DMG_MULTIPLIER; //this way craft at edge of blast might only get disabled instead of bricked
                         emp.softEMP = AllowReboot; //can bypass DMP damage cap
                     }
                 }

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -2586,7 +2586,7 @@ namespace BDArmory.Weapons
                                                     emp = (ModuleDrainEC)p.vessel.rootPart.AddModule("ModuleDrainEC");
                                                     //Debug.Log($"[BDArmory.ModuleWeapon]: EMP Module added to {p.vessel.GetName()}: {p.vessel.rootPart.partInfo.title}");
                                                     var MB = p.vessel.rootPart.FindModuleImplementing<MissileBase>();
-                                                    if (MB != null) emp.EMPThreshold = 10;
+                                                    if (MB != null) emp.isMissile = true;
                                                 }
                                                 float EMPDamage = 0;
                                                 if (!pulseLaser)
@@ -2598,7 +2598,7 @@ namespace BDArmory.Weapons
                                                 else
                                                 {
                                                     //EMPDamage = secondaryAmmoPerShot / 10;
-                                                    EMPDamage = laserDamage;
+                                                    EMPDamage = laserDamage * BDArmorySettings.DMG_MULTIPLIER;
                                                     emp.incomingDamage += EMPDamage;
                                                 }
                                                 emp.softEMP = true;


### PR DESCRIPTION
EMP also now subject to damage multiplier
Also adds exception to missiles to permit them to still be disabled, similar to existent exceptions for bullet/laser/missile damage  vs missiles while in paintball mode