### PR TITLE
Kinematic Missile Evasion Re-work

### DIFF
--- a/BDArmory/Control/BDAirspeedControl.cs
+++ b/BDArmory/Control/BDAirspeedControl.cs
@@ -200,7 +200,7 @@ namespace BDArmory.Control
             float accelError = (actualCurrentAccel - estimatedCurrentAccel); // /2 -- why divide by 2 here?
             dragAccel = accelError;
 
-            possibleAccel += accel; // This assumes that the acceleration from engines is in the same direction as the original possibleAccel.
+            possibleAccel = accel - dragAccel; // This assumes that the acceleration from engines is in the same direction as the original possibleAccel.
             forceAfterburner = forceAfterburner || (afterburnerPriority == 100f);
             allowAfterburner = allowAfterburner && (afterburnerPriority != 0f);
 

--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -1363,7 +1363,11 @@ namespace BDArmory.Control
                     EngageableWeapon engageableWeapon = currentWeapon as EngageableWeapon;
                     minRange = Mathf.Max(engageableWeapon.GetEngagementRangeMin(), minRange);
                     maxRange = engageableWeapon.GetEngagementRangeMax();
-                    usingProjectile = weaponManager.selectedWeapon.GetWeaponClass() != (WeaponClasses.Missile | WeaponClasses.Bomb | WeaponClasses.SLW);
+                    usingProjectile = currentWeapon.GetWeaponClass() switch
+                    {
+                        WeaponClasses.Missile or WeaponClasses.Bomb or WeaponClasses.SLW => false,
+                        _ => true
+                    };
                     if (usingProjectile)
                     {
                         missileTryLaunchTime = 0f;

--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -1363,7 +1363,7 @@ namespace BDArmory.Control
                     EngageableWeapon engageableWeapon = currentWeapon as EngageableWeapon;
                     minRange = Mathf.Max(engageableWeapon.GetEngagementRangeMin(), minRange);
                     maxRange = engageableWeapon.GetEngagementRangeMax();
-                    usingProjectile = weaponManager.selectedWeapon.GetWeaponClass() != WeaponClasses.Missile;
+                    usingProjectile = weaponManager.selectedWeapon.GetWeaponClass() != (WeaponClasses.Missile | WeaponClasses.Bomb | WeaponClasses.SLW);
                     if (usingProjectile)
                     {
                         missileTryLaunchTime = 0f;

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -3449,6 +3449,7 @@ namespace BDArmory.Control
             var weaponManager = WeaponManager;
             if (weaponManager == null) return;
 
+            SetStatus("Evading");
             if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI)
             {
                 debugString.AppendLine($"Evasive {evasiveTimer}s");

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -3683,17 +3683,19 @@ namespace BDArmory.Control
         Vector3 MissileKinematicEvasion(Vector3 breakDirection, Vector3 threatDirection)
         {
             breakDirection = breakDirection.normalized;
+            Vector3 debugBreakDirection = breakDirection;
             string missileEvasionStatus;
+            float newEvasionStateMult = (float)kinematicEvasionState + 2f;
 
             // Constants
             float boostSpeedMult = 5f;
-            float safeDistMult = 10f;
+            float safeDistMult = 5f;
 
             // Get missile information
             var weaponManager = WeaponManager;
             MissileBase missile = VesselModuleRegistry.GetMissileBase(weaponManager.incomingMissileVessel);
-            float missileKinematicTime = missile.GetKinematicTime();
             float missileKinematicSpeed = missile.GetKinematicSpeed();
+            float missileKinematicTime = missile.GetKinematicTime(missileKinematicSpeed, out float missileThrustTime);
             float missileSpeed = (float)weaponManager.incomingMissileVessel.srfSpeed;
             float boostSpeed = boostSpeedMult * missileKinematicSpeed;
             if (missile is MissileLauncher)
@@ -3704,147 +3706,195 @@ namespace BDArmory.Control
             float missileSafeDistSqr = missileSafeDist * missileSafeDist;
             Vector3 missilePos = weaponManager.incomingMissileVessel.transform.position;
             Vector3 missileVel = weaponManager.incomingMissileVessel.Velocity();
-            Vector3 missileDirNorm = missile.GetForwardTransform();
-            Vector3 missileAccelVec = missileAccel * missileDirNorm;
 
             // Get current vessel information
             Vector3 currentPos = vesselTransform.position;
             float currentSpeed = (float)vessel.srfSpeed;
+            Vector3 currentVel = vessel.Velocity();
+            float currentAccel = speedController.GetPossibleAccel();
+            float distToMissile = (currentPos - missilePos).magnitude;
 
-            // Future position variables
-            Vector3 futurePos;
-            Vector3 futureVel;
-            Vector3 futureAccel;
-
-            // Set up maneuver directions
+            // Initialize maneuver variables
+            Vector3 notchDir = breakDirection;
             Vector3 crankDir = breakDirection;
             Vector3 turnDir = breakDirection;
             Vector3 targetDir = (targetVessel != null) ?
                 (targetVessel != missile.vessel ? (targetVessel.CoM - currentPos).normalized : (missile.SourceVessel.CoM - currentPos).normalized)
                 : (missilePos - currentPos).normalized;
+            float crankDistSqr = 0f;
+            float notchDistSqr = 0f;
+            float turnDistSqr = 0f;
+            float crankTime;
+            float notchTime;
+            float turnTime;
 
             // Calculate estimated time to impact if we execute no maneuvers
-            float timeToImpact;
-            float currentAccel = 0; // FIXME if speedController.GetPossibleAccel() is able to calculate acceleration reliably incorporating drag
-            float distToMissile = (currentPos - missilePos).magnitude;
+            // if we are kin evading, see if current direction is sufficient, if so don't change anything
+            float impactDistSqr = 0f;
+            if (kinematicEvasionState > KinematicEvasionStates.None)
+                impactDistSqr = vessel.PredictClosestApproachSqrSeparation(weaponManager.incomingMissileVessel, missileKinematicTime * 2f);
+            
+            // Turn to target / Turn hot (always evaluate to see if it is time to end maneuver)
+            float targetDistSqr = KinematicManeuverEval(KinematicEvasionStates.ToTarget, breakDirection, threatDirection, targetDir, distToMissile, 
+                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileThrustTime,
+                            out float targetTime, out targetDir);
 
-            // Turn to target / Turn hot
-            timeToImpact = distToMissile / (missileSpeed + currentSpeed);
-            futureVel = currentSpeed * targetDir;
-            futureAccel = currentAccel * targetDir;
-            futurePos = AIUtils.PredictPosition(currentPos, futureVel, futureAccel, timeToImpact);
-            missileDirNorm = (futurePos - missilePos).normalized;
-            missileVel = missileSpeed * missileDirNorm;
-            missileAccelVec = missileAccel * missileDirNorm;
-            float targetTime = AIUtils.TimeToCPA(currentPos - missilePos, futureVel - missileVel, futureAccel - missileAccelVec, missileKinematicTime + 5f);
-            //float targetDistSqr = (AIUtils.PredictPosition(currentPos, futureVel, futureAccel, targetTime) - AIUtils.PredictPosition(missilePos, missileVel, missileAccelVec, targetTime)).sqrMagnitude;
-            float targetDistSqr = AIUtils.PredictPosition(currentPos - missilePos, futureVel - missileVel, futureAccel - missileAccelVec, targetTime).sqrMagnitude;
-
-            // Crank
-            float crankTime = 0f;
-            float crankDistSqr = 0f;
-            if (kinematicEvasionState <= KinematicEvasionStates.Crank || BDArmorySettings.DEBUG_AI || BDArmorySettings.DEBUG_TELEMETRY)
-            {
-                // Set up maneuver direction
-                float crankAngle;
-                VesselRadarData vrd = vessel.gameObject.GetComponent<VesselRadarData>();
-                if (vrd)
-                    crankAngle = Mathf.Clamp(vrd.GetCrankFOV() / 2 - 5f, 5f, 85f);
-                else
-                    crankAngle = 60f;
-                crankDir = Vector3.RotateTowards(breakDirection, threatDirection, (90f - crankAngle) * Mathf.Deg2Rad, 0).normalized;
-
-                // Calculate time and distance of closest point of approach
-                timeToImpact = distToMissile / BDAMath.Sqrt(currentSpeed * currentSpeed + missileSpeed * missileSpeed); // Assumes missile/target are perpendicular at impact point, 60% of the time it works everytime
-                futureVel = currentSpeed * crankDir;
-                futureAccel = currentAccel * crankDir;
-                futurePos = AIUtils.PredictPosition(currentPos, futureVel, futureAccel, timeToImpact);
-                missileDirNorm = (futurePos - missilePos).normalized;
-                missileVel = missileSpeed * missileDirNorm;
-                missileAccelVec = missileAccel * missileDirNorm;
-                crankTime = AIUtils.TimeToCPA(currentPos - missilePos, futureVel - missileVel, futureAccel - missileAccelVec, missileKinematicTime + 5f);
-                crankDistSqr = AIUtils.PredictPosition(currentPos - missilePos, futureVel - missileVel, futureAccel - missileAccelVec, crankTime).sqrMagnitude;
-            }
-
-            // Notch
-            float notchTime = 0f;
-            float notchDistSqr = 0f;
-            if (kinematicEvasionState <= KinematicEvasionStates.Notch || BDArmorySettings.DEBUG_AI || BDArmorySettings.DEBUG_TELEMETRY)
-            {
-                float v1 = Mathf.Max(missileSpeed, currentSpeed);
-                float v2 = Mathf.Min(missileSpeed, currentSpeed);
-                timeToImpact = (v1 != v2) ? distToMissile / BDAMath.Sqrt(v1 * v1 - v2 * v2) : timeToImpact; // Assumes angle between start and impact point is 90 deg, 60% of the time it works everytime
-                futureVel = currentSpeed * breakDirection;
-                futureAccel = currentAccel * breakDirection;
-                futurePos = AIUtils.PredictPosition(currentPos, futureVel, futureAccel, timeToImpact);
-                missileDirNorm = (futurePos - missilePos).normalized;
-                missileVel = missileSpeed * missileDirNorm;
-                missileAccelVec = missileAccel * missileDirNorm;
-                notchTime = AIUtils.TimeToCPA(currentPos - missilePos, futureVel - missileVel, futureAccel - missileAccelVec, missileKinematicTime + 5f);
-                notchDistSqr = AIUtils.PredictPosition(currentPos - missilePos, futureVel - missileVel, futureAccel - missileAccelVec, notchTime).sqrMagnitude;
-            }
-
-            // Turn Away / Turn Cold
-            float turnTime = 0f;
-            float turnDistSqr = 0f;
-            if (kinematicEvasionState <= KinematicEvasionStates.TurnAway || BDArmorySettings.DEBUG_AI || BDArmorySettings.DEBUG_TELEMETRY)
-            {
-                turnDir = (currentPos - missilePos).ProjectOnPlanePreNormalized(upDirection).normalized;
-                futureVel = currentSpeed * turnDir;
-                futureAccel = currentAccel * turnDir;
-                futurePos = AIUtils.PredictPosition(currentPos, futureVel, futureAccel, missileKinematicTime);
-                futurePos = GetTerrainSurfacePosition(futurePos) + (minAltitude * upDirection); // Dive towards deck
-                turnDir = futurePos - currentPos;
-                missileDirNorm = (futurePos - missilePos).normalized;
-                missileVel = missileSpeed * missileDirNorm;
-                missileAccelVec = missileAccel * missileDirNorm;
-                turnTime = AIUtils.TimeToCPA(currentPos - missilePos, futureVel - missileVel, futureAccel - missileAccelVec, missileKinematicTime + 5f);
-                turnDistSqr = AIUtils.PredictPosition(currentPos - missilePos, futureVel - missileVel, futureAccel - missileAccelVec, turnTime).sqrMagnitude;
-            }
-
-            if (BDArmorySettings.DEBUG_AI || BDArmorySettings.DEBUG_TELEMETRY)
-            {
-                debugString.AppendLine($"Time to Impact; Notch: {notchTime}s; Crank: {crankTime}s; Flee: {turnTime}s; Target:{targetTime}s");
-                debugString.AppendLine($"Dist. @ Impact; Notch: {BDAMath.Sqrt(notchDistSqr)}m; Crank: {BDAMath.Sqrt(crankDistSqr)}m; Flee: {BDAMath.Sqrt(turnDistSqr)}m; Target: {BDAMath.Sqrt(targetDistSqr)}m");
-                debugString.AppendLine($"Msl Kin. Speed: {missileKinematicSpeed}m/s; Msl Kin. Time: {missileKinematicTime}s; Msl Safe Dist.: {missileSafeDist}m;");
-            }
-
-            float newEvasionStateMult = (kinematicEvasionState == KinematicEvasionStates.None) ? 1f : 3f;
-
-            if (targetDistSqr > (kinematicEvasionState == KinematicEvasionStates.ToTarget ? 1f : newEvasionStateMult) * missileSafeDistSqr)
+            // Evaluate turning back towards target
+            if (targetDistSqr > (kinematicEvasionState == KinematicEvasionStates.ToTarget ? 1f : newEvasionStateMult * 3f) * missileSafeDistSqr) // Be extra conservative when turning back towards missile
             {
                 // Missile is defeated or probably won't hit us, we can turn back towards/stay on target to exit evasion
                 breakDirection = targetDir;
-                missileEvasionStatus = "Turning back towards target!";
                 kinematicEvasionState = KinematicEvasionStates.ToTarget;
             }
-            else if (kinematicEvasionState <= KinematicEvasionStates.Crank && (crankDistSqr > (kinematicEvasionState == KinematicEvasionStates.Crank ? 1f : newEvasionStateMult) * missileSafeDistSqr))
+            else if (impactDistSqr > missileSafeDistSqr) // If existing maneuver is sufficient, don't bother evaluating maneuver tree
             {
-                // Cranking will defeat missile, don't start cranking if we are executing a more conservative maneuver
-                breakDirection = crankDir;
-                missileEvasionStatus = "Cranking from missile threat!";
-                kinematicEvasionState = KinematicEvasionStates.Crank;
+                breakDirection = KinematicManeuverDirection(kinematicEvasionState, breakDirection, threatDirection, targetDir);
             }
-            else if (kinematicEvasionState <= KinematicEvasionStates.Notch && (notchDistSqr > (kinematicEvasionState == KinematicEvasionStates.Notch ? 1f : newEvasionStateMult) * missileSafeDistSqr))
+            else // Evaluate all maneuver options
             {
-                // Notching without a dive will defeat missile, don't start notching if we are executing a more conservative maneuver
-                missileEvasionStatus = "Notching from missile threat!";
-                kinematicEvasionState = KinematicEvasionStates.Notch;
-            }
-            else if (kinematicEvasionState <= KinematicEvasionStates.TurnAway && (turnDistSqr > (kinematicEvasionState == KinematicEvasionStates.TurnAway ? 1f : newEvasionStateMult) * missileSafeDistSqr))
-            {
-                // We need to turn away and dive, don't start turning away if we are executing a more conservative maneuver
-                breakDirection = turnDir;
-                missileEvasionStatus = "Turning away from missile threat!";
-                kinematicEvasionState = KinematicEvasionStates.TurnAway;
-            }
-            else //we need to dive and notch to have a chance against the missile
-            {
-                missileEvasionStatus = "Notching and diving from missile threat";
-                kinematicEvasionState = KinematicEvasionStates.NotchDive;
+                // Crank
+                if (kinematicEvasionState <= KinematicEvasionStates.Crank)
+                {
+                    crankDistSqr = KinematicManeuverEval(KinematicEvasionStates.Crank, breakDirection, threatDirection, targetDir, distToMissile, 
+                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileThrustTime,
+                            out crankTime, out crankDir);
+                }
+                // Notch
+                if (kinematicEvasionState <= KinematicEvasionStates.Notch)
+                {
+                    notchDistSqr = KinematicManeuverEval(KinematicEvasionStates.Notch, breakDirection, threatDirection, targetDir, distToMissile, 
+                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileThrustTime,
+                            out notchTime, out notchDir);
+                }
+                // Turn Away / Turn Cold
+                if (kinematicEvasionState <= KinematicEvasionStates.TurnAway)
+                {
+                    turnDistSqr = KinematicManeuverEval(KinematicEvasionStates.TurnAway, breakDirection, threatDirection, targetDir, distToMissile, 
+                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileThrustTime,
+                            out turnTime, out turnDir);
+                }
+
+                // Pick best maneuver
+                if (kinematicEvasionState <= KinematicEvasionStates.Crank && (crankDistSqr > (kinematicEvasionState == KinematicEvasionStates.Crank ? 1f : newEvasionStateMult) * missileSafeDistSqr))
+                {
+                    // Cranking will defeat missile, don't start cranking if we are executing a more conservative maneuver
+                    breakDirection = crankDir;
+                    kinematicEvasionState = KinematicEvasionStates.Crank;
+                }
+                else if (kinematicEvasionState <= KinematicEvasionStates.Notch && (notchDistSqr > (kinematicEvasionState == KinematicEvasionStates.Notch ? 1f : newEvasionStateMult) * missileSafeDistSqr))
+                {
+                    // Notching without a dive will defeat missile, don't start notching if we are executing a more conservative maneuver
+                    breakDirection = notchDir;
+                    kinematicEvasionState = KinematicEvasionStates.Notch;
+                }
+                else if (kinematicEvasionState <= KinematicEvasionStates.TurnAway && (turnDistSqr > (kinematicEvasionState == KinematicEvasionStates.TurnAway ? 1f : newEvasionStateMult) * missileSafeDistSqr))
+                {
+                    // We need to turn away and dive, don't start turning away if we are executing a more conservative maneuver
+                    breakDirection = turnDir;
+                    kinematicEvasionState = KinematicEvasionStates.TurnAway;
+                }
+                else //we need to dive and notch to have a chance against the missile
+                {
+                    breakDirection = notchDir;
+                    kinematicEvasionState = KinematicEvasionStates.NotchDive;
+                }
             }
 
-            if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI) debugString.AppendLine(missileEvasionStatus);
+            switch (kinematicEvasionState)
+            {
+                case KinematicEvasionStates.ToTarget:
+                    missileEvasionStatus = "Turning back towards target!";
+                    break;
+                case KinematicEvasionStates.Crank:
+                    missileEvasionStatus = "Cranking from missile threat!";
+                    break;
+                case KinematicEvasionStates.Notch:
+                    missileEvasionStatus = "Notching from missile threat!";
+                    break;
+                case KinematicEvasionStates.TurnAway:
+                    missileEvasionStatus = "Turning away from missile threat!";
+                    break;
+                case KinematicEvasionStates.NotchDive:
+                    missileEvasionStatus = "Notching and diving from missile threat";
+                    break;
+                default:
+                    missileEvasionStatus = "";
+                    break;
+            }
+            
+            if (BDArmorySettings.DEBUG_AI || BDArmorySettings.DEBUG_TELEMETRY)
+            {
+                notchDistSqr = KinematicManeuverEval(KinematicEvasionStates.Notch, debugBreakDirection, threatDirection, targetDir, distToMissile, 
+                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileThrustTime,
+                            out notchTime, out notchDir);
+                crankDistSqr = KinematicManeuverEval(KinematicEvasionStates.Crank, debugBreakDirection, threatDirection, targetDir, distToMissile, 
+                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileThrustTime,
+                            out crankTime, out crankDir);
+                turnDistSqr = KinematicManeuverEval(KinematicEvasionStates.TurnAway, debugBreakDirection, threatDirection, targetDir, distToMissile, 
+                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileThrustTime,
+                            out turnTime, out turnDir);
+                debugString.AppendLine($"Time to Impact; Notch: {notchTime}s; Crank: {crankTime}s; Flee: {turnTime}s; Target:{targetTime}s");
+                debugString.AppendLine($"Dist. @ Impact; Notch: {BDAMath.Sqrt(notchDistSqr)}m; Crank: {BDAMath.Sqrt(crankDistSqr)}m; Flee: {BDAMath.Sqrt(turnDistSqr)}m; Target: {BDAMath.Sqrt(targetDistSqr)}m");
+                debugString.AppendLine($"Msl Kin. Speed: {missileKinematicSpeed}m/s; Msl Kin. Time: {missileKinematicTime}s; Msl Safe Dist.: {missileSafeDist}m;");
+                debugString.AppendLine(missileEvasionStatus);
+            }
+
+            return breakDirection;
+        }
+
+        float KinematicManeuverEval(KinematicEvasionStates state, Vector3 breakDirection, Vector3 threatDirection, Vector3 targetDir, float distToMissile, Vector3 currentPos, Vector3 currentVel, float currentSpeed, float currentAccel, Vector3 missilePos, Vector3 missileVel, float missileSpeed, float missileAccel, float missileKinematicSpeed, float missileKinematicTime, float missileThrustTime, out float breakTime, out Vector3 finalBreakDirection)
+        {
+            finalBreakDirection = KinematicManeuverDirection(state, breakDirection, threatDirection, targetDir);
+            
+            float breakSpeed = currentSpeed;
+            if (state != KinematicEvasionStates.ToTarget) // Don't penalize speed to turn towards target
+                breakSpeed *= (Vector3.Angle(currentVel, finalBreakDirection) / 360f); // Estimate speed after performing maneuver, ~50% speed loss to execute 180 deg turn
+            Vector3 futureVel = breakSpeed * finalBreakDirection;
+            float timeToImpact = distToMissile/ (futureVel - missileVel).magnitude;
+            if ((state == KinematicEvasionStates.TurnAway) && (timeToImpact <= missileThrustTime)) // If missile will still be thrusting at impact, don't evaluate turn away option
+            {
+                breakTime = timeToImpact;
+                return 0f;
+            }
+            Vector3 futureAccel = currentAccel * finalBreakDirection;
+            Vector3 futurePos = AIUtils.PredictPosition(currentPos, futureVel, futureAccel, timeToImpact);
+            if (state == KinematicEvasionStates.TurnAway)
+            {
+                futurePos = GetTerrainSurfacePosition(futurePos) + (minAltitude * upDirection); // Dive towards deck
+                finalBreakDirection = futurePos - currentPos;
+            }
+            Vector3 missileDirNorm = (futurePos - missilePos).normalized;
+            Vector3 futureMissileVel = missileSpeed * missileDirNorm;
+            Vector3 futureMissileAccelVec = missileAccel * missileDirNorm;
+            breakTime = AIUtils.TimeToCPA(currentPos - missilePos, futureVel - futureMissileVel, futureAccel - futureMissileAccelVec, missileKinematicTime * 2f);
+            float breakDistSqr = 0f;
+            if ((state != KinematicEvasionStates.ToTarget) || (breakTime * missileAccel + missileSpeed < missileKinematicSpeed)) // Only evaluate turning back to target if missile speed will be below kinematic speed at CPA
+                breakDistSqr = AIUtils.PredictPosition(currentPos - missilePos, futureVel - futureMissileVel, futureAccel - futureMissileAccelVec, breakTime).sqrMagnitude;
+            return breakDistSqr;
+        }
+
+        Vector3 KinematicManeuverDirection(KinematicEvasionStates state, Vector3 breakDirection, Vector3 threatDirection, Vector3 targetDir)
+        {
+            switch (state)
+            {
+                case KinematicEvasionStates.ToTarget:
+                    breakDirection = targetDir;
+                break;
+                case KinematicEvasionStates.Crank:
+                {
+                    float crankAngle;
+                    VesselRadarData vrd = vessel.gameObject.GetComponent<VesselRadarData>();
+                    if (vrd)
+                        crankAngle = Mathf.Clamp(vrd.GetCrankFOV() / 2 - 5f, 5f, 85f);
+                    else
+                        crankAngle = 60f;
+                    breakDirection = Vector3.RotateTowards(breakDirection, threatDirection, (90f - crankAngle) * Mathf.Deg2Rad, 0).normalized;
+                }
+                break;
+                case KinematicEvasionStates.TurnAway:
+                    breakDirection = (-1f * threatDirection).ProjectOnPlanePreNormalized(upDirection).normalized;
+                break;
+            }
             return breakDirection;
         }
 

--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -3449,7 +3449,6 @@ namespace BDArmory.Control
             var weaponManager = WeaponManager;
             if (weaponManager == null) return;
 
-            SetStatus("Evading");
             if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI)
             {
                 debugString.AppendLine($"Evasive {evasiveTimer}s");
@@ -3477,6 +3476,7 @@ namespace BDArmory.Control
             Vessel missileThreat = weaponManager.incomingMissileVessel;
             MissileBase missileThreatMB;
             float closingTime;
+            string kinematicEvasionStatus = "";
 
             if (
                 missileThreat != null
@@ -3516,11 +3516,39 @@ namespace BDArmory.Control
 
                     // Missile kinematics check to see if alternate break directions are better (crank or turn around and run)
                     bool dive = true;
+                    float diveAngle = 75f;
                     if (evasionMissileKinematic && !inVacuum)
                     {
+                        dive = false;
                         breakDirection = MissileKinematicEvasion(breakDirection, threatDirection);
-                        if (kinematicEvasionState != KinematicEvasionStates.NotchDive)
-                            dive = false;
+                        if (kinematicEvasionState == KinematicEvasionStates.NotchDive)
+                        {
+                            dive = true;
+                            if (weaponManager.incomingMissileTime > weaponManager.cmThreshold)
+                            {
+                                float t = Mathf.Clamp01((weaponManager.incomingMissileTime - weaponManager.cmThreshold)/(weaponManager.evadeThreshold - weaponManager.cmThreshold));
+                                t =-1.72f*t*t*t+4.06f*t*t-3.34f*t+1f;
+                                diveAngle = Mathf.Lerp(35f, 75f, t); // Gradually dive more as missile gets closer
+                            }
+                        }
+                        switch (kinematicEvasionState)
+                        {
+                            case KinematicEvasionStates.ToTarget:
+                                kinematicEvasionStatus = " (Turning Hot)";
+                            break;
+                            case KinematicEvasionStates.Crank:
+                                kinematicEvasionStatus = " (Cranking)";
+                            break;
+                            case KinematicEvasionStates.Notch:
+                                kinematicEvasionStatus = " (Notching)";
+                            break;
+                            case KinematicEvasionStates.TurnAway:
+                                kinematicEvasionStatus = " (Turning Cold)";
+                            break;
+                            case KinematicEvasionStates.NotchDive:
+                                kinematicEvasionStatus = " (Notching & Diving)";
+                            break;
+                        }
                     }
                     else
                         if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI) debugString.AppendLine("Breaking from missile threat!");
@@ -3532,7 +3560,7 @@ namespace BDArmory.Control
                         float angle = Mathf.Clamp((float)vessel.radarAltitude - minAltitude, 0, diveScale) / diveScale * 90;
                         float angleAdjMissile = Mathf.Max(Mathf.Asin(((float)vessel.radarAltitude - (float)weaponManager.incomingMissileVessel.radarAltitude) /
                             weaponManager.incomingMissileDistance) * Mathf.Rad2Deg, 0f); // Don't dive into the missile if it's coming from below
-                        angle = Mathf.Clamp(angle - angleAdjMissile, 0, 75) * Mathf.Deg2Rad;
+                        angle = Mathf.Clamp(angle - angleAdjMissile, 0, diveAngle) * Mathf.Deg2Rad;
                         breakDirection = Vector3.RotateTowards(breakDirection, -upDirection, angle, 0);
                     }
                     if (BDArmorySettings.DEBUG_LINES) debugBreakDirection = breakDirection;
