### PR TITLE
Allow nuclear warheads to detonate

### DIFF
--- a/BDArmory/Weapons/BDModuleNuke.cs
+++ b/BDArmory/Weapons/BDModuleNuke.cs
@@ -122,7 +122,7 @@ namespace BDArmory.Weapons
                 }
                 Sourcevessel = part.vessel.GetName();
 
-                if (engineCore) part.OnJustAboutToBeDestroyed += Detonate;
+                part.OnJustAboutToBeDestroyed += Detonate;
                 GameEvents.onVesselPartCountChanged.Add(CheckAttached);
                 GameEvents.onVesselCreate.Add(CheckAttached);
             }
@@ -239,6 +239,18 @@ namespace BDArmory.Weapons
         {
             GameEvents.onVesselPartCountChanged.Remove(CheckAttached);
             GameEvents.onVesselCreate.Remove(CheckAttached);
+        }
+
+        [KSPAction("Detonate")]
+        public void DetonateAG(KSPActionParam param)
+        {
+            Detonate();
+        }
+
+        [KSPEvent(guiActive = true, guiActiveEditor = false, guiName = "#LOC_BDArmory_Detonate", active = true)]//Detonate
+        public void DetonateEvent()
+        {
+            Detonate();
         }
 
         public void Detonate()


### PR DESCRIPTION
The BDArmory Extended mod adds a nuclear warhead to be used by modular missiles, but it doesn't work like the other warheads: it doesn't have a Detonate button and it doesn't actually explode when the missile it's attached to collides with something. This fixes both of those issues.