### PR TITLE
Bugfixes and additions

### DIFF
--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -3730,7 +3730,7 @@ namespace BDArmory.Control
                         {
                             designatedGPSInfo = new GPSTargetInfo(foundCam.bodyRelativeGTP, "Guard Target");
                         }
-                        FireCurrentMissile(CurrentMissile, true, guardTarget != null ? guardTarget : null);
+                        FireCurrentMissile(CurrentMissile, true, guardTarget);
                         timeBombReleased = Time.time;
                         yield return new WaitForSecondsFixed(rippleFire ? 60f / rippleRPM : 0.06f);
                         if (firedMissiles >= maxMissilesOnTarget) // If not, continue bombing until overshooting.

--- a/BDArmory/UI/BDATeamIcons.cs
+++ b/BDArmory/UI/BDATeamIcons.cs
@@ -220,7 +220,7 @@ namespace BDArmory.UI
                 float size = 40;
                 UpdateStyles();
                 float minDistanceSqr = BDTISettings.DISTANCE_THRESHOLD * BDTISettings.DISTANCE_THRESHOLD;
-                float maxDistanceSqr = BDTISettings.MAX_DISTANCE_THRESHOLD * BDTISettings.MAX_DISTANCE_THRESHOLD;
+                float maxDistanceSqr = BDTISettings.MAX_DISTANCE_THRESHOLD == 0 ? float.MaxValue : BDTISettings.MAX_DISTANCE_THRESHOLD * BDTISettings.MAX_DISTANCE_THRESHOLD;
                 using var vessel = FlightGlobals.Vessels.GetEnumerator();
                 while (vessel.MoveNext())
                 {

--- a/BDArmory/UI/BDTISetup.cs
+++ b/BDArmory/UI/BDTISetup.cs
@@ -329,8 +329,6 @@ namespace BDArmory.UI
                 Debug.Log("[BDTeamIcons]=== Loading settings.cfg ===");
 
                 SettingsDataField.Load();
-                if (BDTISettings.MAX_DISTANCE_THRESHOLD < 1) // || BDTISettings.MAX_DISTANCE_THRESHOLD > BDArmorySettings.MAX_GUARD_VISUAL_RANGE) //unlink icon range from vis range
-                    BDTISettings.MAX_DISTANCE_THRESHOLD = BDArmorySettings.MAX_GUARD_VISUAL_RANGE;
             }
             catch (NullReferenceException)
             {
@@ -421,8 +419,9 @@ namespace BDArmory.UI
                 BDTISettings.DISTANCE_THRESHOLD = BDAMath.RoundToUnit(GUI.HorizontalSlider(SRect(line++, 40), BDTISettings.DISTANCE_THRESHOLD, 10f, 250f), 10f);
                 GUI.Label(SRect(line++), $"{StringUtils.Localize("#LOC_BDArmory_Icon_opacity")} {BDTISettings.OPACITY * 100f:0}%");
                 BDTISettings.OPACITY = BDAMath.RoundToUnit(GUI.HorizontalSlider(SRect(line++, 40), BDTISettings.OPACITY, 0f, 1f), 0.01f);
-                GUI.Label(SRect(line++), $"{StringUtils.Localize("#LOC_BDArmory_Icon_max_distance_threshold")} {(BDTISettings.MAX_DISTANCE_THRESHOLD < BDArmorySettings.MAX_GUARD_VISUAL_RANGE ? $"{BDTISettings.MAX_DISTANCE_THRESHOLD / 1000f:0}km" : "Unlimited")}");
-                BDTISettings.MAX_DISTANCE_THRESHOLD = GUIUtils.HorizontalSemiLogSlider(SRect(line++, 40), BDTISettings.MAX_DISTANCE_THRESHOLD / 1000f, 1f, BDArmorySettings.MAX_GUARD_VISUAL_RANGE / 1000f, 1, false, false, ref cacheMaxDistanceThreshold) * 1000f;
+                GUI.Label(SRect(line++), $"{StringUtils.Localize("#LOC_BDArmory_Icon_max_distance_threshold")} {(BDTISettings.MAX_DISTANCE_THRESHOLD > 0 ? $"{BDTISettings.MAX_DISTANCE_THRESHOLD / 1000f:0}km" : "Unlimited")}");
+                BDTISettings.MAX_DISTANCE_THRESHOLD = GUIUtils.HorizontalSemiLogSlider(SRect(line++, 40), BDTISettings.MAX_DISTANCE_THRESHOLD / 1000f, 1f, BDArmorySettings.MAX_GUARD_VISUAL_RANGE / 1000f, 1, true, false, ref cacheMaxDistanceThreshold) * 1000f;
+                
                 GUI.EndGroup();
                 IconOptionsGroup.height = 25f * line;
 

--- a/BDArmory/UI/VesselSpawnerWindow.cs
+++ b/BDArmory/UI/VesselSpawnerWindow.cs
@@ -886,6 +886,8 @@ namespace BDArmory.UI
                                 if (CustomTemplateSpawning.Instance.ConfigureTemplate(true))
                                 {
                                     CustomTemplateSpawning.Instance.SpawnCustomTemplate(CustomTemplateSpawning.customSpawnConfig);
+                                    TournamentCoordinator.Instance.Configure(null, new WaypointFollowingStrategy(course), null);
+                                    TournamentCoordinator.Instance.Run();
                                 }
                             }
                             else
@@ -912,9 +914,9 @@ namespace BDArmory.UI
                                     new WaypointFollowingStrategy(course),
                                     CircularSpawning.Instance
                                 );
+                                // Run the waypoint competition.
+                                TournamentCoordinator.Instance.Run();
                             }
-                            // Run the waypoint competition.
-                            TournamentCoordinator.Instance.Run();
                         }
                         else
                         {

--- a/BDArmory/VesselSpawning/CircularSpawning.cs
+++ b/BDArmory/VesselSpawning/CircularSpawning.cs
@@ -225,9 +225,9 @@ namespace BDArmory.VesselSpawning
             var vesselSpawnConfigs = new List<VesselSpawnConfig>();
             if (BDArmorySettings.WAYPOINTS_MODE && !BDArmorySettings.WAYPOINTS_ONE_AT_A_TIME && !spawnAirborne)
             {
+                //TODO - move over to SpawnCustomTemplate once TournamentCoordinator deprecated
                     var direction = (Quaternion.AngleAxis(0, radialUnitVector) * refDirection).ProjectOnPlanePreNormalized(radialUnitVector).normalized;
 
-                    int SpawnCount = 0;
                     float craftSeparation = Mathf.Min(20f * Mathf.Log10(spawnDistance), 4f * BDAMath.Sqrt(spawnDistance));
                     var spreadDirection = Vector3.Cross(radialUnitVector, direction);
                     var facingDirection = direction;


### PR DESCRIPTION
-Fix bombs not respecting MaxMslPerTgt
-Fix ARads softlocking weapon selection
-Fix laser missile terrain check
-Remove max guard view range clamp on icon draw dist
-Add option for twinned ordnance to drop both at the same time, similar to MML functionality
-Fix reloadable rail mass
-Add gridspawn for surface AI Waypoint races
-Fix Surface AI WP race immediately finishing and going to next heat if Activate Guard After Gate is deactivated
-Fix SrfAI circling last gate in WP race and not exiting isRunningWaypoints