@@ -3564,6 +3592,7 @@ namespace BDArmory.Control
                         targetDirection += -2f * verticalComponent * upDirection;
                     }
                 }
+                SetStatus("Evading" + kinematicEvasionStatus);
                 RCSEvade(s, targetDirection);//add spacemode RCS dodging; missile evasion, fire in targetDirection
                 FlyToPosition(s, vesselTransform.position + targetDirection * 100, overrideThrottle);
                 return;
@@ -3688,19 +3717,14 @@ namespace BDArmory.Control
             float newEvasionStateMult = (float)kinematicEvasionState + 2f;
 
             // Constants
-            float boostSpeedMult = 5f;
             float safeDistMult = 5f;
 
             // Get missile information
             var weaponManager = WeaponManager;
             MissileBase missile = VesselModuleRegistry.GetMissileBase(weaponManager.incomingMissileVessel);
             float missileKinematicSpeed = missile.GetKinematicSpeed();
-            float missileKinematicTime = missile.GetKinematicTime(missileKinematicSpeed, out float missileThrustTime);
+            float missileKinematicTime = missile.GetKinematicTime(missileKinematicSpeed, out float missileKinematicRange);
             float missileSpeed = (float)weaponManager.incomingMissileVessel.srfSpeed;
-            float boostSpeed = boostSpeedMult * missileKinematicSpeed;
-            if (missile is MissileLauncher)
-                boostSpeed = Mathf.Max(boostSpeed, ((MissileLauncher)missile).optimumAirspeed);
-            missileSpeed = (missile.MissileState == MissileBase.MissileStates.Boost && missileSpeed < boostSpeed) ? boostSpeed : missileSpeed;
             float missileAccel = (missileKinematicSpeed - missileSpeed) / (missileKinematicTime == 0 ? Mathf.Sign(missileKinematicTime) * 0.001f : missileKinematicTime);
             float missileSafeDist = safeDistMult * missile.GetBlastRadius(); // Comfortable safe distance
             float missileSafeDistSqr = missileSafeDist * missileSafeDist;
