### PR TITLE
Custom turret and HitpointTracker fixes

### DIFF
--- a/BDArmory/Armor/ArmorInfo.cs
+++ b/BDArmory/Armor/ArmorInfo.cs
@@ -10,6 +10,8 @@ namespace BDArmory.Armor
     public class ArmorInfo
     {
         public string name { get; private set; }
+
+        public string localizedName { get; private set; } //display name
         public float Density { get; private set; } //mass kg/m3 lighter is better. Or is it?
         public float Strength { get; private set; } //in MPa, yieldstrength for material, controls fail point for material when projectile can penetrate. Higher is better
         public float Hardness { get; private set; } //hardness, in MPa, of material. Controls how much deformation impacting projectiles experience
@@ -41,9 +43,10 @@ namespace BDArmory.Armor
         public static List<string> armorNames;
         public static ArmorInfo defaultArmor;
 
-        public ArmorInfo(string name, float Density, float Strength, float Hardness, float yield, float youngModulus, float Ductility, float Diffusivity, float SafeUseTemp, float Stealth, float Cost, float defaultPenShrapnel, float defaultPenHEAT)
+        public ArmorInfo(string name, string localizedName, float Density, float Strength, float Hardness, float yield, float youngModulus, float Ductility, float Diffusivity, float SafeUseTemp, float Stealth, float Cost, float defaultPenShrapnel, float defaultPenHEAT)
         {
             this.name = name;
+            this.localizedName = localizedName;
             this.Density = Density;
             this.Strength = Strength;
             this.Hardness = Hardness;
@@ -124,6 +127,7 @@ namespace BDArmory.Armor
                     Debug.Log("[BDArmory.ArmorInfo]: Parsing default armor definition from " + nodes[i].parent.name);
                     defaultArmor = new ArmorInfo(
                         "def",
+                        (string)ParseField(node, "localizedName", typeof(string)),
                         (float)ParseField(node, "Density", typeof(float)),
                         (float)ParseField(node, "Strength", typeof(float)),
                         (float)ParseField(node, "Hardness", typeof(float)),
@@ -161,6 +165,7 @@ namespace BDArmory.Armor
                     armors.Add(
                         new ArmorInfo(
                             name_,
+                        (string)ParseField(node, "localizedName", typeof(string)),
                         (float)ParseField(node, "Density", typeof(float)),
                         (float)ParseField(node, "Strength", typeof(float)),
                         (float)ParseField(node, "Hardness", typeof(float)),

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -9555,7 +9555,7 @@ namespace BDArmory.Control
                         PDMslTgts.Add(tInfo);
                 }
             }
-            //Debug.Log($"[BDArmory.MissileFire - {(this.vessel != null ? vessel.GetName() : "null")}] tgtcount: {PDBulletTgts.Count + PDRktTgts.Count + PDMslTgts.Count}, APS count: {APScount}; interceptor count: {missileCount}");
+            //if (BDArmorySettings.DEBUG_APS) Debug.Log($"[BDArmory.MissileFire - {(this.vessel != null ? vessel.GetName() : "null")}] tgtcount: {PDBulletTgts.Count + PDRktTgts.Count + PDMslTgts.Count}, APS count: {APScount}; interceptor count: {missileCount}");
             if (APScount + missileCount <= 0)
             {
                 PDScanTimer = -100;
@@ -9584,7 +9584,9 @@ namespace BDArmory.Control
                                 if (PDBulletTgts[ballisticTurretID] != null && (PDBulletTgts[ballisticTurretID].currentPosition - kbCorrection).FurtherFromThan(weapon.fireTransforms[0].position, weapon.engageRangeMax * 2)) ballisticTurretID = 0; //reset cycle so out of range guns engage closer targets
                                 if (PDBulletTgts[ballisticTurretID] != null) //second check in case of turretID reset
                                 {
-                                    if (TargetInTurretRange(weapon.turret, 7, PDBulletTgts[ballisticTurretID].currentPosition - kbCorrection, weapon))
+                                    //if (TargetInTurretRange(weapon.turret, 7, PDBulletTgts[ballisticTurretID].currentPosition - kbCorrection, weapon))
+                                    if ((weapon.turret && TargetInTurretRange(weapon.turret, 7, PDBulletTgts[ballisticTurretID].currentPosition - kbCorrection, weapon)) ||
+    (weapon.customTurret.Count > 0 && TargetInCustomTurretRange(weapon, 7, PDBulletTgts[ballisticTurretID].currentPosition - kbCorrection)))
                                     {
                                         weapon.tgtShell = PDBulletTgts[ballisticTurretID]; // if target within turret fire zone, assign
                                     }
@@ -9594,7 +9596,9 @@ namespace BDArmory.Control
                                             while (item.MoveNext())
                                             {
                                                 if (item.Current == null) continue;
-                                                if (TargetInTurretRange(weapon.turret, 7, item.Current.currentPosition - kbCorrection, weapon))
+                                                //if (TargetInTurretRange(weapon.turret, 7, item.Current.currentPosition - kbCorrection, weapon))
+                                                if ((weapon.turret && TargetInTurretRange(weapon.turret, 7, item.Current.currentPosition - kbCorrection, weapon)) ||
+(weapon.customTurret.Count > 0 && TargetInCustomTurretRange(weapon, 7, item.Current.currentPosition - kbCorrection)))
                                                 {
                                                     weapon.tgtShell = item.Current;
                                                     break;
@@ -9624,7 +9628,9 @@ namespace BDArmory.Control
                                 {
                                     bool viableTarget = true;
                                     if (BDArmorySettings.BULLET_WATER_DRAG && weapon.eWeaponType == ModuleWeapon.WeaponTypes.Ballistic && FlightGlobals.getAltitudeAtPos(PDRktTgts[rocketTurretID].currentPosition - kbCorrection) < 0) viableTarget = false;
-                                    if (viableTarget && TargetInTurretRange(weapon.turret, 7, PDRktTgts[rocketTurretID].currentPosition - kbCorrection, weapon))
+                                    //if (viableTarget && TargetInTurretRange(weapon.turret, 7, PDRktTgts[rocketTurretID].currentPosition - kbCorrection, weapon))
+                                    if ((weapon.turret && TargetInTurretRange(weapon.turret, 7, PDRktTgts[rocketTurretID].currentPosition - kbCorrection, weapon)) ||
+(weapon.customTurret.Count > 0 && TargetInCustomTurretRange(weapon, 7, PDRktTgts[rocketTurretID].currentPosition - kbCorrection)))
                                     {
                                         weapon.tgtRocket = PDRktTgts[rocketTurretID]; // if target within turret fire zone, assign
                                         weapon.tgtShell = null;
@@ -9636,7 +9642,9 @@ namespace BDArmory.Control
                                             {
                                                 if (item.Current == null) continue;
                                                 if (!viableTarget) continue;
-                                                if (TargetInTurretRange(weapon.turret, 7, item.Current.currentPosition - kbCorrection, weapon))
+                                                //if (TargetInTurretRange(weapon.turret, 7, item.Current.currentPosition - kbCorrection, weapon))
+                                                if ((weapon.turret && TargetInTurretRange(weapon.turret, 7, item.Current.currentPosition - kbCorrection, weapon)) ||
+(weapon.customTurret.Count > 0 && TargetInCustomTurretRange(weapon, 7, item.Current.currentPosition - kbCorrection)))
                                                 {
                                                     weapon.tgtRocket = item.Current;
                                                     weapon.tgtShell = null;
@@ -9657,7 +9665,9 @@ namespace BDArmory.Control
                             {
                                 bool viableTarget = true;
                                 if (BDArmorySettings.BULLET_WATER_DRAG && weapon.eWeaponType == ModuleWeapon.WeaponTypes.Ballistic && PDMslTgts[TurretID].Vessel.Splashed) viableTarget = false;
-                                if (viableTarget && TargetInTurretRange(weapon.turret, 7, PDMslTgts[TurretID].Vessel.CoM, weapon))
+                                //if (viableTarget && TargetInTurretRange(weapon.turret, 7, PDMslTgts[TurretID].Vessel.CoM, weapon))
+                                if (viableTarget && (weapon.turret && TargetInTurretRange(weapon.turret, 7, PDMslTgts[TurretID].Vessel.CoM, weapon)) ||
+(weapon.customTurret.Count > 0 && TargetInCustomTurretRange(weapon, 7, PDMslTgts[TurretID].Vessel.CoM)))
                                 {
                                     weapon.visualTargetPart = PDMslTgts[TurretID].Vessel.rootPart;  // if target within turret fire zone, assign
                                                                                                     //Debug.Log($"[BDArmory.MissileLauncher] assigning missile target {PDMslTgts[TurretID].Vessel.name}, ID {TurretID}");
@@ -9671,7 +9681,9 @@ namespace BDArmory.Control
                                         {
                                             if (item.Current.Vessel == null) continue;
                                             if (!viableTarget) continue;
-                                            if (TargetInTurretRange(weapon.turret, 7, item.Current.Vessel.CoM, weapon))
+                                            //if (TargetInTurretRange(weapon.turret, 7, item.Current.Vessel.CoM, weapon))
+                                            if ((weapon.turret && TargetInTurretRange(weapon.turret, 7, item.Current.Vessel.CoM, weapon)) ||
+            (weapon.customTurret.Count > 0 && TargetInCustomTurretRange(weapon, 7, item.Current.Vessel.CoM)))
                                             {
                                                 weapon.visualTargetPart = item.Current.Vessel.rootPart;
                                                 //Debug.Log($"[BDArmory.MissileLauncher] assigning missile target {PDMslTgts[TurretID].Vessel.name} as secondary target, ID {TurretID}");
@@ -9689,13 +9701,13 @@ namespace BDArmory.Control
                             if (guardTarget == null)
                             {
                                 weapon.visualTargetPart = null;
-                                //Debug.Log($"[BDArmory.MissileLauncher] No Target! nulling visaltargetpart!");
+                                //if (BDArmorySettings.DEBUG_APS) Debug.Log($"[BDArmory.MissileLauncher] No Target! nulling visaltargetpart!");
                             }
                             // weapon.Current.tgtShell = null; // FIXME These were wiping Omni type APS shell and rocket targets.
                             // weapon.Current.tgtRocket = null;
                         }
                     }
-                    if (BDArmorySettings.DEBUG_WEAPONS)
+                    if (BDArmorySettings.DEBUG_APS)
                         Debug.Log($"[BDArmory.MissileFire - {(this.vessel != null ? vessel.GetName() : "null")}]: PDMslTgts: {PDMslTgts.Count}; {weapon.shortName} assigned shell:{(weapon.tgtShell != null ? "true" : "false")}; rocket: {(weapon.tgtRocket != null ? "true" : "false")}; missile:{(weapon.visualTargetPart != null ? weapon.visualTargetPart.vessel.GetName() : "null")}");
                     weapon.autoFireTimer = Time.time;
                     weapon.autoFireLength = (fireBurstLength < 0.01f) ? targetScanInterval / 2f : fireBurstLength;
@@ -9966,6 +9978,7 @@ namespace BDArmory.Control
                     }
                     //need to see if missile is turreted (and is a unique turret we haven't seen yet); if so, check if target is within traverse, else see if target is within boresight
                     bool turreted = false;
+                    bool customTurreted = false;
                     MissileTurret mT = null;
                     if (launcher && (launcher.missileTurret || launcher.multiLauncher && launcher.multiLauncher.turret))
                     {
@@ -9991,9 +10004,10 @@ namespace BDArmory.Control
                             currMissile.customTurret[i].AimToTarget(currMissile.customTurret[i].slavedTargetPosition);
                         }
                         //TODO - don't assign two missiles on the same custom turret to two different targets check
+                        customTurreted = true;
                     }
                     //Debug.Log($"[PD Missile Debug - {vessel.GetName()}]viable: {viableTarget}; turreted: {turreted}; inRange: {(turreted ? TargetInTurretRange(mT.turret, mT.fireFOV, targetVessel.CoM) : GetLaunchAuthorization(targetVessel, this, currMissile))}");
-                    if (viableTarget && turreted ? TargetInTurretRange(mT.turret, mT.fireFOV, targetVessel.CoM) : GetLaunchAuthorization(targetVessel, this, currMissile))
+                    if (viableTarget && turreted ? TargetInTurretRange(mT.turret, mT.fireFOV, targetVessel.CoM) : customTurreted ? TargetInCustomTurretRange(null, 5, targetVessel.CoM, currMissile) : GetLaunchAuthorization(targetVessel, this, currMissile))
                     {
                         //missileTarget = targetVessel;
                         //if (logging)
@@ -10025,7 +10039,7 @@ namespace BDArmory.Control
                     return false;
             }
             MissileID = currIndex;
-            //if (BDArmorySettings.DEBUG_MISSILES && BDArmorySettings.DEBUG_AI)
+            //if (BDArmorySettings.DEBUG_APS)
             //    Debug.Log($"[BDArmory.MissileFire - {(this.vessel != null ? vessel.GetName() : "null")}]: PD Selected target: {(PDMslTgts[currIndex].Vessel != null ? PDMslTgts[currIndex].Vessel.GetName() : "null")} has: {GetMissilesAway(PDMslTgts[currIndex])[0]} interceptors targeted");
             return true;
         }
@@ -10387,9 +10401,9 @@ namespace BDArmory.Control
             }
         }
 
-        bool TargetInCustomTurretRange(ModuleWeapon weapon, float tolerance, Vector3 gTarget = default(Vector3))
+        bool TargetInCustomTurretRange(ModuleWeapon weapon, float tolerance, Vector3 gTarget = default(Vector3), MissileBase msl = null)
         {
-            if (!weapon || weapon.customTurret.Count == 0)
+            if ((!weapon || weapon.customTurret.Count == 0) && msl == null)
             {
                 return false;
             }
@@ -10403,7 +10417,9 @@ namespace BDArmory.Control
             }
             if (gTarget == default) gTarget = guardTarget.CoM;
             if (weapon != null && (gTarget - weapon.fireTransforms[0].transform.position).sqrMagnitude > (weapon.engageRangeMax * 1.25f) * (weapon.engageRangeMax * 1.25f)) return false; //target too far away
-            Transform turretTransform = weapon.customTurret[0].bottomTransform; //might be an issue if grabbing non-servo; servos are proper Z+ forward Y+ up that turrets are, hinges...
+            else if (msl != null && (gTarget - msl.MissileReferenceTransform.position).sqrMagnitude > (msl.engageRangeMax * 1.25f) * (msl.engageRangeMax * 1.25f)) return false; //target too far away
+            Transform turretTransform = weapon != null? weapon.customTurret[0].bottomTransform : msl != null? msl.customTurret[0].bottomTransform : null; //might be an issue if grabbing non-servo; servos are proper Z+ forward Y+ up that turrets are, hinges...
+            if (turretTransform == null) return false;
             Vector3 direction = gTarget - turretTransform.position;
             if (weapon != null && weapon.bulletDrop) // Account for bullet drop (rough approximation not accounting for target movement).
             {
@@ -10427,7 +10443,7 @@ namespace BDArmory.Control
                         }
                 }
             }
-            Vector3 directionYaw = weapon.fireTransforms[0].transform.up;
+            Vector3 directionYaw = weapon != null ? weapon.fireTransforms[0].transform.up : msl.MissileReferenceTransform.transform.up;
             float angleYaw = 0;
             float yawRange = 0;
             bool withinPitchRange = false;

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -9316,7 +9316,7 @@ namespace BDArmory.Control
 
                     if (multiTargetNum > 1)
                     {
-                        if (weapon.Current.turret && (weapon.Current.maxPitch > weapon.Current.minPitch || weapon.Current.yawRange > 0))
+                        if ((weapon.Current.turret && (weapon.Current.maxPitch > weapon.Current.minPitch || weapon.Current.yawRange > 0)) || weapon.Current.customTurret.Count > 0)
                         {
                             if (TurretID >= Mathf.Min((targetsAssigned.Count), multiTargetNum))
                             {
@@ -9327,7 +9327,8 @@ namespace BDArmory.Control
                                 if (((weapon.Current.engageAir && targetsAssigned[TurretID].isFlying) ||
                                     (weapon.Current.engageGround && targetsAssigned[TurretID].isLandedOrSurfaceSplashed) ||
                                     (weapon.Current.engageSLW && targetsAssigned[TurretID].isUnderwater)) //check engagement envelope
-                                    && TargetInTurretRange(weapon.Current.turret, 7, targetsAssigned[TurretID].Vessel.CoM, weapon.Current))
+                                    && weapon.Current.turret? TargetInTurretRange(weapon.Current.turret, 7, targetsAssigned[TurretID].Vessel.CoM, weapon.Current) : 
+                                    TargetInCustomTurretRange(weapon.Current, 7, targetsAssigned[TurretID].Vessel.CoM))
                                 {
                                     weapon.Current.visualTargetVessel = targetsAssigned[TurretID].Vessel; // if target within turret fire zone, assign
                                     firedTargets.Add(targetsAssigned[TurretID]);
@@ -9341,7 +9342,8 @@ namespace BDArmory.Control
                                             if ((weapon.Current.engageAir && !item.Current.isFlying) ||
                                             (weapon.Current.engageGround && !item.Current.isLandedOrSurfaceSplashed) ||
                                             (weapon.Current.engageSLW && !item.Current.isUnderwater)) continue;
-                                            if (TargetInTurretRange(weapon.Current.turret, 7, item.Current.Vessel.CoM, weapon.Current))
+                                            if ((weapon.Current.turret && TargetInTurretRange(weapon.Current.turret, 7, item.Current.Vessel.CoM, weapon.Current)) ||
+                                                (weapon.Current.customTurret.Count > 0 && TargetInCustomTurretRange(weapon.Current, 7, item.Current.Vessel.CoM)))
                                             {
                                                 weapon.Current.visualTargetVessel = item.Current.Vessel;
                                                 firedTargets.Add(item.Current);
@@ -9359,7 +9361,8 @@ namespace BDArmory.Control
                             {
                                 if (weapon.Current.engageMissile)
                                 {
-                                    if (TargetInTurretRange(weapon.Current.turret, 7, missilesAssigned[MissileTgtID].Vessel.CoM, weapon.Current))
+                                    if ((weapon.Current.turret && TargetInTurretRange(weapon.Current.turret, 7, missilesAssigned[MissileTgtID].Vessel.CoM, weapon.Current)) ||
+    (weapon.Current.customTurret.Count > 0 && TargetInCustomTurretRange(weapon.Current, 7, missilesAssigned[MissileTgtID].Vessel.CoM)))
                                     {
                                         weapon.Current.visualTargetVessel = missilesAssigned[MissileTgtID].Vessel; // if target within turret fire zone, assign
                                         firedTargets.Add(missilesAssigned[MissileTgtID]);
@@ -9370,7 +9373,8 @@ namespace BDArmory.Control
                                             while (item.MoveNext())
                                             {
                                                 if (item.Current.Vessel == null) continue;
-                                                if (TargetInTurretRange(weapon.Current.turret, 7, item.Current.Vessel.CoM, weapon.Current))
+                                                if ((weapon.Current.turret && TargetInTurretRange(weapon.Current.turret, 7, item.Current.Vessel.CoM, weapon.Current)) ||
+                                                    (weapon.Current.customTurret.Count > 0 && TargetInCustomTurretRange(weapon.Current, 7, item.Current.Vessel.CoM)))
                                                 {
                                                     weapon.Current.visualTargetVessel = item.Current.Vessel;
                                                     firedTargets.Add(item.Current);

--- a/BDArmory/Control/MissileFire.cs
+++ b/BDArmory/Control/MissileFire.cs
@@ -2896,7 +2896,7 @@ namespace BDArmory.Control
                                 {
                                     ml.SetSlavedGuard(true);
 
-                                    float turretEndTime = attemptStartTime + Mathf.Max(targetScanInterval / 2f, 2);
+                                    float turretEndTime = attemptStartTime + Mathf.Max(targetScanInterval / 2f, (360/mlauncher.missileTurret.turret.yawSpeedDPS));
                                     float angleThreshold = GetMissileTurretFireAngle(mlauncher);
                                     (bool loft, float loftFac) = GetMissileTurretLoft(ml, mlauncher);
                                     

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -4,6 +4,7 @@ using BDArmory.Modules;
 using BDArmory.Settings;
 using BDArmory.UI;
 using BDArmory.Utils;
+using BDArmory.Weapons;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -333,7 +334,9 @@ namespace BDArmory.Damage
             }
             if (part.Modules.Contains("ModuleB9PartSwitch") || part.Modules.Contains("ModulePartVariants"))
             {
-                isVariantPart = true;
+                if (!B9PartSwitch.checkForSimpleRepaint(part)) isVariantPart = false;
+                else
+                    isVariantPart = true;
             }
             StartingArmor = Armor;
             if (ProjectileUtils.IsArmorPart(this.part))

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -671,6 +671,56 @@ namespace BDArmory.Damage
             {
                 if (HighLogic.LoadedSceneIsEditor || HighLogic.LoadedSceneIsFlight) // Also needed in flight mode for initial setup of mass, hull and HP, but shouldn't be triggered afterwards as ShipModified is only for the editor.
                 {
+                    if (_updateMass)
+                    {
+                        _updateMass = false;
+                        var oldPartMass = partMass;
+                        var oldHullMassAdjust = HullMassAdjust; // We need to temporarily remove the HullmassAdjust and update the part.mass to get the correct value as KSP clamps the mass to > 1e-4.
+                        HullMassAdjust = 0;  
+                        //partMass = part.mass - armorMass - HullMassAdjust; //part mass is taken from the part.cfg val, not current part mass; this overrides that
+                        if (isProcWing || isProcPart || isProcWheel || isVariantPart)
+                        {
+                            float Safetymass = 0;
+                            var SST = part.GetComponent<ModuleSelfSealingTank>();
+                            if (SST != null)
+                            { Safetymass = SST.FBmass + SST.FISmass; }
+                            partMass = part.mass - armorMass - HullMassAdjust - Safetymass;
+                            if (isVariantPart)
+                            {
+                                var r = part.GetComponentsInChildren<Renderer>();
+                                for (int i = 0; i < r.Length; i++)
+                                {
+                                    if (r[i].GetComponentInParent<Part>() != part) continue; // Don't recurse to child parts.
+                                    int key = r[i].material.GetInstanceID(); // The instance ID is unique for each object (not just component or gameObject).
+                                    if (!defaultShader.ContainsKey(key))
+                                    {
+                                        defaultShader.Add(key, r[i].material.shader); //grab materials for part variant variants when switching to that variant
+                                        if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: ARMOR: part shader on {r[i].GetComponentInParent<Part>().partInfo.name} is {r[i].material.shader.name}");
+                                    }
+                                    if (r[i].material.HasProperty("_Color"))
+                                    {
+                                        if (!defaultColor.ContainsKey(key)) defaultColor.Add(key, r[i].material.color);
+                                    }
+                                }
+                            }
+                        }
+                        CalculateDryCost(); //recalc if modify event added a fueltank -resource swap, etc
+                        HullMassAdjust = oldHullMassAdjust; // Put the HullmassAdjust back so we can test against it when we update the hull mass.
+                        float tweakScaleMassMultiplier = _tweakScaleMassMultiplier;
+                        _tweakScaleMassMultiplier = part.GetTweakScaleMultiplier(); // Update our copy of the TweakScale mass multiplier.
+                        if (oldPartMass != partMass)
+                        {
+                            if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: {part.name} updated mass at {Time.time}: part.mass {part.mass}, partMass {oldPartMass}->{partMass}, armorMass {armorMass}, hullMassAdjust {HullMassAdjust}, tweakScaleMassMultiplier {tweakScaleMassMultiplier}->{_tweakScaleMassMultiplier}");
+                            if (isProcPart || isProcWheel || isVariantPart)
+                            {
+                                calcPartSize();
+                                _armorModified = true;
+                            }
+                            _hullModified = true; // Modifying the mass modifies the hull.
+                            _updateHitpoints = true;
+                        }
+                        part.UpdateMass();
+                    }
                     if (_armorModified)
                     {
                         _armorModified = false;
@@ -692,58 +742,7 @@ namespace BDArmory.Damage
                         _finished_setting_up = true;
                     }
                 }
-            }
-
-            if (_updateMass)
-            {
-                _updateMass = false;
-                var oldPartMass = partMass;
-                var oldHullMassAdjust = HullMassAdjust; // We need to temporarily remove the HullmassAdjust and update the part.mass to get the correct value as KSP clamps the mass to > 1e-4.
-                HullMassAdjust = 0;
-                part.UpdateMass();
-                //partMass = part.mass - armorMass - HullMassAdjust; //part mass is taken from the part.cfg val, not current part mass; this overrides that
-                if (isProcWing || isProcPart || isProcWheel || isVariantPart)
-                {
-                    float Safetymass = 0;
-                    var SST = part.GetComponent<ModuleSelfSealingTank>();
-                    if (SST != null)
-                    { Safetymass = SST.FBmass + SST.FISmass; }
-                    partMass = part.mass - armorMass - HullMassAdjust - Safetymass;
-                    if (isVariantPart)
-                    {
-                        var r = part.GetComponentsInChildren<Renderer>();
-                        for (int i = 0; i < r.Length; i++)
-                        {
-                            if (r[i].GetComponentInParent<Part>() != part) continue; // Don't recurse to child parts.
-                            int key = r[i].material.GetInstanceID(); // The instance ID is unique for each object (not just component or gameObject).
-                            if (!defaultShader.ContainsKey(key))
-                            {
-                                defaultShader.Add(key, r[i].material.shader); //grab materials for part variant variants when switching to that variant
-                                if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: ARMOR: part shader on {r[i].GetComponentInParent<Part>().partInfo.name} is {r[i].material.shader.name}");
-                            }
-                            if (r[i].material.HasProperty("_Color"))
-                            {
-                                if (!defaultColor.ContainsKey(key)) defaultColor.Add(key, r[i].material.color);
-                            }
-                        }
-                    }
-                }
-                CalculateDryCost(); //recalc if modify event added a fueltank -resource swap, etc
-                HullMassAdjust = oldHullMassAdjust; // Put the HullmassAdjust back so we can test against it when we update the hull mass.
-                float tweakScaleMassMultiplier = _tweakScaleMassMultiplier;
-                _tweakScaleMassMultiplier = part.GetTweakScaleMultiplier(); // Update our copy of the TweakScale mass multiplier.
-                if (oldPartMass != partMass)
-                {
-                    if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: {part.name} updated mass at {Time.time}: part.mass {part.mass}, partMass {oldPartMass}->{partMass}, armorMass {armorMass}, hullMassAdjust {HullMassAdjust}, tweakScaleMassMultiplier {tweakScaleMassMultiplier}->{_tweakScaleMassMultiplier}");
-                    if (isProcPart || isProcWheel || isVariantPart)
-                    {
-                        calcPartSize();
-                        _armorModified = true;
-                    }
-                    _hullModified = true; // Modifying the mass modifies the hull.
-                    _updateHitpoints = true;
-                }
-            }
+            }            
 
             if (HighLogic.LoadedSceneIsFlight && !UI.BDArmorySetup.GameIsPaused)
             {
@@ -1026,7 +1025,13 @@ namespace BDArmory.Damage
                             armorVolume = -1;
                             if (ProceduralWing.CheckForB9ProcWing() && ProceduralWing.CheckForPWModule())
                             {
+                                var oldMass = part.mass;
                                 float aeroVolume = ProceduralWing.GetPWingVolume(part); //PWing  0.7 * length * (widthRoot + WidthTip) + (thicknessRoot + ThicknessTip) / 4; yields 1.008 for a stock dimension 2*4*.18 board, so need mult of 1400 for parity with stock wing boards
+                                if (oldMass != part.mass && !_delayedShipModifiedRunning)
+                                {
+                                    _hullModified = true; // Modifying the mass modifies the hull.
+                                    _updateMass = true; // Recalculate the mass on the next frame unless we're already going to.
+                                }
                                 if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: Found {part.name}; HP: {Hitpoints}->{hitpoints} at time {Time.time}, partMass: {partMass}, Pwing Aerovolume: {aeroVolume}");
                                 //hitpoints should scale with stock wings correctly (and if used as thicker structural elements, should scale with tanks of similar size)
                                 armorVolume = ProceduralWing.GetPWingArea(part);
@@ -1468,7 +1473,6 @@ namespace BDArmory.Damage
             {
                 if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: {part.name} updated armour mass {oldArmorMass}->{armorMass} or type {OldArmorType}->{ArmorTypeNum} at time {Time.time}");
                 OldArmorType = ArmorTypeNum;
-                _updateMass = true;
                 part.UpdateMass();
                 if (HighLogic.LoadedSceneIsEditor && EditorLogic.fetch != null)
                     GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
@@ -1637,7 +1641,6 @@ namespace BDArmory.Damage
             {
                 if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: {part.name} updated hull mass {OldHullMassAdjust}->{HullMassAdjust} (part mass {partMass}, total mass {part.mass + HullMassAdjust - OldHullMassAdjust}) or type {OldHullType}->{HullTypeNum} at time {Time.time}");
                 OldHullType = HullTypeNum;
-                _updateMass = true;
                 part.UpdateMass();
                 if (HighLogic.LoadedSceneIsEditor && EditorLogic.fetch != null)
                     GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -162,6 +162,7 @@ namespace BDArmory.Damage
         public float maxSupportedArmor = -1; //upper cap on armor per part, overridable in MM/.cfg
         [KSPField(isPersistant = true)]
         public float armorVolume = -1;
+        float aeroVolume = -1;
         private float sizeAdjust;
 
         AttachNode bottom;
@@ -671,20 +672,53 @@ namespace BDArmory.Damage
             {
                 if (HighLogic.LoadedSceneIsEditor || HighLogic.LoadedSceneIsFlight) // Also needed in flight mode for initial setup of mass, hull and HP, but shouldn't be triggered afterwards as ShipModified is only for the editor.
                 {
+                    float Safetymass = -1;
+                    var oldPartMass = partMass;
+                    if (_updateMass)
+                    {                        
+                        var oldHullMassAdjust = HullMassAdjust; // We need to temporarily remove the HullmassAdjust and update the part.mass to get the correct value as KSP clamps the mass to > 1e-4.
+                        HullMassAdjust = 0;
+                        if (isProcWing || isProcPart || isProcWheel || isVariantPart)
+                        {
+                            UpdatePartMass(Safetymass);
+                            HullMassAdjust = oldHullMassAdjust; // Put the HullmassAdjust back so we can test against it when we update the hull mass.
+                            if (oldPartMass != partMass) //non-pParts partMAss is and would remain the mass value in the .cfg grabbed during OnStart()
+                            {
+                                if (isProcWing)
+                                {
+                                    aeroVolume = ProceduralWing.GetPWingVolume(part);
+                                }
+                                else
+                                {
+                                    calcPartSize();
+                                    _armorModified = true;
+                                }
+                                _updateHitpoints = true;
+                            }                            
+                            _hullModified = true; // Modifying the mass modifies the hull.
+                        }
+                        part.UpdateMass();
+                    }
+                    if (_armorModified)
+                    {
+                        _armorModified = false;
+                        _armorConfigured = false;
+                        ArmorSetup(null, null);
+                    }
+                    UpdatePartMass(Safetymass);
+                    if (_hullModified) // Wait for the mass to update first.
+                    {
+                        _hullModified = false;
+                        _hullConfigured = false;
+                        HullSetup(null, null);
+                    }
+                    UpdatePartMass(Safetymass);
                     if (_updateMass)
                     {
                         _updateMass = false;
-                        var oldPartMass = partMass;
-                        var oldHullMassAdjust = HullMassAdjust; // We need to temporarily remove the HullmassAdjust and update the part.mass to get the correct value as KSP clamps the mass to > 1e-4.
-                        HullMassAdjust = 0;  
-                        //partMass = part.mass - armorMass - HullMassAdjust; //part mass is taken from the part.cfg val, not current part mass; this overrides that
+
                         if (isProcWing || isProcPart || isProcWheel || isVariantPart)
                         {
-                            float Safetymass = 0;
-                            var SST = part.GetComponent<ModuleSelfSealingTank>();
-                            if (SST != null)
-                            { Safetymass = SST.FBmass + SST.FISmass; }
-                            partMass = part.mass - armorMass - HullMassAdjust - Safetymass;
                             if (isVariantPart)
                             {
                                 var r = part.GetComponentsInChildren<Renderer>();
@@ -705,38 +739,17 @@ namespace BDArmory.Damage
                             }
                         }
                         CalculateDryCost(); //recalc if modify event added a fueltank -resource swap, etc
-                        HullMassAdjust = oldHullMassAdjust; // Put the HullmassAdjust back so we can test against it when we update the hull mass.
                         float tweakScaleMassMultiplier = _tweakScaleMassMultiplier;
                         _tweakScaleMassMultiplier = part.GetTweakScaleMultiplier(); // Update our copy of the TweakScale mass multiplier.
-                        if (oldPartMass != partMass)
-                        {
-                            if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: {part.name} updated mass at {Time.time}: part.mass {part.mass}, partMass {oldPartMass}->{partMass}, armorMass {armorMass}, hullMassAdjust {HullMassAdjust}, tweakScaleMassMultiplier {tweakScaleMassMultiplier}->{_tweakScaleMassMultiplier}");
-                            if (isProcPart || isProcWheel || isVariantPart)
-                            {
-                                calcPartSize();
-                                _armorModified = true;
-                            }
-                            _hullModified = true; // Modifying the mass modifies the hull.
-                            _updateHitpoints = true;
-                        }
+                        if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: {part.name} updated mass at {Time.time}: part.mass {part.mass}, partMass {oldPartMass}->{partMass}, armorMass {armorMass}, hullMassAdjust {HullMassAdjust}, tweakScaleMassMultiplier {tweakScaleMassMultiplier}->{_tweakScaleMassMultiplier}");
+
                         part.UpdateMass();
                     }
-                    if (_armorModified)
-                    {
-                        _armorModified = false;
-                        _armorConfigured = false;
-                        ArmorSetup(null, null);
-                    }
-                    if (_hullModified && !_updateMass) // Wait for the mass to update first.
-                    {
-                        _hullModified = false;
-                        _hullConfigured = false;
-                        HullSetup(null, null);
-                    }
-                    if (!_updateMass) // Wait for the mass to update first.
+                    else // Wait for the mass to update first.
                     {
                         RefreshHitPoints();
                     }
+
                     if (HighLogic.LoadedSceneIsFlight && _armorConfigured && _hullConfigured && _hpConfigured) // No more changes, we're done.
                     {
                         _finished_setting_up = true;
@@ -793,6 +806,21 @@ namespace BDArmory.Damage
                 SetupPrefab();
                 if (HighLogic.LoadedSceneIsEditor)
                     BDAEditorArmorWindow.Instance.OnEditorShipModifiedEvent(EditorLogic.fetch.ship);
+            }
+        }
+
+        private void UpdatePartMass(float Safetymass)
+        {
+            if (isProcWing || isProcPart || isProcWheel || isVariantPart)
+            {
+                if (Safetymass < 0)
+                {
+                    var SST = part.GetComponent<ModuleSelfSealingTank>();
+                    if (SST != null)
+                    { Safetymass = SST.FBmass + SST.FISmass; }
+                    else Safetymass = 0;
+                }
+                partMass = part.mass - armorMass - HullMassAdjust - Safetymass;
             }
         }
 
@@ -1025,13 +1053,6 @@ namespace BDArmory.Damage
                             armorVolume = -1;
                             if (ProceduralWing.CheckForB9ProcWing() && ProceduralWing.CheckForPWModule())
                             {
-                                var oldMass = part.mass;
-                                float aeroVolume = ProceduralWing.GetPWingVolume(part); //PWing  0.7 * length * (widthRoot + WidthTip) + (thicknessRoot + ThicknessTip) / 4; yields 1.008 for a stock dimension 2*4*.18 board, so need mult of 1400 for parity with stock wing boards
-                                if (oldMass != part.mass && !_delayedShipModifiedRunning)
-                                {
-                                    _hullModified = true; // Modifying the mass modifies the hull.
-                                    _updateMass = true; // Recalculate the mass on the next frame unless we're already going to.
-                                }
                                 if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: Found {part.name}; HP: {Hitpoints}->{hitpoints} at time {Time.time}, partMass: {partMass}, Pwing Aerovolume: {aeroVolume}");
                                 //hitpoints should scale with stock wings correctly (and if used as thicker structural elements, should scale with tanks of similar size)
                                 armorVolume = ProceduralWing.GetPWingArea(part);
@@ -1473,6 +1494,7 @@ namespace BDArmory.Damage
             {
                 if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: {part.name} updated armour mass {oldArmorMass}->{armorMass} or type {OldArmorType}->{ArmorTypeNum} at time {Time.time}");
                 OldArmorType = ArmorTypeNum;
+                _updateMass = true;
                 part.UpdateMass();
                 if (HighLogic.LoadedSceneIsEditor && EditorLogic.fetch != null)
                     GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
@@ -1557,14 +1579,14 @@ namespace BDArmory.Damage
 
         public void HullSetup(BaseField field, object obj) //no longer needed for realtime HP calcs, but does need to be updated occasionally to give correct vessel mass
         {
-            if (isProcWing)
-            {
-                StartCoroutine(WaitForHullSetup());
-            }
-            else
-            {
+            //if (isProcWing)
+            //{
+            //    StartCoroutine(WaitForHullSetup()); //pWings now handled as aprt of the FixedUpdate pipeline
+            //}
+            //else
+            //{
                 SetHullMass();
-            }
+            //}
         }
         IEnumerator WaitForHullSetup()
         {
@@ -1641,6 +1663,7 @@ namespace BDArmory.Damage
             {
                 if (BDArmorySettings.DEBUG_ARMOR) Debug.Log($"[BDArmory.HitpointTracker]: {part.name} updated hull mass {OldHullMassAdjust}->{HullMassAdjust} (part mass {partMass}, total mass {part.mass + HullMassAdjust - OldHullMassAdjust}) or type {OldHullType}->{HullTypeNum} at time {Time.time}");
                 OldHullType = HullTypeNum;
+                _updateMass = true;
                 part.UpdateMass();
                 if (HighLogic.LoadedSceneIsEditor && EditorLogic.fetch != null)
                     GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);

--- a/BDArmory/Damage/HitpointTracker.cs
+++ b/BDArmory/Damage/HitpointTracker.cs
@@ -1,15 +1,15 @@
-﻿using System;
+﻿using BDArmory.Armor;
+using BDArmory.Extensions;
+using BDArmory.Modules;
+using BDArmory.Settings;
+using BDArmory.UI;
+using BDArmory.Utils;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
-
-using BDArmory.Armor;
-using BDArmory.Extensions;
-using BDArmory.Modules;
-using BDArmory.Settings;
-using BDArmory.Utils;
 
 namespace BDArmory.Damage
 {
@@ -661,38 +661,39 @@ namespace BDArmory.Damage
             }
         }
 
-        void Update()
+        void FixedUpdate()
         {
             if (_finished_setting_up) // Only gets set in flight mode.
             {
                 RefreshHitPoints();
-                return;
             }
-            if (HighLogic.LoadedSceneIsEditor || HighLogic.LoadedSceneIsFlight) // Also needed in flight mode for initial setup of mass, hull and HP, but shouldn't be triggered afterwards as ShipModified is only for the editor.
+            else
             {
-                if (_armorModified)
+                if (HighLogic.LoadedSceneIsEditor || HighLogic.LoadedSceneIsFlight) // Also needed in flight mode for initial setup of mass, hull and HP, but shouldn't be triggered afterwards as ShipModified is only for the editor.
                 {
-                    _armorModified = false;
-                    ArmorSetup(null, null);
-                }
-                if (_hullModified && !_updateMass) // Wait for the mass to update first.
-                {
-                    _hullModified = false;
-                    HullSetup(null, null);
-                }
-                if (!_updateMass) // Wait for the mass to update first.
-                {
-                    RefreshHitPoints();
-                }
-                if (HighLogic.LoadedSceneIsFlight && _armorConfigured && _hullConfigured && _hpConfigured) // No more changes, we're done.
-                {
-                    _finished_setting_up = true;
+                    if (_armorModified)
+                    {
+                        _armorModified = false;
+                        _armorConfigured = false;
+                        ArmorSetup(null, null);
+                    }
+                    if (_hullModified && !_updateMass) // Wait for the mass to update first.
+                    {
+                        _hullModified = false;
+                        _hullConfigured = false;
+                        HullSetup(null, null);
+                    }
+                    if (!_updateMass) // Wait for the mass to update first.
+                    {
+                        RefreshHitPoints();
+                    }
+                    if (HighLogic.LoadedSceneIsFlight && _armorConfigured && _hullConfigured && _hpConfigured) // No more changes, we're done.
+                    {
+                        _finished_setting_up = true;
+                    }
                 }
             }
-        }
 
-        void FixedUpdate()
-        {
             if (_updateMass)
             {
                 _updateMass = false;
@@ -791,6 +792,8 @@ namespace BDArmory.Damage
                 _updateHitpoints = false;
                 _forceUpdateHitpointsUI = false;
                 SetupPrefab();
+                if (HighLogic.LoadedSceneIsEditor)
+                    BDAEditorArmorWindow.Instance.OnEditorShipModifiedEvent(EditorLogic.fetch.ship);
             }
         }
 
@@ -1325,7 +1328,7 @@ namespace BDArmory.Damage
                 //	armorInfo = ArmorInfo.armors[SelectedArmorType];
                 //    ArmorTypeNum = ArmorInfo.armors.FindIndex(t => t.name == SelectedArmorType); //adjust part's current armor setting to match
                 //}
-                guiArmorTypeString = armorInfo.name; //FIXME - Localize these
+                guiArmorTypeString = string.IsNullOrEmpty(armorInfo.localizedName) ? armorInfo.name : StringUtils.Localize(armorInfo.localizedName);
                 SelectedArmorType = armorInfo.name;
                 Density = armorInfo.Density;
                 Diffusivity = armorInfo.Diffusivity;

--- a/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Armors.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Armors.cfg
@@ -5,6 +5,7 @@
 ARMOR
 {
     name = def // do not change this!
+	localizedName = def //name displayed in game
 	Density = 7850 //in kg/m3
 	Strength = 840 // Ultimate Tensile Strengh, in MPa
 	Hardness = 1176 // in MPa, using Brinell
@@ -23,6 +24,7 @@ ARMOR
 ARMOR
 {
     name = None //based off of Aluminium, since most parts assumed to be made if it
+	localizedName = #LOC_BDArmory_ArmorNone
 	Density = 2700 //hardcoded overide, armor of type None will add 0 mass to part
 	Strength = 200
 	Hardness = 300
@@ -37,7 +39,8 @@ ARMOR
 
 ARMOR
 {
-    name = Mild Steel //more or less analogous to legacy armor
+    name = Mild Steel //more or less analogous to legacy armor. More-or-less equivalent to RHA.
+	localizedName = #LOC_BDArmory_ArmorSteel
 	Density = 7850
 	Strength = 940
 	Hardness = 1176
@@ -52,7 +55,8 @@ ARMOR
 
 ARMOR
 {
-    name = Titanium 
+    name = Titanium //Beta Titanium alloy
+	localizedName = #LOC_BDArmory_ArmorTitanium
 	Density = 4506
 	Strength = 552 
 	Hardness = 2000
@@ -68,6 +72,7 @@ ARMOR
 ARMOR
 {
     name = Beryllium
+	localizedName = #LOC_BDArmory_ArmorBeryllium
 	Density = 1850
 	Strength = 370
 	Hardness = 1320
@@ -83,6 +88,7 @@ ARMOR
 ARMOR
 {
     name = Aramid Fibre
+	localizedName =  #LOC_BDArmory_ArmorAramid
 	Density = 1440
 	Strength = 300
 	Hardness = 10
@@ -98,6 +104,7 @@ ARMOR
 ARMOR
 {
     name = S-Glass Composite
+	localizedName = #LOC_BDArmory_ArmorFiberglass
 	Density = 1800 //2480 for raw S-Glass fibre
 	Strength = 274.6 //4710 for raw fibre
 	Hardness = 780
@@ -113,6 +120,7 @@ ARMOR
 ARMOR
 {
     name = Depleted Uranium
+	localizedName = #LOC_BDArmory_ArmorDU
 	Density = 19000
 	Strength = 1720
 	Hardness = 3850
@@ -128,6 +136,7 @@ ARMOR
 ARMOR
 {
     name = Armor Aluminium // Aluminium 7039
+	localizedName = #LOC_BDArmory_Aluminium
 	Density = 2740
 	Strength = 450
 	Hardness = 300
@@ -144,6 +153,7 @@ ARMOR
     // Based on https://www.laird.com/sites/default/files/2021-10/RFP-DS-BSR%20MFS%2022092021.pdf
     // List of other RAM products here: https://www.laird.com/sites/default/files/2023-02/Brochure-%20Absorber%20Infosheet_Military_Aerospace.pdf
     name = Radar Absorbent Coating
+	localizedName = #LOC_BDArmory_ArmorRAM
     Density = 4200
     Strength = 5
     Hardness = 514 // ~70 Shore hardness

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -31,7 +31,7 @@
 	- Turrets:
 		- Added "baseTransformName" field to turrets, while this was previously unclear, the parent transform of yawTransform was previously being used to determine the turret's center of rotation and the orientation of its axes. This has now been made into an explicit field to allow modders to better control this behavior. Unless specified, the transform will be set to the parent of the yawTransform.
 		- Made turret code more failure tolerant, and capable of dealing with cases where yawTransform and/or pitchTransform are missing. IMPORTANT NOTE: A turret lacking a yawTransform and/or pitchTransform will NOT function properly, it will try to work around it, but the modder should fix this issue ASAP!
-	- Active rotection Systems:
+	- Active Protection Systems:
 		- Target shells now need to be within a certain size/APS needs to pass penetration depth check to destroy larger shells; no more destroying battleship shells with standard anti-tankshell APS.
 		- APS debugging moved to new Debug Pointdefense toggle.
 	- Explosions:

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -2,12 +2,16 @@ IMPROVEMENTS / FIXES
 - General:
 	- Fix GetBodyByName("Kerbin") issues for mods that replace Kerbin.
 	- Fix HP and cost scaling of parts when TweakScale is installed.
+	- Fix Battle Damage 'Proc Min Penetration'; now properly functions as a minimum threshold for BD to occur.
+	- Added additional conditions for BD to occur, should stop seeing gimbals jam, etc, from scratch-the-paint chip damage.
 - UI:
 	- Updated German localisation from EzBro.
 	- Updated Japanese localisation from Taka005.
 	- Fix infolink explanation of Extend Abort Time / Extend Min Gain Rate.
 	- BDA UI Icon draw distance (MAX_DISTANCE_THRESHOLD) no longer clamped to a max of MAX_GUARD_VISUAL_RANGE.
 	- Add an option (and MM patch) to allow specifying the Kerbal Suit kerbals spawn with in crewed parts. Adds an override in the vessel spawner window for BDA spawns.
+	- New 'localizedName' field for armor material configs.
+	- Fix Craft Utilities Tool GUI mis-reporting craft Lift-To-Weight on craft load in some cases.
 - AI / WM:
 	- Fix Guard Mode using incorrect heat signature value for IR missile selection.
 	- Add "Attack Uncontrolled Tgt." Weight to the Weapon Manager, setting this to negative makes the AI prioritize targets under control, thus avoiding wasting ammo on vehicles with knocked out crews. NOTE: Be cautious when using this on aircraft, this includes g-loc'd pilots!
@@ -40,9 +44,9 @@ IMPROVEMENTS / FIXES
 			- The currently selected weapon will always take priority over all other turrets using that axis.
 			- New "turretPriority" field that determines which turret is prioritized over others when none of the weapons using that axis are currently selected. HIGHER values are prioritized.
 			- For turrets with the same "turretPriority" value, the turret with the LOWEST "turretID" is prioritized (to allow support for older mods which were created prior to this feature being added).
-  - Active Protection Systems:
+	- Active Protection Systems:
 		- Target shells now need to be within a certain size/APS needs to pass penetration depth check to destroy larger shells; no more destroying battleship shells with standard anti-tankshell APS.
-		- APS debugging moved to new Debug Pointdefense toggle.
+		- APS debugging moved to new Debug PointDefense toggle.
 	- Explosions:
 		- Re-implemented the shaped charge unfocusing/squeezing mechanic, where as the shaped charge jet penetrates armor, it loses coherence and diameter.
 		- Add spall to shaped charge damage calculations, shaped charge now carries along a % of the spall it produces as it penetrates causing additional damage.
@@ -87,9 +91,9 @@ IMPROVEMENTS / FIXES
 			- Custom turrets now compatible with turret multi-targeting		
 			- Can now use custom turrets for anti-missile point defense.
 		- Improved debug telemetry output format.
-	- Competition:
-		- Fix Waypoint mode immediately moving to next heat on start when running a surface AI WP race with multiple racers when Activate Guard After Gate is disabled.
-		- Groundspawn Waypoint Races will now spawn racers in a grid start arrangement instead of circle spawn.
+- Competition:
+	- Fix Waypoint mode immediately moving to next heat on start when running a surface AI WP race with multiple racers when Activate Guard After Gate is disabled.
+	- Groundspawn Waypoint Races will now spawn racers in a grid start arrangement instead of circle spawn.
 
 v1.12.1.0
 IMPROVEMENTS / FIXES

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -29,6 +29,9 @@
 	- Turrets:
 		- Added "baseTransformName" field to turrets, while this was previously unclear, the parent transform of yawTransform was previously being used to determine the turret's center of rotation and the orientation of its axes. This has now been made into an explicit field to allow modders to better control this behavior. Unless specified, the transform will be set to the parent of the yawTransform.
 		- Made turret code more failure tolerant, and capable of dealing with cases where yawTransform and/or pitchTransform are missing. IMPORTANT NOTE: A turret lacking a yawTransform and/or pitchTransform will NOT function properly, it will try to work around it, but the modder should fix this issue ASAP!
+	- Active rotection Systems:
+		- Target shells now need to be within a certain size/APS needs to pass penetration depth check to destroy larger shells; no more destroying battleship shells with standard anti-tankshell APS.
+		- APS debugging moved to new Debug Pointdefense toggle.
 	- Explosions:
 		- Re-implemented the shaped charge unfocusing/squeezing mechanic, where as the shaped charge jet penetrates armor, it loses coherence and diameter.
 		- Add spall to shaped charge damage calculations, shaped charge now carries along a % of the spall it produces as it penetrates causing additional damage.
@@ -52,11 +55,13 @@
 		- Fix IR missiles not turning towards a target they lost track of.
 		- Fix terminal targeting checks reducing track accuracy for missiles with a terminal targeting mode.
 		- Fix debug readouts for radar missiles, now when lacking a target they should properly display "No target!", seeker timeout time will also now display correctly.
-    - Fix active sonar torpedoes diving to the seafloor if they lose lock immediately on launch.
+    		- Fix active sonar torpedoes diving to the seafloor if they lose lock immediately on launch.
 		- Custom Turrets:
 			- Add Lofted Aimpoint and Loft Vel. Fac. settings to missiles on custom turrets, giving them function parity with regular missile turrets.
 			- Fix custom turrets with no radar failing the launch authorization check.
-      - Fix custom turrets incorporating guns with turrets (M102 howitzer, etc.) not targeting aircraft.
+      			- Fix custom turrets incorporating guns with turrets (M102 howitzer, etc.) not targeting aircraft.
+			- Custom turrets now compatible with turret multi-targeting		
+			- Can now use custom turrets for anti-missile point defense.
 		- Improved debug telemetry output format.
 	- Competition
 		- Fix Waypoint mode immediately moving to next heat on start when running a surface AI WP race with multiple racers when Activate Guard Aftter Gate is disabled.

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -188,6 +188,7 @@ Localization
                 #LOC_BDArmory_Settings_DebugRadar = Detectors
                 #LOC_BDArmory_Settings_DebugSpawning = Spawning
                 #LOC_BDArmory_Settings_DebugWeapons = Weapons
+                #LOC_BDArmory_Settings_DebugAPS = PointDefense
                 #LOC_BDArmory_Settings_ResetScrollZoom = Reset Scroll-Zoom
 
         // Gameplay      FIXME These need more sorting

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -1554,12 +1554,6 @@ Localization
         #LOC_BDArmory_ArmorAdjustParts = Translate Attached Parts
         #LOC_BDArmory_ArmorTriIso = Triangle Type: Isoceles
         #LOC_BDArmory_ArmorTriSca = Triangle Type: Scalene 
-        #LOC_BDArmory_Wood = Wood
-        #LOC_BDArmory_Aluminium = Aluminium
-        #LOC_BDArmory_Steel = Steel
-        #LOC_BDArmory_Titanium = Titanium
-        #LOC_BDArmory_Composites = Composites
-        #LOC_BDArmory_RAMFoam = Radar Absorbent Foam
         #LOC_BDArmory_Armor_HullType = Hull Material
         #LOC_BDArmory_ArmorThickness = Armor Thickness
         #LOC_BDArmory_EquivalentThickness = Steel Equivalent Thickness
@@ -1606,7 +1600,22 @@ Localization
         #LOC_BDArmory_ArmorToolNonCockpit = not attached to cockpit
         #LOC_BDArmory_ArmorToolOversizedPWings = pWings exceeding max Lift - check Lift Visualizer
         #LOC_BDArmory_ArmorToolVesselLegal = Vessel legal!
-
+    // Hull Material Names
+        #LOC_BDArmory_Wood = Wood
+        #LOC_BDArmory_Aluminium = Aluminium
+        #LOC_BDArmory_Steel = Steel
+        #LOC_BDArmory_Titanium = Titanium
+        #LOC_BDArmory_Composites = Composites
+        #LOC_BDArmory_RAMFoam = Radar Absorbent Foam
+    //Armor Material names
+        #LOC_BDArmory_ArmorNone = No Armor
+        #LOC_BDArmory_ArmorSteel = RHA Steel
+        #LOC_BDArmory_ArmorTitanium = Beta Titanium
+        #LOC_BDArmory_ArmorBeryllium = Beryllium
+        #LOC_BDArmory_ArmorAramid = Aramid Fibre
+        #LOC_BDArmory_ArmorFiberglass = S-Glass Composite
+        #LOC_BDArmory_ArmorDU = Depleted Uranium
+        #LOC_BDArmory_ArmorRAM = Radar Absorbent Coating
 
     // Missile & CM Settings
         #LOC_BDArmory_Settings_MissileCMToggle = Show Missile & Countermeasure Settings

--- a/BDArmory/GameModes/BattleDamage/BattleDamageHandler.cs
+++ b/BDArmory/GameModes/BattleDamage/BattleDamageHandler.cs
@@ -1,7 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using UnityEngine;
-
 using BDArmory.Ammo;
 using BDArmory.Competition;
 using BDArmory.Control;
@@ -15,7 +11,11 @@ using BDArmory.Settings;
 using BDArmory.Targeting;
 using BDArmory.Utils;
 using BDArmory.WeaponMounts;
+using BDArmory.Weapons.Missiles;
 using Expansions.Serenity;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
 
 namespace BDArmory.GameModes
 {
@@ -24,6 +24,7 @@ namespace BDArmory.GameModes
         public static void CheckDamageFX(Part part, float caliber, float penetrationFactor, bool explosivedamage, bool incendiary, string attacker, RaycastHit hitLoc, bool firsthit = true, bool cockpitPen = false, Vector3 colliderLocalHitPoint = default)
         {      
             if (!BDArmorySettings.BATTLEDAMAGE || BDArmorySettings.PAINTBALL_MODE) return;
+			if (penetrationFactor < BDArmorySettings.BD_DAMAGE_PENETRATION) return;
             penetrationFactor = Mathf.Clamp(penetrationFactor, 0.01f, 4f);
             if (BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.ZOMBIE_MODE)
             //if (BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.RUNWAY_PROJECT_ROUND == -1)
@@ -136,6 +137,7 @@ namespace BDArmory.GameModes
             if (BDArmorySettings.BD_PROPULSION)
             {
                 BattleDamageTracker tracker = part.gameObject.AddOrGetComponent<BattleDamageTracker>();
+				if (penetrationFactor < 0.8f) return;
                 tracker.Part = part;
                 if (part.isEngine() && part.GetDamagePercentage() < 0.95f) //first hit's free
                 {
@@ -252,27 +254,82 @@ namespace BDArmory.GameModes
                 if (BDArmorySettings.BD_GIMBALS) //engine gimbal damage
                 {
                     var gimbal = part.FindModuleImplementing<ModuleGimbal>();
-                    if (gimbal != null)
+					if (penetrationFactor < 0.65f) return;
+                    if (gimbal != null && part.GetDamagePercentage() < 0.95f) //first hit's free)
                     {
-                        double HEBonus = 1;
+                        float HEBonus = 1;
                         if (explosivedamage)
                         {
-                            HEBonus = 1.4;
+                            HEBonus = 0.8f;
                         }
                         if (incendiary)
                         {
-                            HEBonus = 1.25;
+                            HEBonus = 0.95f;
                         }
                         //gimbal.gimbalRange *= (1 - (((1 - part.GetDamagePercentatge()) * HEBonus) / BDArmorySettings.BD_PROP_DAM_RATE)); //HE does bonus damage
                         double Diceroll = UnityEngine.Random.Range(0, 100);
                         if (BDArmorySettings.DEBUG_DAMAGE) Debug.Log("[BDArmory.BattleDamageHandler]: Gimbal DiceRoll: " + Diceroll);
-                        if (Diceroll <= (BDArmorySettings.BD_DAMAGE_CHANCE * HEBonus))
+                        if (Diceroll <= (damageChance * HEBonus))
                         {
-                            gimbal.enabled = false;
-                            gimbal.gimbalRange = 0;
-                            if (incendiary)
+                            if (gimbal.gimbalRangeXN + gimbal.gimbalRangeXP + gimbal.gimbalRangeYN + gimbal.gimbalRangeYP > 0)
                             {
-                                BulletHitFX.AttachFire(hitPoint, part, caliber, attacker, 20);
+                                double ActuatorRoll = UnityEngine.Random.Range(0, 100);
+                                if (ActuatorRoll <= 88)
+                                {
+                                    if (ActuatorRoll <= 22)
+                                    {
+                                        if (gimbal.gimbalRangeXN > 2) { gimbal.gimbalRangeXN *= (part.GetDamagePercentage() * HEBonus); }
+                                        else gimbal.gimbalRangeXN = 0;
+                                    }
+                                    else if (ActuatorRoll <= 44)
+                                    {
+                                        if (gimbal.gimbalRangeXP > 2) { gimbal.gimbalRangeXP *= (part.GetDamagePercentage() * HEBonus); }
+                                        else gimbal.gimbalRangeXP = 0;
+                                    }
+                                    else if (ActuatorRoll <= 66)
+                                    {
+                                        if (gimbal.gimbalRangeYP > 2) { gimbal.gimbalRangeYP *= (part.GetDamagePercentage() * HEBonus); }
+                                        else gimbal.gimbalRangeYP = 0;
+                                    }
+                                    else
+                                    {
+                                        if (gimbal.gimbalRangeYN > 2) { gimbal.gimbalRangeYN *= (part.GetDamagePercentage() * HEBonus); }
+                                        else gimbal.gimbalRangeYN = 0;
+                                    }
+                                    if (Diceroll <= ((BDArmorySettings.BD_DAMAGE_CHANCE / HEBonus) / 2))
+                                    {
+                                        BulletHitFX.AttachFire(hitPoint, part, caliber, attacker, 10);
+                                    }
+                                }
+                                else
+                                {
+                                    gimbal.enabled = false;
+                                    gimbal.gimbalRange = 0;
+                                    if (incendiary)
+                                    {
+                                        BulletHitFX.AttachFire(hitPoint, part, caliber, attacker, 20);
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                if (gimbal.gimbalRange < 3)
+                                {
+                                    gimbal.enabled = false;
+                                    gimbal.gimbalRange = 0;
+                                    if (incendiary)
+                                    {
+                                        BulletHitFX.AttachFire(hitPoint, part, caliber, attacker, 20);
+                                    }
+                                }
+                                else
+                                {
+                                    gimbal.gimbalRange *= (part.GetDamagePercentage() * HEBonus);
+                                    if (Diceroll <= ((BDArmorySettings.BD_DAMAGE_CHANCE / HEBonus) / 2))
+                                    {
+                                        BulletHitFX.AttachFire(hitPoint, part, caliber, attacker, 10);
+                                    }
+                                }
                             }
                         }
                     }
@@ -344,6 +401,7 @@ namespace BDArmory.GameModes
             //Subsystems
             if (BDArmorySettings.BD_SUBSYSTEMS && firsthit)
             {
+				if (penetrationFactor < 0.8) return;
                 double Diceroll = UnityEngine.Random.Range(0, 100);
                 bool subsysCrit = false;
                 if (BDArmorySettings.DEBUG_DAMAGE) Debug.Log("[BDArmory.BattleDamageHandler]: Subsystem DiceRoll: " + Diceroll + "; needs: " + damageChance);

--- a/BDArmory/Settings/BDArmorySettings.cs
+++ b/BDArmory/Settings/BDArmorySettings.cs
@@ -121,6 +121,7 @@ namespace BDArmory.Settings
         [BDAPersistentSettingsField] public static bool DEBUG_OTHER = false;                 //internal debugging
         [BDAPersistentSettingsField] public static bool DEBUG_ARMOR = false;                 //armor and HP
         [BDAPersistentSettingsField] public static bool DEBUG_WEAPONS = false;               //Debug messages for guns/rockets/lasers and their projectiles
+        [BDAPersistentSettingsField] public static bool DEBUG_APS = false;                   //Debug messages for point defense weapons
         [BDAPersistentSettingsField] public static bool DEBUG_MISSILES = false;              //Missile launch, tracking and targeting debug labels
         [BDAPersistentSettingsField] public static bool DEBUG_DAMAGE = false;                //Explosions and battle damage logging
         [BDAPersistentSettingsField] public static bool DEBUG_AI = false;                    //AI debugging

--- a/BDArmory/UI/BDAEditorArmorWindow.cs
+++ b/BDArmory/UI/BDAEditorArmorWindow.cs
@@ -148,7 +148,7 @@ namespace BDArmory.UI
             armorGUI = new GUIContent[ArmorInfo.armors.Count];
             for (int i = 0; i < ArmorInfo.armors.Count; i++)
             {
-                GUIContent gui = new GUIContent(ArmorInfo.armors[i].name.Length <= 17 ? ArmorInfo.armors[i].name : ArmorInfo.armors[i].name.Remove(14) + "...");
+                GUIContent gui = new GUIContent(ArmorInfo.armors[i].localizedName.Length <= 17 ? ArmorInfo.armors[i].localizedName : ArmorInfo.armors[i].name.Remove(14) + "...");
                 armorGUI[i] = gui;
             }
             armorBoxText = new GUIContent();
@@ -184,7 +184,7 @@ namespace BDArmory.UI
             }
         }
 
-        private void OnEditorShipModifiedEvent(ShipConstruct data)
+        public void OnEditorShipModifiedEvent(ShipConstruct data)
         {
             if (data is null) return;
             delayedRefreshVisuals = true;
@@ -274,7 +274,7 @@ namespace BDArmory.UI
 
         private void OnEditorPartPlacedEvent(Part data)
         {
-            DoVesselLegalityChecks(true);
+            //DoVesselLegalityChecks(true); //these also get triggered in OnShipModified, which properly waits for HP, etc to settle; important since LegalityChecks also calls CalculateTotalLift, which needs craft mass settled
             if (BDArmorySettings.RUNWAY_PROJECT && BDArmorySettings.RUNWAY_PROJECT_ROUND == 78)
             {
                 data.sameVesselCollision = true;

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -2641,7 +2641,7 @@ namespace BDArmory.UI
                         BDArmorySettings.DEBUG_RADAR = GUI.Toggle(SQuarterRect(line, 2), BDArmorySettings.DEBUG_RADAR, StringUtils.Localize("#LOC_BDArmory_Settings_DebugRadar"));//"Debug Detectors"
                         BDArmorySettings.DEBUG_SPAWNING = GUI.Toggle(SQuarterRect(line, 3), BDArmorySettings.DEBUG_SPAWNING, StringUtils.Localize("#LOC_BDArmory_Settings_DebugSpawning"));//"Debug Spawning"
                         BDArmorySettings.DEBUG_APS = GUI.Toggle(SQuarterRect(++line, 0), BDArmorySettings.DEBUG_APS, StringUtils.Localize("#LOC_BDArmory_Settings_DebugAPS"));//"Debug PointDefense"
-                        BDArmorySettings.DEBUG_OTHER = GUI.Toggle(SQuarterRect(++line, 0), BDArmorySettings.DEBUG_OTHER, StringUtils.Localize("#LOC_BDArmory_Settings_DebugOther"));//"Debug Other"
+                        BDArmorySettings.DEBUG_OTHER = GUI.Toggle(SQuarterRect(line, 2), BDArmorySettings.DEBUG_OTHER, StringUtils.Localize("#LOC_BDArmory_Settings_DebugOther"));//"Debug Other"
 
                         if (BDArmorySettings.DEBUG_OTHER && GUI.Button(SLineRect(++line), StringUtils.Localize("#LOC_BDArmory_Settings_ResetScrollZoom"))) GUIUtils.ResetScrollRate(); // Reset scroll-zoom.
                         if (BDArmorySettings.DEBUG_AI && GUI.Button(SLineRect(++line), "Debug Extending")) // Debug why a vessel is stuck in extending.

--- a/BDArmory/UI/BDArmorySetup.cs
+++ b/BDArmory/UI/BDArmorySetup.cs
@@ -2625,6 +2625,7 @@ namespace BDArmory.UI
                             BDArmorySettings.DEBUG_SPAWNING = false;
                             BDArmorySettings.DEBUG_TELEMETRY = false;
                             BDArmorySettings.DEBUG_WEAPONS = false;
+                            BDArmorySettings.DEBUG_APS = false;
                         }
                     }
                     if (BDArmorySettings.DEBUG_SETTINGS_TOGGLE)
@@ -2639,6 +2640,7 @@ namespace BDArmory.UI
                         BDArmorySettings.DEBUG_COMPETITION = GUI.Toggle(SQuarterRect(line, 1), BDArmorySettings.DEBUG_COMPETITION, StringUtils.Localize("#LOC_BDArmory_Settings_DebugCompetition"));//"Debug Competition"
                         BDArmorySettings.DEBUG_RADAR = GUI.Toggle(SQuarterRect(line, 2), BDArmorySettings.DEBUG_RADAR, StringUtils.Localize("#LOC_BDArmory_Settings_DebugRadar"));//"Debug Detectors"
                         BDArmorySettings.DEBUG_SPAWNING = GUI.Toggle(SQuarterRect(line, 3), BDArmorySettings.DEBUG_SPAWNING, StringUtils.Localize("#LOC_BDArmory_Settings_DebugSpawning"));//"Debug Spawning"
+                        BDArmorySettings.DEBUG_APS = GUI.Toggle(SQuarterRect(++line, 0), BDArmorySettings.DEBUG_APS, StringUtils.Localize("#LOC_BDArmory_Settings_DebugAPS"));//"Debug PointDefense"
                         BDArmorySettings.DEBUG_OTHER = GUI.Toggle(SQuarterRect(++line, 0), BDArmorySettings.DEBUG_OTHER, StringUtils.Localize("#LOC_BDArmory_Settings_DebugOther"));//"Debug Other"
 
                         if (BDArmorySettings.DEBUG_OTHER && GUI.Button(SLineRect(++line), StringUtils.Localize("#LOC_BDArmory_Settings_ResetScrollZoom"))) GUIUtils.ResetScrollRate(); // Reset scroll-zoom.

--- a/BDArmory/Utils/FARUtils.cs
+++ b/BDArmory/Utils/FARUtils.cs
@@ -414,4 +414,79 @@ namespace BDArmory.Utils
             return 20;
         }
     }
+
+    public class B9PartSwitch : MonoBehaviour
+    {
+        public static B9PartSwitch Instance;
+        public static bool hasB9 = false;
+        private static bool hasCheckedForB9 = false;
+        public static bool hasB9Module = false;
+        private static bool hasCheckedForB9Module = false;
+
+        public static Assembly B9PSAssembly;
+        public static Type B9PSModule;
+
+
+        void Awake()
+        {
+            if (Instance != null) return; // Don't replace existing instance.
+            Instance = new B9PartSwitch();
+        }
+
+        void Start()
+        {
+            CheckForB9PS();
+            if (hasB9)
+            {
+                CheckForB9Module();
+            }
+        }
+
+        public static bool CheckForB9PS()
+        {
+            if (hasCheckedForB9) return hasB9;
+            hasCheckedForB9 = true;
+            foreach (var assy in AssemblyLoader.loadedAssemblies)
+            {
+                if (assy.assembly.FullName.StartsWith("B9PartSwitch"))
+                {
+                    B9PSAssembly = assy.assembly;
+                    hasB9 = true;
+                    if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.B9Utils]: Found B9PS Assembly: {B9PSAssembly.FullName}");
+                }
+            }
+            return hasB9;
+        }
+
+        public static bool CheckForB9Module()
+        {
+            if (!hasB9) return false;
+            if (hasCheckedForB9Module) return hasB9Module;
+            hasCheckedForB9Module = true;
+            foreach (var type in B9PSAssembly.GetTypes())
+            {
+                if (type.Name == "ModuleB9PartSwitch")
+                {
+                    B9PSModule = type;
+                    hasB9Module = true;
+                    if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.B9Utils]: Found B9 module type.");
+                }
+            }
+            return hasB9Module;
+        }
+
+        public static bool checkForSimpleRepaint(Part part)
+        {
+            if (!hasB9Module) return false;
+            foreach (var module in part.Modules)
+            {
+                if (module.GetType() == B9PSModule)
+                {
+                    string SR = (string)B9PSModule.GetField("moduleID", BindingFlags.Public | BindingFlags.Instance).GetValue(module);
+                    return SR == "SimpleRepaint" ? true : false;
+                }
+            }
+            return false;
+        }
+    }
 }

--- a/BDArmory/Utils/FARUtils.cs
+++ b/BDArmory/Utils/FARUtils.cs
@@ -321,6 +321,7 @@ namespace BDArmory.Utils
                                 }
                             }
                         }
+                        part.UpdateMass();
                         return aeroVolume;
                     }
                 }
@@ -365,7 +366,7 @@ namespace BDArmory.Utils
                     }
                 }
             }
-
+            part.UpdateMass();
             if (BDArmorySettings.DEBUG_OTHER) Debug.Log($"[BDArmory.FARUtils]: Pwing module not found!");
             return 0;
         }

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -6178,11 +6178,11 @@ namespace BDArmory.Weapons
                 }
                 yield return new WaitForSeconds(delayTime);
                 bool tgtDestroyed = false;
-                bool tgtdeflected = false;
+                bool tgtDeflected = false;
                 if (shell != null)
                 {
                     //Hit cases:
-                    //HE APS vs HE tgtShell: can APS pen tgtShell? (e.g. this vs naval arty?) Y destroy shell, N deflect (impact, force of detonation, tgtshell now deformed and tumbling, etc
+                    //HE APS vs HE tgtShell: can APS pen tgtShell? (e.g. this vs naval arty?) Y destroy shell, N deflect (impact, force of detonation, tgtshell now deformed and tumbling, etc)
                     //AP APS vs HE tgtshell: deflect tgtshell based on velocity/mass, if tgtshell is at most 2x size of APSshell, detonate; something something slamming into the fuze
                     //AP APS vs slug tgtShell: deflect tgtShell based on velocity/mass
                     //HE APS vs Slug tgtShell: can APS pen tgtShell? higher threshold, would need to pen almost to center, but same as above
@@ -6190,17 +6190,17 @@ namespace BDArmory.Weapons
                     {
                         if (tntMass > 0 || eWeaponType == WeaponTypes.Laser)// APS using HE bullet/rocket
                         {
-                            if (penetrationDepth * 1.3f > ((shell.caliber / 2) * HERatio)) //pendepth * fudgefactor to account relative velocity/impact speed vs shell radius, modified my HE filler amount
+                            if (penetrationDepth * 1.3f > ((shell.caliber / 2) * HERatio)) //pendepth * fudgefactor to account relative velocity/impact speed vs shell radius, modified by HE filler amount
                                 tgtDestroyed = true;
                             else
-                                tgtdeflected = true;
+                                tgtDeflected = true;
                         }
                         else //APS using slug ammo
                         {
                             if (tgtShell.caliber <= caliber * 2) //abstraction; something something APS round slamming into the fuze as it impacts
                                 tgtDestroyed = true;
                             else
-                                tgtdeflected = true;
+                                tgtDeflected = true;
                         }
                     }
                     else //solid slug tgtShells
@@ -6216,11 +6216,11 @@ namespace BDArmory.Weapons
                             if (penetrationDepth * 1.3f > (shell.caliber / 2) && Mathf.Clamp(tntMass / shell.bulletMass, 0f, 0.95f) > 0.05f) //can APS pen to center + have enough HE to shatter tgtshell?
                                 tgtDestroyed = true;
                             else
-                                tgtdeflected = true;
+                                tgtDeflected = true;
                         }
                         else //APS using slug ammo
                         {
-                            tgtdeflected = true;
+                            tgtDeflected = true;
                         }                        
                     }
                 }
@@ -6242,7 +6242,7 @@ namespace BDArmory.Weapons
                     tgtShell = null;
                     if (BDArmorySettings.DEBUG_APS) Debug.Log($"[BDArmory.ModuleWeapon] {part.partInfo.name} on {vessel.vesselName} Detonated Incoming Projectile!");
                 }
-                if (tgtdeflected)
+                if (tgtDeflected)
                 {
                     shell.bulletMass -= bulletMass;
                     shell.currentVelocity = VectorUtils.GaussianDirectionDeviation(shell.currentVelocity, ((shell.bulletMass * shell.currentVelocity.magnitude) / (bulletMass * bulletVelocity)));

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -214,6 +214,7 @@ namespace BDArmory.Weapons
         public PooledRocket tgtRocket = null;
         Vector3 closestTarget = Vector3.zero;
         Vector3 tgtVelocity = Vector3.zero;
+        float penetrationDepth = 0;
 
         private int targetID = 0;
         bool targetAcquired;
@@ -6140,26 +6141,43 @@ namespace BDArmory.Weapons
                         yield break; //simulate inaccuracy, decreasing as incoming projectile gets closer
                     }
                 }
+                float HERatio = 1 - Mathf.Clamp(shell.tntMass / shell.bulletMass, 0f, 0.95f);
                 delayTime = eWeaponType == WeaponTypes.Ballistic ? (targetDistance / (bulletVelocity + (targetVelocity - part.rb.velocity).magnitude)) : (eWeaponType == WeaponTypes.Rocket ? (targetDistance / ((targetDistance / predictedFlightTime) + (targetVelocity - part.rb.velocity).magnitude)) : -1);
                 if (delayTime < 0)
                 {
-                    delayTime = rocket != null ? 0.5f : (shell.bulletMass * (1 - Mathf.Clamp(shell.tntMass / shell.bulletMass, 0f, 0.95f) / 2)); //for shells, laser delay time is based on shell mass/HEratio. The heavier the shell, the more mass to burn through. Don't expect to stop sabots via laser APS
+                    delayTime = rocket != null ? 0.5f : (shell.bulletMass * (HERatio / 2)); //for shells, laser delay time is based on shell mass/HEratio. The heavier the shell, the more mass to burn through. Don't expect to stop sabots via laser APS
                     var angularSpread = tanAngle * targetDistance;
                     delayTime /= ((laserDamage / (1 + Mathf.PI * angularSpread * angularSpread) * 0.425f) / 100);
                     if (delayTime < TimeWarp.fixedDeltaTime) delayTime = 0;
                 }
                 yield return new WaitForSeconds(delayTime);
+                bool tgtDestroyed = false;
+                bool tgtdeflected = false;
                 if (shell != null)
                 {
-                    if (shell.tntMass > 0)
+                    //Hit cases:
+                    //HE APS vs HE tgtShell: can APS pen tgtShell? (e.g. this vs naval arty?) Y destroy shell, N deflect (impact, force of detonation, tgtshell now deformed and tumbling, etc
+                    //AP APS vs HE tgtshell: deflect tgtshell based on velocity/mass, if tgtshell is at most 2x size of APSshell, detonate; something something slamming into the fuze
+                    //AP APS vs slug tgtShell: deflect tgtShell based on velocity/mass
+                    //HE APS vs Slug tgtShell: can APS pen tgtShell? higher threshold, would need to pen almost to center, but same as above
+                    if (shell.tntMass > 0) //HE tgtshells
                     {
-                        shell.hasDetonated = true;
-                        ExplosionFx.CreateExplosion(shell.transform.position, shell.tntMass, shell.explModelPath, shell.explSoundPath, ExplosionSourceType.Bullet, shell.caliber, null, shell.sourceVesselName, null, null, default, -1, false, shell.bulletMass, -1, 1, sourceVelocity: shell.currentVelocity);
-                        shell.KillBullet();
-                        tgtShell = null;
-                        if (BDArmorySettings.DEBUG_WEAPONS) Debug.Log($"[BDArmory.ModuleWeapon] {part.partInfo.name} on {vessel.vesselName} Detonated Incoming Projectile!");
+                        if (tntMass > 0 || eWeaponType == WeaponTypes.Laser)// APS using HE bullet/rocket
+                        {
+                            if (penetrationDepth * 1.3f > ((shell.caliber / 2) * HERatio)) //pendepth * fudgefactor to account relative velocity/impact speed vs shell radius, modified my HE filler amount
+                                tgtDestroyed = true;
+                            else
+                                tgtdeflected = true;
+                        }
+                        else //APS using slug ammo
+                        {
+                            if (tgtShell.caliber <= caliber * 2) //abstraction; something something APS round slamming into the fuze as it impacts
+                                tgtDestroyed = true;
+                            else
+                                tgtdeflected = true;
+                        }
                     }
-                    else
+                    else //solid slug tgtShells
                     {
                         if (eWeaponType == WeaponTypes.Laser)
                         {
@@ -6167,24 +6185,17 @@ namespace BDArmory.Weapons
                             tgtShell = null;
                             if (BDArmorySettings.DEBUG_WEAPONS) Debug.Log($"[BDArmory.ModuleWeapon] {part.partInfo.name} on {vessel.vesselName} Vaporized Incoming Projectile!");
                         }
-                        else
+                        else if (tntMass > 0)// APS using HE bullet/rocket
                         {
-                            if (tntMass <= 0) //e.g. APS flechettes vs sabot
-                            {
-                                shell.bulletMass -= bulletMass;
-                                shell.currentVelocity = VectorUtils.GaussianDirectionDeviation(shell.currentVelocity, ((shell.bulletMass * shell.currentVelocity.magnitude) / (bulletMass * bulletVelocity)));
-                                //shell.caliber = //have some modification of caliber to sim knocking round off-prograde?
-                                //Thing is, something like a sabot liable to have lever action work upon it, spin it so it now hits on it's side instead of point first, but a heavy arty shell you have both substantially greater mass to diflect, and lesser increase in caliber from perpendicular hit - sabot from point on to side on is like a ~10x increase, a 208mm shell is like 1.2x 
-                                //there's also the issue of gross modification of caliber in this manner if the shell receives multiple impacts from APS interceptors before it hits; would either need to be caliber = x, which isn't appropraite for heavy shells that would not be easily knocked off course, or caliber +=, which isn't viable for sabots
-                                //easiest way would just have the APS interceptor destroy the incoming round, regardless; and just accept the occasional edge cases like a flechetteammo APS being able to destroy AP naval shells instead of tickling them and not much else
-                            }
+                            if (penetrationDepth * 1.3f > (shell.caliber / 2) && Mathf.Clamp(tntMass / shell.bulletMass, 0f, 0.95f) > 0.05f) //can APS pen to center + have enough HE to shatter tgtshell?
+                                tgtDestroyed = true;
                             else
-                            {
-                                shell.KillBullet();
-                                tgtShell = null;
-                                if (BDArmorySettings.DEBUG_WEAPONS) Debug.Log($"[BDArmory.ModuleWeapon] {part.partInfo.name} on {vessel.vesselName} Exploded Incoming Projectile!");
-                            }
+                                tgtdeflected = true;
                         }
+                        else //APS using slug ammo
+                        {
+                            tgtdeflected = true;
+                        }                        
                     }
                 }
                 else
@@ -6196,6 +6207,20 @@ namespace BDArmory.Weapons
                     }
                     rocket.gameObject.SetActive(false);
                     tgtRocket = null;
+                }
+                if (tgtDestroyed)
+                {
+                    shell.hasDetonated = true;
+                    ExplosionFx.CreateExplosion(shell.transform.position, shell.tntMass, shell.explModelPath, shell.explSoundPath, ExplosionSourceType.Bullet, shell.caliber, null, shell.sourceVesselName, null, null, default, -1, false, shell.bulletMass, -1, 1, sourceVelocity: shell.currentVelocity);
+                    shell.KillBullet();
+                    tgtShell = null;
+                    if (BDArmorySettings.DEBUG_WEAPONS) Debug.Log($"[BDArmory.ModuleWeapon] {part.partInfo.name} on {vessel.vesselName} Detonated Incoming Projectile!");
+                }
+                if (tgtdeflected)
+                {
+                    shell.bulletMass -= bulletMass;
+                    shell.currentVelocity = VectorUtils.GaussianDirectionDeviation(shell.currentVelocity, ((shell.bulletMass * shell.currentVelocity.magnitude) / (bulletMass * bulletVelocity)));
+                    if (BDArmorySettings.DEBUG_WEAPONS) Debug.Log($"[BDArmory.ModuleWeapon] {part.partInfo.name} on {vessel.vesselName} Deflected Incoming Projectile!");
                 }
             }
             else
@@ -6603,6 +6628,7 @@ namespace BDArmory.Weapons
         }
         public void ParseAmmoStats()
         {
+            penetrationDepth = 0;
             if (eWeaponType == WeaponTypes.Ballistic)
             {
                 bulletInfo = bulletInfoList[currentTypeIndex];
@@ -6700,6 +6726,7 @@ namespace BDArmory.Weapons
                     }
                 }
                 electroLaser = bulletInfo.EMP; //borrowing electrolaser bool, should really rename it empWeapon
+                penetrationDepth = ProjectileUtils.CalculatePenetration(caliber, bulletVelocity, bulletMass, bulletInfo.apBulletMod, muParam1: bulletInfo.sabot ? 0.9470311374f : 0.656060636f, muParam2: bulletInfo.sabot ? 1.555757746f : 1.20190930f, muParam3: bulletInfo.sabot ? 2.753715499f : 1.77791929f, sabot: bulletInfo.sabot);
             }
             if (eWeaponType == WeaponTypes.Rocket)
             {
@@ -6784,6 +6811,8 @@ namespace BDArmory.Weapons
                 choker = rocketInfo.choker;
                 incendiary = rocketInfo.incendiary;
                 SetupRocketPool(currentType, rocketModelPath);
+                penetrationDepth = ProjectileUtils.CalculatePenetration(caliber, (thrust / rocketMass) * thrustTime, rocketMass, 0.75f, muParam1: 0.9470311374f, muParam2: 1.555757746f, muParam3: 2.753715499f, sabot: true);
+
             }
             PAWRefresh();
             SetInitialDetonationDistance();

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -6100,7 +6100,7 @@ namespace BDArmory.Weapons
                     targetAcquired = true;
                     targetAcquisitionType = TargetAcquisitionType.Visual;
                     if (wm.slavingTurrets && turret) slaved = false;
-                    if (BDArmorySettings.DEBUG_WEAPONS)
+                    if (BDArmorySettings.DEBUG_APS)
                     {
                         Debug.Log("[BDArmory.ModuleWeapon] tgtVelocity: " + tgtVelocity + "; tgtPosition: " + targetPosition + "; tgtAccel: " + targetAcceleration);
                         Debug.Log($"[BDArmory.ModuleWeapon - {(vessel != null ? vessel.GetName() : "null")}] Lead Offset: {fixedLeadOffset}, FinalAimTgt: {finalAimTarget}, tgt CosAngle {targetCosAngle}, wpn CosAngle {targetAdjustedMaxCosAngle}, Wpn Autofire: {autoFire}");
@@ -6183,7 +6183,7 @@ namespace BDArmory.Weapons
                         {
                             shell.KillBullet();
                             tgtShell = null;
-                            if (BDArmorySettings.DEBUG_WEAPONS) Debug.Log($"[BDArmory.ModuleWeapon] {part.partInfo.name} on {vessel.vesselName} Vaporized Incoming Projectile!");
+                            if (BDArmorySettings.DEBUG_APS) Debug.Log($"[BDArmory.ModuleWeapon] {part.partInfo.name} on {vessel.vesselName} Vaporized Incoming Projectile!");
                         }
                         else if (tntMass > 0)// APS using HE bullet/rocket
                         {
@@ -6214,13 +6214,13 @@ namespace BDArmory.Weapons
                     ExplosionFx.CreateExplosion(shell.transform.position, shell.tntMass, shell.explModelPath, shell.explSoundPath, ExplosionSourceType.Bullet, shell.caliber, null, shell.sourceVesselName, null, null, default, -1, false, shell.bulletMass, -1, 1, sourceVelocity: shell.currentVelocity);
                     shell.KillBullet();
                     tgtShell = null;
-                    if (BDArmorySettings.DEBUG_WEAPONS) Debug.Log($"[BDArmory.ModuleWeapon] {part.partInfo.name} on {vessel.vesselName} Detonated Incoming Projectile!");
+                    if (BDArmorySettings.DEBUG_APS) Debug.Log($"[BDArmory.ModuleWeapon] {part.partInfo.name} on {vessel.vesselName} Detonated Incoming Projectile!");
                 }
                 if (tgtdeflected)
                 {
                     shell.bulletMass -= bulletMass;
                     shell.currentVelocity = VectorUtils.GaussianDirectionDeviation(shell.currentVelocity, ((shell.bulletMass * shell.currentVelocity.magnitude) / (bulletMass * bulletVelocity)));
-                    if (BDArmorySettings.DEBUG_WEAPONS) Debug.Log($"[BDArmory.ModuleWeapon] {part.partInfo.name} on {vessel.vesselName} Deflected Incoming Projectile!");
+                    if (BDArmorySettings.DEBUG_APS) Debug.Log($"[BDArmory.ModuleWeapon] {part.partInfo.name} on {vessel.vesselName} Deflected Incoming Projectile!");
                 }
             }
             else


### PR DESCRIPTION
-Custom turrets now work for turret multi-targeting
-Custom turrets now work for APS missile interception
-Rework APS shell interception; now takes target shell size/APS bullet penetration into account; no more destroying battleship shells with basic APS
-APS debugging now moved to debug Pointdefense toggle
...
Also locnames for armor materials and rework of HitPointTracker's HP/partmass calcs to streamline things for external usage (BDAEditorArmorWindow, etc)