### PR TITLE
Add some null checks

### DIFF
--- a/BDArmory/Extensions/PartExtensions.cs
+++ b/BDArmory/Extensions/PartExtensions.cs
@@ -473,9 +473,9 @@ namespace BDArmory.Extensions
         public static Vector3 GetSize(this Part part)
         {
             var meshFilter = part.GetComponentInChildren<MeshFilter>();
-            if (meshFilter == null)
+            if (meshFilter == null || meshFilter.mesh == null || meshFilter.mesh.bounds == null || meshFilter.mesh.bounds.size == null)
             {
-                Debug.LogWarning($"[BDArmory.PartExtension]: {part.name} has no MeshFilter! Returning zero size.");
+                Debug.LogWarning($"[BDArmory.PartExtension]: Could not find size of {part.name}! Returning zero size.");
                 return Vector3.zero;
             }
             var size = meshFilter.mesh.bounds.size;
@@ -501,7 +501,7 @@ namespace BDArmory.Extensions
                         tweakScaleInstalled = true;
                 tweakScaleChecked = true;
             }
-            if (tweakScaleInstalled && part.Modules.Contains("TweakScale"))
+            if (tweakScaleInstalled && part.Modules != null && part.Modules.Contains("TweakScale"))
             {
                 var tweakScaleModule = part.Modules["TweakScale"];
                 scaleMultiplier = tweakScaleModule.Fields["currentScale"].GetValue<float>(tweakScaleModule) /


### PR DESCRIPTION
Repeated NREs was [reported](https://discord.com/channels/1113137628305440818/1424197146470776832/1424236798443257906) by "space_i_isaac" in the KSP Modding Society server ([logs](https://www.mediafire.com/file/5mx83olawsrw0zd/KSP.log/file))

```
[ERR 20:49:28.976] ItemPrefab for control type 'UI_ScaleEditNumeric' not found.

[EXC 20:49:28.992] NullReferenceException: Object reference not set to an instance of an object
    BDArmory.Core.Extension.PartExtensions.GetSize (Part part) (at <9ee3b96531cd4baf912c3106c5082ed2>:0)
    BDArmory.Core.Extension.PartExtensions.GetAverageBoundSize (Part part) (at <9ee3b96531cd4baf912c3106c5082ed2>:0)
    BDArmory.Core.Module.HitpointTracker.CalculateTotalHitpoints () (at <9ee3b96531cd4baf912c3106c5082ed2>:0)
    BDArmory.Core.Module.HitpointTracker.SetupPrefab () (at <9ee3b96531cd4baf912c3106c5082ed2>:0)
    BDArmory.Core.Module.HitpointTracker.RefreshHitPoints () (at <9ee3b96531cd4baf912c3106c5082ed2>:0)
    BDArmory.Core.Module.HitpointTracker.Update () (at <9ee3b96531cd4baf912c3106c5082ed2>:0)
    UnityEngine.DebugLogHandler:LogException(Exception, Object)
    ModuleManager.UnityLogHandle.InterceptLogHandler:LogException(Exception, Object)
    UnityEngine.Debug:CallOverridenDebugHandler(Exception, Object)
```

This should at least prevent the NREs