@@ -3724,9 +3748,9 @@ namespace BDArmory.Control
             float crankDistSqr = 0f;
             float notchDistSqr = 0f;
             float turnDistSqr = 0f;
-            float crankTime;
-            float notchTime;
-            float turnTime;
+            float crankTime = 0f;
+            float notchTime = 0f;
+            float turnTime = 0f;
 
             // Calculate estimated time to impact if we execute no maneuvers
             // if we are kin evading, see if current direction is sufficient, if so don't change anything
@@ -3736,7 +3760,7 @@ namespace BDArmory.Control
             
             // Turn to target / Turn hot (always evaluate to see if it is time to end maneuver)
             float targetDistSqr = KinematicManeuverEval(KinematicEvasionStates.ToTarget, breakDirection, threatDirection, targetDir, distToMissile, 
-                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileThrustTime,
+                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileKinematicRange,
                             out float targetTime, out targetDir);
 
             // Evaluate turning back towards target
@@ -3756,21 +3780,21 @@ namespace BDArmory.Control
                 if (kinematicEvasionState <= KinematicEvasionStates.Crank)
                 {
                     crankDistSqr = KinematicManeuverEval(KinematicEvasionStates.Crank, breakDirection, threatDirection, targetDir, distToMissile, 
-                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileThrustTime,
+                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileKinematicRange,
                             out crankTime, out crankDir);
                 }
                 // Notch
                 if (kinematicEvasionState <= KinematicEvasionStates.Notch)
                 {
                     notchDistSqr = KinematicManeuverEval(KinematicEvasionStates.Notch, breakDirection, threatDirection, targetDir, distToMissile, 
-                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileThrustTime,
+                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileKinematicRange,
                             out notchTime, out notchDir);
                 }
                 // Turn Away / Turn Cold
                 if (kinematicEvasionState <= KinematicEvasionStates.TurnAway)
                 {
                     turnDistSqr = KinematicManeuverEval(KinematicEvasionStates.TurnAway, breakDirection, threatDirection, targetDir, distToMissile, 
-                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileThrustTime,
+                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileKinematicRange,
                             out turnTime, out turnDir);
                 }
 
