### PR TITLE
Update ModuleWeapon.cs

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Armors.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Armors.cfg
@@ -152,7 +152,7 @@ ARMOR
 ARMOR
 {
     name = Reinforced Concrete 
-	localizedName = #LOC_BDArmory_Ferrocrete
+	localizedName = #LOC_BDArmory_ArmorConcrete
 	Density = 2560
 	Strength = 52
 	Hardness = 100
@@ -168,7 +168,7 @@ ARMOR
 ARMOR
 {
     name = Silicon Carbide // COADE and MIL.DTC
-	localizedName = #LOC_BDArmory_SiliconCarbide
+	localizedName = #LOC_BDArmory_ArmorSiCarbide
 	Density = 3210
 	Strength = 350
 	Hardness = 27500

--- a/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Armors.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Armors.cfg
@@ -9,7 +9,7 @@ ARMOR
 	Density = 7850 //in kg/m3
 	Strength = 840 // Ultimate Tensile Strengh, in MPa
 	Hardness = 1176 // in MPa, using Brinell
-	Yield = 700 // Yield Strength, in MPa
+	Yield = 700 // Yield Strength (for metals) or Compressive Strength(for ceramics), in MPa
 	YoungModulus = 200 // Young Modulus, in GPa
 	Ductility = 0.15 //measure of deformation/elongation; 0 is Ceramic, 1 is rubber
 	Diffusivity = 48.8 //ability to diffuse thermal energy - laser resist

--- a/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Armors.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/BulletDefs/BD_Armors.cfg
@@ -34,7 +34,7 @@ ARMOR
 	Diffusivity = 237
 	SafeUseTemp = 993
 	radarReflectivity = 1 
-	Cost = 400
+	Cost = 300
 }
 
 ARMOR
@@ -58,15 +58,15 @@ ARMOR
     name = Titanium //Beta Titanium alloy
 	localizedName = #LOC_BDArmory_ArmorTitanium
 	Density = 4506
-	Strength = 552 
+	Strength = 950 
 	Hardness = 2000
-	Yield = 330
+	Yield = 880
 	YoungModulus = 116
 	Ductility = 0.58 
 	Diffusivity = 22
 	SafeUseTemp = 703 //Titanium loses tensile strength above 430 C
 	radarReflectivity = 1
-	Cost = 5000
+	Cost = 2400
 }
 
 ARMOR
@@ -82,7 +82,7 @@ ARMOR
 	Diffusivity = 200
 	SafeUseTemp = 1830
 	radarReflectivity = 1 
-	Cost = 8000
+	Cost = 2400
 }
 
 ARMOR
@@ -92,13 +92,13 @@ ARMOR
 	Density = 1440
 	Strength = 300
 	Hardness = 10
-	Yield = 300
+	Yield = 312
 	YoungModulus = 82.2
 	Ductility = 0.035 
 	Diffusivity = 0.04
 	SafeUseTemp = 770
 	radarReflectivity = 1.1
-	Cost = 10000
+	Cost = 2400
 }
 
 ARMOR
@@ -114,7 +114,7 @@ ARMOR
 	Diffusivity = 1.35
 	SafeUseTemp = 470 //resins vulnerable to heating, 1470 for raw fibre
 	radarReflectivity = 1.2 //something something fiberlgass transparent to radar and letting sub-surface structure be reflected
-	Cost = 6600
+	Cost = 1500
 }
 
 ARMOR
@@ -122,15 +122,15 @@ ARMOR
     name = Depleted Uranium
 	localizedName = #LOC_BDArmory_ArmorDU
 	Density = 19000
-	Strength = 1720
+	Strength = 2720
 	Hardness = 3850
-	Yield = 965
+	Yield = 1490
 	YoungModulus = 170
 	Ductility = 0.15 
 	Diffusivity = 12
 	SafeUseTemp = 1623
 	radarReflectivity = 1
-	Cost = 21000
+	Cost = 10000
 }
 
 ARMOR
@@ -146,7 +146,39 @@ ARMOR
 	Diffusivity = 58
 	SafeUseTemp = 644
 	radarReflectivity = 1