@@ -3799,77 +3823,90 @@ namespace BDArmory.Control
                     kinematicEvasionState = KinematicEvasionStates.NotchDive;
                 }
             }
-
-            switch (kinematicEvasionState)
-            {
-                case KinematicEvasionStates.ToTarget:
-                    missileEvasionStatus = "Turning back towards target!";
-                    break;
-                case KinematicEvasionStates.Crank:
-                    missileEvasionStatus = "Cranking from missile threat!";
-                    break;
-                case KinematicEvasionStates.Notch:
-                    missileEvasionStatus = "Notching from missile threat!";
-                    break;
-                case KinematicEvasionStates.TurnAway:
-                    missileEvasionStatus = "Turning away from missile threat!";
-                    break;
-                case KinematicEvasionStates.NotchDive:
-                    missileEvasionStatus = "Notching and diving from missile threat";
-                    break;
-                default:
-                    missileEvasionStatus = "";
-                    break;
-            }
             
+            // DEBUGGING
             if (BDArmorySettings.DEBUG_AI || BDArmorySettings.DEBUG_TELEMETRY)
             {
+                switch (kinematicEvasionState)
+                {
+                    case KinematicEvasionStates.ToTarget:
+                        missileEvasionStatus = "Turning back towards target!";
+                        break;
+                    case KinematicEvasionStates.Crank:
+                        missileEvasionStatus = "Cranking from missile threat!";
+                        break;
+                    case KinematicEvasionStates.Notch:
+                        missileEvasionStatus = "Notching from missile threat!";
+                        break;
+                    case KinematicEvasionStates.TurnAway:
+                        missileEvasionStatus = "Turning away from missile threat!";
+                        break;
+                    case KinematicEvasionStates.NotchDive:
+                        missileEvasionStatus = "Notching and diving from missile threat";
+                        break;
+                    default:
+                        missileEvasionStatus = "";
+                        break;
+                }
+                    
                 notchDistSqr = KinematicManeuverEval(KinematicEvasionStates.Notch, debugBreakDirection, threatDirection, targetDir, distToMissile, 
-                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileThrustTime,
+                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileKinematicRange,
                             out notchTime, out notchDir);
                 crankDistSqr = KinematicManeuverEval(KinematicEvasionStates.Crank, debugBreakDirection, threatDirection, targetDir, distToMissile, 
-                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileThrustTime,
+                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileKinematicRange,
                             out crankTime, out crankDir);
                 turnDistSqr = KinematicManeuverEval(KinematicEvasionStates.TurnAway, debugBreakDirection, threatDirection, targetDir, distToMissile, 
-                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileThrustTime,
+                            currentPos, currentVel, currentSpeed, currentAccel, missilePos, missileVel, missileSpeed, missileAccel, missileKinematicSpeed, missileKinematicTime, missileKinematicRange,
                             out turnTime, out turnDir);
-                debugString.AppendLine($"Time to Impact; Notch: {notchTime}s; Crank: {crankTime}s; Flee: {turnTime}s; Target:{targetTime}s");
-                debugString.AppendLine($"Dist. @ Impact; Notch: {BDAMath.Sqrt(notchDistSqr)}m; Crank: {BDAMath.Sqrt(crankDistSqr)}m; Flee: {BDAMath.Sqrt(turnDistSqr)}m; Target: {BDAMath.Sqrt(targetDistSqr)}m");
-                debugString.AppendLine($"Msl Kin. Speed: {missileKinematicSpeed}m/s; Msl Kin. Time: {missileKinematicTime}s; Msl Safe Dist.: {missileSafeDist}m;");
+                debugString.AppendLine($"Time to Impact; Target:{targetTime}s; Crank: {crankTime}s; Notch: {notchTime}s; Flee: {turnTime}s;");
+                debugString.AppendLine($"Dist. @ Impact; Target: {BDAMath.Sqrt(targetDistSqr)}m, Crank: {BDAMath.Sqrt(crankDistSqr)}m; Notch: {BDAMath.Sqrt(notchDistSqr)}m; Flee: {BDAMath.Sqrt(turnDistSqr)}m;");
+                debugString.AppendLine($"Msl Kin. Speed: {missileKinematicSpeed}m/s; Msl Kin. Time: {missileKinematicTime}s; Msl Kin. Range: {missileKinematicRange}m; Msl Safe Dist.: {missileSafeDist}m;");
                 debugString.AppendLine(missileEvasionStatus);
             }
 
             return breakDirection;
         }
 
-        float KinematicManeuverEval(KinematicEvasionStates state, Vector3 breakDirection, Vector3 threatDirection, Vector3 targetDir, float distToMissile, Vector3 currentPos, Vector3 currentVel, float currentSpeed, float currentAccel, Vector3 missilePos, Vector3 missileVel, float missileSpeed, float missileAccel, float missileKinematicSpeed, float missileKinematicTime, float missileThrustTime, out float breakTime, out Vector3 finalBreakDirection)
+        float KinematicManeuverEval(KinematicEvasionStates state, Vector3 breakDirection, Vector3 threatDirection, Vector3 targetDir, float distToMissile, Vector3 currentPos, Vector3 currentVel, float currentSpeed, float currentAccel, Vector3 missilePos, Vector3 missileVel, float missileSpeed, float missileAccel, float missileKinematicSpeed, float missileKinematicTime, float missileKinematicRange, out float breakTime, out Vector3 finalBreakDirection)
         {
-            finalBreakDirection = KinematicManeuverDirection(state, breakDirection, threatDirection, targetDir);
-            
+            breakDirection = KinematicManeuverDirection(state, breakDirection, threatDirection, targetDir); // Get direction for state
+            finalBreakDirection = breakDirection;
+            // Calculate initial estimate of time to impact and use that to estimate future positions, velocities, and accelerations
             float breakSpeed = currentSpeed;
             if (state != KinematicEvasionStates.ToTarget) // Don't penalize speed to turn towards target
-                breakSpeed *= (Vector3.Angle(currentVel, finalBreakDirection) / 360f); // Estimate speed after performing maneuver, ~50% speed loss to execute 180 deg turn
-            Vector3 futureVel = breakSpeed * finalBreakDirection;
+                breakSpeed *= (Vector3.Angle(currentVel, breakDirection) / 360f); // Estimate speed after performing maneuver, ~50% speed loss to execute 180 deg turn
+            Vector3 futureVel = breakSpeed * breakDirection;
             float timeToImpact = distToMissile/ (futureVel - missileVel).magnitude;
-            if ((state == KinematicEvasionStates.TurnAway) && (timeToImpact <= missileThrustTime)) // If missile will still be thrusting at impact, don't evaluate turn away option
-            {
-                breakTime = timeToImpact;
-                return 0f;
-            }
-            Vector3 futureAccel = currentAccel * finalBreakDirection;
+
+            Vector3 futureAccel = currentAccel * breakDirection;
             Vector3 futurePos = AIUtils.PredictPosition(currentPos, futureVel, futureAccel, timeToImpact);
+            
+            // Evaluate TurnAway based on kinematic range
             if (state == KinematicEvasionStates.TurnAway)
             {
-                futurePos = GetTerrainSurfacePosition(futurePos) + (minAltitude * upDirection); // Dive towards deck
-                finalBreakDirection = futurePos - currentPos;
+                float selfKinematicRangeSqr = (futurePos - currentPos).sqrMagnitude;
+                breakTime = timeToImpact;
+                if (selfKinematicRangeSqr < missileKinematicRange * missileKinematicRange) // If missile has greater kinematic range than we do turning away, maneuver will not work
+                    return 0f;
+                else // Otherwise maneuver is valid
+                {
+                    futurePos = GetTerrainSurfacePosition(futurePos) + (minAltitude * upDirection) - currentPos; // Incorporate dive towards deck for TurnAway state
+                    finalBreakDirection = futurePos - currentPos;
+                    return selfKinematicRangeSqr - missileKinematicRange * missileKinematicRange;
+                }
             }
+            
+            // Update missile estimates based on our future position
             Vector3 missileDirNorm = (futurePos - missilePos).normalized;
             Vector3 futureMissileVel = missileSpeed * missileDirNorm;
             Vector3 futureMissileAccelVec = missileAccel * missileDirNorm;
+            
+            // Calculate time to CPA and square distance at CPA
             breakTime = AIUtils.TimeToCPA(currentPos - missilePos, futureVel - futureMissileVel, futureAccel - futureMissileAccelVec, missileKinematicTime * 2f);
             float breakDistSqr = 0f;
             if ((state != KinematicEvasionStates.ToTarget) || (breakTime * missileAccel + missileSpeed < missileKinematicSpeed)) // Only evaluate turning back to target if missile speed will be below kinematic speed at CPA
                 breakDistSqr = AIUtils.PredictPosition(currentPos - missilePos, futureVel - futureMissileVel, futureAccel - futureMissileAccelVec, breakTime).sqrMagnitude;
+
             return breakDistSqr;
         }
 