-	Cost = 600
+	Cost = 500
+}
+
+ARMOR
+{
+    name = Reinforced Concrete 
+	localizedName = #LOC_BDArmory_Ferrocrete
+	Density = 2560
+	Strength = 52
+	Hardness = 100
+	Yield = 62
+	YoungModulus = 42
+	Ductility = 0.1
+	Diffusivity = 21
+	SafeUseTemp = 1900
+	radarReflectivity = 1
+	Cost = 20
+}
+
+ARMOR
+{
+    name = Silicon Carbide // COADE and MIL.DTC
+	localizedName = #LOC_BDArmory_SiliconCarbide
+	Density = 3210
+	Strength = 350
+	Hardness = 27500
+	Yield = 3900
+	YoungModulus = 460
+	Ductility = 0.005
+	Diffusivity = 13
+	SafeUseTemp = 2884
+	radarReflectivity = 1
+	Cost = 1800
 }
 ARMOR
 {

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -53,6 +53,8 @@
 	- Adjust the climb-slope limiter to allow maintaining a decent slope at high speeds (relative to min speed) even if the TWR drops to almost 0. This is particularly relevant for prop engines.
 - Armor:
 	- Limit Adjustable Armor thickness to the minimum of length / width of the armor plate to prevent unphysical armor calculations.
+	- Armor cost, some stats tweaked to be more reasonable.
+	- Adds Reinforced Concrete and Silicon Carbide armor materials.
 - Sensors:
   - Improvements to target camera target switching behavior, should no longer switch to a new target while current laser ordnance is still in the air.
   - Multiple target cam support, craft with multiple cams can now simultaneously engage multiple targets with laser ordnance, one per camera.

--- a/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Localization/UI/en-us.cfg
@@ -1644,6 +1644,8 @@ Localization
         #LOC_BDArmory_ArmorBeryllium = Beryllium
         #LOC_BDArmory_ArmorAramid = Aramid Fibre
         #LOC_BDArmory_ArmorFiberglass = S-Glass Composite
+        #LOC_BDArmory_ArmorConcrete = Reinforced Concrete
+        #LOC_BDArmory_ArmorSiCarbide = Silicon Carbide
         #LOC_BDArmory_ArmorDU = Depleted Uranium
         #LOC_BDArmory_ArmorRAM = Radar Absorbent Coating
 

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -2777,7 +2777,7 @@ namespace BDArmory.Weapons
                                             /////////////////////////////////////////////////
                                             if (!VesselModuleRegistry.IgnoredVesselTypes.Contains(p.vessel.vesselType))
                                             {
-                                                float EMPDamage = initialDamage * (pulseLaser ? 1 : TimeWarp.fixedDeltaTime) * (BDArmorySettings.DMG_MULTIPLIER / 100);
+                                                float EMPDamage = laserDamage * (pulseLaser ? 1 : TimeWarp.fixedDeltaTime) * (BDArmorySettings.DMG_MULTIPLIER / 100);
                                                 Part closestCommand = null;
                                                 float distToCommandSqr = float.PositiveInfinity; //lets find out which command part is closest to the hit
                                                 Vector3 commandDir = Vector3.zero;
@@ -2896,7 +2896,7 @@ namespace BDArmory.Weapons
                                             }
                                             else
                                             {
-                                                p.skinTemperature += (laserDamage * (pulseLaser ? 1 : TimeWarp.fixedDeltaTime * (BDArmorySettings.DMG_MULTIPLIER / 100))); //add modifier to adjust damage by armor diffusivity value?
+                                                p.skinTemperature += (initialDamage * (pulseLaser ? 1 : TimeWarp.fixedDeltaTime * (BDArmorySettings.DMG_MULTIPLIER / 100))); //add modifier to adjust damage by armor diffusivity value?
 
                                                 if (BDArmorySettings.DEBUG_WEAPONS) Debug.Log($"[BDArmory.ModuleWeapon]: Heatray Applying {damage} heat to {p.name}");
                                             }


### PR DESCRIPTION
Was reviewing weapon damage for lasers following the aperture/wavelength changes and electrolasers shouldn't be affected by tanAngle (since it's a bolt of electricity traveling down an ionized channel painted by the laser), heatrays should(since beam collimation/target area/energy delivered per cm2 based on distance), so swapping their damage vars.