@@ -3877,10 +3914,10 @@ namespace BDArmory.Control
         {
             switch (state)
             {
-                case KinematicEvasionStates.ToTarget:
+                case KinematicEvasionStates.ToTarget: // Turn to target, ignoring missile
                     breakDirection = targetDir;
                 break;
-                case KinematicEvasionStates.Crank:
+                case KinematicEvasionStates.Crank: // Keep us within radar FOV of target, but don't fly straight towards missile
                 {
                     float crankAngle;
                     VesselRadarData vrd = vessel.gameObject.GetComponent<VesselRadarData>();
@@ -3891,8 +3928,16 @@ namespace BDArmory.Control
                     breakDirection = Vector3.RotateTowards(breakDirection, threatDirection, (90f - crankAngle) * Mathf.Deg2Rad, 0).normalized;
                 }
                 break;
-                case KinematicEvasionStates.TurnAway:
+                case KinematicEvasionStates.TurnAway: // Turn 180 deg from missile
                     breakDirection = (-1f * threatDirection).ProjectOnPlanePreNormalized(upDirection).normalized;
+                break;
+                default: // Notch, beam missile initially, start to turn away as missile gets closer
+                {
+                    float t = Mathf.Clamp01((WeaponManager.incomingMissileTime - WeaponManager.cmThreshold)/(WeaponManager.evadeThreshold - WeaponManager.cmThreshold));
+                    t = -1.72f*t*t*t+4.06f*t*t-3.34f*t+1f;
+                    float notchAngle = Mathf.Lerp(90f, 135f, t); // Gradually turn from 90 deg notch to 135 deg as missile gets closer
+                    breakDirection = Vector3.RotateTowards(threatDirection, breakDirection, notchAngle * Mathf.Deg2Rad, 0).normalized;
+                }
                 break;
             }
             return breakDirection;

--- a/BDArmory/Radar/RadarUtils.cs
+++ b/BDArmory/Radar/RadarUtils.cs
@@ -2551,10 +2551,10 @@ namespace BDArmory.Radar
                 if (missile.SourceVessel != null && missile.SourceVessel.ActiveController().WM != null)
                     teammate = (missile.SourceVessel.ActiveController().WM.team == mf.team) && (missile.targetVessel != null ? missile.targetVessel != mf.vessel : true); // Missile is fired from teammate and not locked onto us
                 bool withinRadarFOV = (missile.TargetingMode == MissileBase.TargetingModes.Radar && !teammate) ?
-                    (VectorUtils.Angle(missile.GetForwardTransform(), vectorFromMissile) <= Mathf.Clamp(missile.lockedSensorFOV, 40f, 90f) * 0.5f) : false;
+                    (VectorUtils.Angle(missile.GetForwardTransform(), vectorFromMissile) <= Mathf.Clamp(missile.lockedSensorFOV * 0.5f + missile.maxOffBoresight, 20f, 75f)) : false;
                 var missileBlastRadiusSqr = teammate ? mf.vessel.GetRadius() : 3f * Mathf.Max(missile.GetBlastRadius(), mf.vessel.GetRadius()); // Blast radius or self radius, whichever is larger (use self radius if missile is from teammate)
                 missileBlastRadiusSqr *= missileBlastRadiusSqr;
-
+                
                 return (missile.HasFired && missile.MissileState > MissileBase.MissileStates.Drop && approaching && maneuverCapability &&
                             (
                                 (missile.TargetPosition - (mf.vessel.CoM + (mf.vessel.Velocity() * Time.fixedDeltaTime))).sqrMagnitude < missileBlastRadiusSqr || // Target position is within blast radius of missile.

--- a/BDArmory/Weapons/Missiles/BDModularGuidance.cs
+++ b/BDArmory/Weapons/Missiles/BDModularGuidance.cs
@@ -1873,20 +1873,23 @@ namespace BDArmory.Weapons.Missiles
             return GetTransform(ForwardTransformAxis);
         }
 
-        public override float GetKinematicTime()
+        public override float GetKinematicTime(float minSpeed, out float thrustTime)
         {
+            thrustTime = 0f;
             if (!_missileIgnited) return -1f;
 
-            float missileKinematicTime = (float)vessel.VesselDeltaV.TotalBurnTime;
+            thrustTime = (float)vessel.VesselDeltaV.TotalBurnTime;
+            float missileKinematicTime = thrustTime;
+
             if (!vessel.InVacuum())
             {
-                float drag = vessel.parts.Sum(x => x.dragScalar);
+                float dragArea = vessel.parts.Sum(x => x.dragScalar);
                 float speed = (float)vessel.srfSpeed;
                 float mass = (float)vessel.totalMass;
-                float dragTerm = 0.008f * mass * drag * 0.5f * (float)vessel.atmDensity;
-                float minSpeed = GetKinematicSpeed();
+                float dragTerm = 0.008f * mass * dragArea * speed * speed * 0.5f * (float)vessel.atmDensity;
+                float dragTermMinSpeed = 0.008f * mass * dragArea * minSpeed * minSpeed * 0.5f * (float)vessel.atmDensity;
                 if (speed > minSpeed)
-                    missileKinematicTime += mass / (minSpeed * dragTerm) - mass / (speed * dragTerm); ; // Add time for missile to slow down to min speed
+                    missileKinematicTime += mass * (speed - minSpeed) / ((dragTerm + dragTermMinSpeed) / 2f); // Add time for missile to slow down to min speed
             }
 
             return missileKinematicTime;

--- a/BDArmory/Weapons/Missiles/BDModularGuidance.cs
+++ b/BDArmory/Weapons/Missiles/BDModularGuidance.cs
@@ -1873,23 +1873,27 @@ namespace BDArmory.Weapons.Missiles
             return GetTransform(ForwardTransformAxis);
         }
 
-        public override float GetKinematicTime(float minSpeed, out float thrustTime)
+        public override float GetKinematicTime(float minSpeed, out float kinematicRange)
         {
-            thrustTime = 0f;
+            kinematicRange = 0f;
             if (!_missileIgnited) return -1f;
 
-            thrustTime = (float)vessel.VesselDeltaV.TotalBurnTime;
-            float missileKinematicTime = thrustTime;
+            float missileKinematicTime = (float)vessel.VesselDeltaV.TotalBurnTime;
 
             if (!vessel.InVacuum())
             {
                 float dragArea = vessel.parts.Sum(x => x.dragScalar);
                 float speed = (float)vessel.srfSpeed;
+                kinematicRange += speed * missileKinematicTime;
                 float mass = (float)vessel.totalMass;
                 float dragTerm = 0.008f * mass * dragArea * speed * speed * 0.5f * (float)vessel.atmDensity;
                 float dragTermMinSpeed = 0.008f * mass * dragArea * minSpeed * minSpeed * 0.5f * (float)vessel.atmDensity;
                 if (speed > minSpeed)
-                    missileKinematicTime += mass * (speed - minSpeed) / ((dragTerm + dragTermMinSpeed) / 2f); // Add time for missile to slow down to min speed
+                {
+                    float t = mass * (speed - minSpeed) / ((dragTerm + dragTermMinSpeed) / 2f); // Add time for missile to slow down to min speed
+                    missileKinematicTime += t;
+                    kinematicRange += (speed + minSpeed) / 2f * t;
+                }
             }
 
             return missileKinematicTime;

--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -715,7 +715,7 @@ UI_FloatRange(minValue = 0f, maxValue = 20f, stepIncrement = 1, scene = UI_Scene
 
         public abstract Vector3 GetForwardTransform();
 
-        public abstract float GetKinematicTime();
+        public abstract float GetKinematicTime(float minSpeed, out float thrustTime);
 
         public abstract float GetKinematicSpeed();
 

--- a/BDArmory/Weapons/Missiles/MissileBase.cs
+++ b/BDArmory/Weapons/Missiles/MissileBase.cs
@@ -715,7 +715,7 @@ UI_FloatRange(minValue = 0f, maxValue = 20f, stepIncrement = 1, scene = UI_Scene
 
         public abstract Vector3 GetForwardTransform();
 
-        public abstract float GetKinematicTime(float minSpeed, out float thrustTime);
+        public abstract float GetKinematicTime(float minSpeed, out float kinematicRange);
 
         public abstract float GetKinematicSpeed();
 

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -4034,17 +4034,17 @@ namespace BDArmory.Weapons.Missiles
                 return MissileReferenceTransform.forward;
         }
 
-        public override float GetKinematicTime(float minSpeed, out float thrustTime)
+        public override float GetKinematicTime(float minSpeed, out float kinematicRange)
         {
             // Get time at which the missile is traveling at the GetKinematicSpeed() speed
-            thrustTime = 0f;
+            kinematicRange = 0f;
             if (!launched) return -1f;
 
-            thrustTime = boostTime + cruiseTime + cruiseDelay + dropTime - TimeIndex;
-            float missileKinematicTime = thrustTime;
+            float missileKinematicTime = Mathf.Max(boostTime + cruiseTime + cruiseDelay + dropTime - TimeIndex, 0f);
             if (!vessel.InVacuum())
             {
-                float speed = currentThrust > 0 ? optimumAirspeed : (float)vessel.srfSpeed;
+                float speed = GetBurnoutSpeed(out float burnoutRange);
+                kinematicRange = burnoutRange;
                 if (speed > minSpeed)
                 {
                     float airDensity = (float)vessel.atmDensity;
@@ -4053,18 +4053,19 @@ namespace BDArmory.Weapons.Missiles
                     if (useSimpleDrag)
                     {
                         dragTerm = (deployed ? deployedDrag : simpleDrag) * (0.008f * part.mass) * 0.5f * airDensity;
-                        t = part.mass / (minSpeed * dragTerm) - part.mass / (speed * dragTerm);
+                        t = part.mass * (speed - minSpeed) / ((dragTerm * speed * speed + dragTerm * minSpeed * minSpeed) / 2f);
                     }
                     else
                     {
                         float AoA = smoothedAoA.Value;
                         FloatCurve dragCurve = MissileGuidance.DefaultDragCurve;
-                        float dragCd = dragCurve.Evaluate(AoA);
+                        float dragCd = Mathf.Max(dragCurve.Evaluate(AoA), 0f);
                         float dragMultiplier = BDArmorySettings.GLOBAL_DRAG_MULTIPLIER;
                         dragTerm = 0.5f * airDensity * speed * speed * currDragArea * dragMultiplier * dragCd;
                         float dragTermMinSpeed = 0.5f * airDensity * minSpeed * minSpeed * currDragArea * dragMultiplier * dragCurve.Evaluate(Mathf.Min(30f, maxAoA)); // Max AoA or 29 deg (at kink in drag curve)
                         t = part.mass * (speed - minSpeed) / ((dragTerm + dragTermMinSpeed) / 2f);
                     }
+                    kinematicRange += t * (speed + minSpeed) / 2f;
                     missileKinematicTime += t; // Add time for missile to slow down to min speed
                 }
             }
@@ -4085,6 +4086,44 @@ namespace BDArmory.Weapons.Missiles
             float kinematicSpeed = BDAMath.Sqrt((Gs * part.mass * bodyGravity) / (0.5f * (float)vessel.atmDensity * currLiftArea * liftMultiplier * liftCurve.Evaluate(maxAoA)));
 
             return Mathf.Min(kinematicSpeed, 0.5f * (float)vessel.speedOfSound);
+        }
+
+        public float GetBurnoutSpeed(out float burnoutRange)
+        {
+            burnoutRange = 0f;
+            if (vessel.InVacuum() || weaponClass != WeaponClasses.Missile) return 0f;
+            float currentSpeed = (float)vessel.srfSpeed;
+            if (MissileState == MissileStates.PostThrust) return currentSpeed;
+
+            float boostTimeLeft = Mathf.Max(boostTime + dropTime - TimeIndex, 0f);
+            float cruiseTimeLeft = Mathf.Max(boostTime + cruiseTime + cruiseDelay + dropTime - TimeIndex, 0f);
+            float boostAccel = thrust / part.mass;
+            float cruiseAccel = cruiseThrust / part.mass;
+
+            float clampSpeed = Mathf.Clamp(optimumAirspeed, currentSpeed, 2f * currentSpeed); // Don't let the below speeds get out of control, leads to unrealistically high drag estimates
+            float boostDragSpeed = Mathf.Min((boostAccel * boostTimeLeft + 2f * currentSpeed)/2f, clampSpeed); // Average of speed after boost and currentSpeed
+            float cruiseDragSpeed = Mathf.Min((cruiseAccel * cruiseTimeLeft + boostAccel * boostTimeLeft + 2f * currentSpeed)/2f, clampSpeed); // Average of speed after boost+cruise and currentSpeed
+            
+            float airDensity = (float)vessel.atmDensity;
+            float boostDragAccel;
+            float cruiseDragAccel;
+            if (useSimpleDrag)
+            {
+                boostDragAccel = (deployed ? deployedDrag : simpleDrag) * (0.008f * part.mass) * 0.5f * airDensity * boostDragSpeed * boostDragSpeed / part.mass;
+                cruiseDragAccel = (deployed ? deployedDrag : simpleDrag) * (0.008f * part.mass) * 0.5f * airDensity * cruiseDragSpeed * cruiseDragSpeed / part.mass;
+            }
+            else
+            {
+                float AoA = smoothedAoA.Value;
+                FloatCurve dragCurve = MissileGuidance.DefaultDragCurve;
+                float dragCd = Mathf.Max(dragCurve.Evaluate(AoA), 0f);
+                float dragMultiplier = BDArmorySettings.GLOBAL_DRAG_MULTIPLIER;
+                boostDragAccel = 0.5f * airDensity * boostDragSpeed * boostDragSpeed * currDragArea * dragMultiplier * dragCd / part.mass;
+                cruiseDragAccel = 0.5f * airDensity * cruiseDragSpeed * cruiseDragSpeed * currDragArea * dragMultiplier * dragCd / part.mass;
+            }
+            burnoutRange = Mathf.Max(boostAccel - boostDragAccel, 0f) * boostTimeLeft * boostTimeLeft + Mathf.Max(cruiseAccel - cruiseDragAccel, 0f) * cruiseTimeLeft * cruiseTimeLeft + currentSpeed * (boostTimeLeft + cruiseTimeLeft);
+            
+            return Mathf.Max(boostAccel - boostDragAccel, 0f) * boostTimeLeft + Mathf.Max(cruiseAccel - cruiseDragAccel, 0f) * cruiseTimeLeft + currentSpeed;
         }
 
         protected override void PartDie(Part p)

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -4034,16 +4034,17 @@ namespace BDArmory.Weapons.Missiles
                 return MissileReferenceTransform.forward;
         }
 
-        public override float GetKinematicTime()
+        public override float GetKinematicTime(float minSpeed, out float thrustTime)
         {
             // Get time at which the missile is traveling at the GetKinematicSpeed() speed
+            thrustTime = 0f;
             if (!launched) return -1f;
 
-            float missileKinematicTime = boostTime + cruiseTime + cruiseDelay + dropTime - TimeIndex;
+            thrustTime = boostTime + cruiseTime + cruiseDelay + dropTime - TimeIndex;
+            float missileKinematicTime = thrustTime;
             if (!vessel.InVacuum())
             {
                 float speed = currentThrust > 0 ? optimumAirspeed : (float)vessel.srfSpeed;
-                float minSpeed = GetKinematicSpeed();
                 if (speed > minSpeed)
                 {
                     float airDensity = (float)vessel.atmDensity;
@@ -4060,9 +4061,9 @@ namespace BDArmory.Weapons.Missiles
                         FloatCurve dragCurve = MissileGuidance.DefaultDragCurve;
                         float dragCd = dragCurve.Evaluate(AoA);
                         float dragMultiplier = BDArmorySettings.GLOBAL_DRAG_MULTIPLIER;
-                        dragTerm = 0.5f * airDensity * currDragArea * dragMultiplier * dragCd;
-                        float dragTermMinSpeed = 0.5f * airDensity * currDragArea * dragMultiplier * dragCurve.Evaluate(Mathf.Min(30f, maxAoA)); // Max AoA or 29 deg (at kink in drag curve)
-                        t = part.mass / (minSpeed * dragTermMinSpeed) - part.mass / (speed * dragTerm);
+                        dragTerm = 0.5f * airDensity * speed * speed * currDragArea * dragMultiplier * dragCd;
+                        float dragTermMinSpeed = 0.5f * airDensity * minSpeed * minSpeed * currDragArea * dragMultiplier * dragCurve.Evaluate(Mathf.Min(30f, maxAoA)); // Max AoA or 29 deg (at kink in drag curve)
+                        t = part.mass * (speed - minSpeed) / ((dragTerm + dragTermMinSpeed) / 2f);
                     }
                     missileKinematicTime += t; // Add time for missile to slow down to min speed
                 }
@@ -4075,8 +4076,8 @@ namespace BDArmory.Weapons.Missiles
         {
             if (vessel.InVacuum() || weaponClass != WeaponClasses.Missile) return 0f;
 
-            // Get speed at which the missile is only capable of pulling a 2G turn at maxAoA
-            float Gs = 2f;
+            // Get speed at which the missile is only capable of pulling a 4G turn at maxAoA
+            float Gs = 4f;
 
             FloatCurve liftCurve = MissileGuidance.DefaultLiftCurve;
             float bodyGravity = (float)PhysicsGlobals.GravitationalAcceleration * (float)vessel.orbit.referenceBody.GeeASL;


### PR DESCRIPTION
- Re-worked/improved kinematic missile evasion:
-- Improved handling of turning cold (use estimated missile range)
-- Change notch+dive to more shallow maneuver until CM starts, which better avoids radar missiles
-- Adjust notch angle so it gradually moves away
-- Add details on kinematic evasion state to AI status

- Bug fixes
-- Fix bug where radar terminal missiles with small lockedSensorFOV and large maxOffBoresight were not considered threats
-- Fix potential NRE in OrbitalAI