### PR TITLE
Better Missile Boresight Limiting

### DIFF
--- a/BDArmory/Control/BDModulePilotAI.cs
+++ b/BDArmory/Control/BDModulePilotAI.cs
@@ -3778,20 +3778,31 @@ namespace BDArmory.Control
                             radarDir = VectorUtils.NormalizedDiff(missileThreatMB.radarTarget.lockedByRadar.vessel.CoM, vessel.CoM); // Use radar parent vessel dir
                         }
 
-                        emergencyNotch = emergencyNotch && weaponManager.isChaffing;
-                        if (evasionMissileEmergencyNotchVel > 0 && weaponManager.isChaffing && (emergencyNotch || Mathf.Abs(Vector3.Dot(vesselVel, radarDir)) > evasionMissileEmergencyNotchVel))
+                        if (!inVacuum)
                         {
-                            emergencyNotch = true;
-                            // Emergency notch, get us notched ASAP!
-                            kinematicEvasionStatus = " (Emergency Notch)";
-                            if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI) debugString.Append(" Emergency Notch!");
-                            breakDirection = vesselVel.ProjectOnPlanePreNormalized(radarDir);
+                            emergencyNotch = emergencyNotch && weaponManager.isChaffing;
+                            if (evasionMissileEmergencyNotchVel > 0 && weaponManager.isChaffing && (emergencyNotch || Mathf.Abs(Vector3.Dot(vesselVel, radarDir)) > evasionMissileEmergencyNotchVel))
+                            {
+                                emergencyNotch = true;
+                                // Emergency notch, get us notched ASAP!
+                                kinematicEvasionStatus = " (Emergency Notch)";
+                                if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_AI) debugString.Append(" Emergency Notch!");
+                                breakDirection = vesselVel.ProjectOnPlanePreNormalized(radarDir);
+                            }
+                            else
+                            {
+                                emergencyNotch = false;
+                                // Standard notch
+                                //breakDirection = NotchDir(breakDirection, radarDir, dive ? diveAngle : 0f);
+                                const float halfPi = Mathf.PI * 0.5f;
+                                breakDirection = VectorUtils.ConePlaneIntercept(breakDirection, radarDir, -vessel.up, (dive ? (halfPi - diveAngle) : halfPi));
+                            }
                         }
                         else
                         {
+                            // No need to worry about diving or emergencyNotch in a vacuum...
                             emergencyNotch = false;
-                            // Standard notch
-                            breakDirection = NotchDir(breakDirection, radarDir, dive ? diveAngle : 0f);
+                            breakDirection = vesselVel.ProjectOnPlanePreNormalized(radarDir);
                         }
                     }
                     else
@@ -3944,7 +3955,7 @@ namespace BDArmory.Control
             FlyToPosition(s, target);
         }
 
-        /// <summary>
+        /*/// <summary>
         /// Calculates the appropriate notch direction based on the direction to the radar, "radarDir",
         /// the commanded "diveAngle" (radians, +ve down, 0 is level flight), and "breakDirection", the preferred
         /// direction of travel (as there are potential two solutions).
@@ -4113,7 +4124,7 @@ namespace BDArmory.Control
 
             sol1 = new Vector3(xsol1, ysol1, zsol1);
             sol2 = new Vector3(xsol2, ysol2, zsol2);
-        }
+        }*/
 
         Vector3 MissileKinematicEvasion(Vector3 breakDirection, Vector3 threatDirection)
         {

--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -1,4 +1,11 @@
 IMPROVEMENTS / FIXES
+- Weapons:
+	- Missiles:
+		- Improved missile "maxOffBoresight" limiting. Missiles will now try to turn as hard as they can in the commanded direction while keeping the target inside "maxOffBoresight".
+		- Added new "terminalMaxOffBoresight" field to "MissileLauncher" missiles. When a missile has a "terminalGuidanceType", "terminalMaxOffBoresight" replaces "maxOffBoresight" (if specified) when targeting gets handed over to "terminalGuidanceType".
+
+v1.13.0.0
+IMPROVEMENTS / FIXES
 - General:
 	- Fix GetBodyByName("Kerbin") issues for mods that replace Kerbin.
 	- Fix HP and cost scaling of parts when TweakScale is installed.

--- a/BDArmory/Guidances/MissileGuidance.cs
+++ b/BDArmory/Guidances/MissileGuidance.cs
@@ -579,6 +579,8 @@ namespace BDArmory.Guidances
             vertVel = -vertVel;
             float ttgoVert = vertR / vertVel;
 
+            //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa ttgo: {ttgo}, ttgoPlanar: {ttgoPlanar}, ttgoVert: {ttgoVert}, vertVel: {vertVel}, vertR: {vertR}");
+
             // If going up and target is below, or target is below and going up
             if (vertVel * vertR < 0f)
             {
@@ -600,6 +602,8 @@ namespace BDArmory.Guidances
                     }
                 }
             }
+
+            //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa ttgo post-clamp: {ttgo}");
 
             // Lead limiting
             if (ttgo <= 0f)
@@ -651,11 +655,11 @@ namespace BDArmory.Guidances
             // Excess accel available to the missile
             maneuverCapability *= ml.currLiftArea * BDArmorySettings.GLOBAL_LIFT_MULTIPLIER * (float)(((Math.Abs(targetAlt - ml.vessel.altitude) < 1000d) ? q : (0.5 * (currDensity = 0.5 * (currentBody.GetDensity(currentBody.GetPressure(targetAlt), currentBody.GetTemperature(targetAlt)) + ml.vessel.atmDensity)) * sqrSpeed)) / vesselMass) * (1f + TL);
             float accelSqr = Mathf.Max(maneuverCapability - 0.5f * Rdir.ProjectOnPlanePreNormalized(velDirection).magnitude * ttgoInv * ttgoInv, 0f);
-            //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa Guidance - maneuverCapability: {maneuverCapability}, reqAccel: {0.5f * Rdir.ProjectOnPlanePreNormalized(relVelNorm).magnitude * ttgoInv * ttgoInv}, excessAccel: {accelSqr}");
+            //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa Guidance - maneuverCapability: {maneuverCapability}, reqAccel: {0.5f * Rdir.ProjectOnPlanePreNormalized(velDirection).magnitude * ttgoInv * ttgoInv}, excessAccel: {accelSqr}");
             // Target accel
             accelSqr *= targetAccel.magnitude;
             float leadTimeMax = (accelSqr > 1e-15f) ? Mathf.Clamp(2f * BDAMath.Sqrt(targetVelocity.sqrMagnitude / accelSqr), 8f, 16f) : 16f;
-            //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa Guidance - targetAccel: {(targetAccel.ProjectOnPlanePreNormalized(relVelNorm)).magnitude}, accelSqr: {accelSqr}, leadTimeMax: {leadTimeMax}, unclampedLeadTimeMax: {((accelSqr > 1e-15f) ? 2f * (relSpeed) / BDAMath.Sqrt(accelSqr) : boostGuidance ? 12f : 16f)}");
+            //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa Guidance - targetVel: {targetVelocity.magnitude}, targetAccel: {targetAccel.magnitude}, accelSqr: {accelSqr}, leadTimeMax: {leadTimeMax}, unclampedLeadTimeMax: {((accelSqr > 1e-15f) ? 2f * BDAMath.Sqrt(targetVelocity.sqrMagnitude / accelSqr) : 16f)}");
 
             leadTime = Mathf.Clamp(ttgo, 0f, leadTimeMax);
 
@@ -706,6 +710,9 @@ namespace BDArmory.Guidances
                 sinTarget = Vector3.Dot(targetTermVec, -upDirection); //Vector3.Dot((targetPosition - ml.vessel.CoM), -upDirection) / R;
 
                 boostGuidance = (midcourseRange > 0f) && (R > midcourseRange) && (sinTarget < termSin) && (-sinTarget < loftSin);
+
+                //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa Guidance - sinTarget: {sinTarget}, termSin: {termSin}, angle cond: {sinTarget > termSin}, targetTermDist: {targetTermDist}, boostGuidance: {boostGuidance}");
+
                 if (!boostGuidance && targetTermDist < 2f * terminalHomingRange && shapingAngle > 0)
                 {
                     // Modulate kappaAngle if we're really close.
@@ -715,12 +722,14 @@ namespace BDArmory.Guidances
                         shapingAngle = 0;
                         ml.kappaAngle = 0;
                         loftState = MissileBase.LoftStates.Terminal;
+                        //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa Guidance - Gone terminal at: {targetTermDist} m from PIP, shapingAngle clamped to 0!");
                     }
                     else
                     {
                         shapingAngle *= fac * fac / (terminalHomingRange * terminalHomingRange);
                         ml.kappaAngle = shapingAngle;
                         loftState = MissileBase.LoftStates.Midcourse;
+                        //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa Guidance - Gone terminal at: {targetTermDist} m from PIP, shapingAngle clamped to {shapingAngle}!");
                     }
                 }
                 if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_MISSILES)
@@ -803,6 +812,8 @@ namespace BDArmory.Guidances
                     loftState = MissileBase.LoftStates.Midcourse;
                 }
 
+                //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: turnFactor: {turnFactor}, vel: {currSpeed}, turnFactorMult: {turnFactorMult}, invTurnFactorMult: {1f / turnFactorMult}, tempgLim: {tempgLim}, propAccel: {(3f / currSpeed) * VelTripleProduct(currVel, turnDir).ProjectOnPlanePreNormalized(velDirection).magnitude / g}, curveAccel: {(currSpeed * currSpeed * turnFactorMult * loftAngle * Mathf.Deg2Rad * turnSin) / g}, gLimit: {gLimit}, AoALimit: {AoALimit}");
+
                 return ml.vessel.CoM + currVel * 3f + accel * 9f;
             }
 
@@ -833,6 +844,7 @@ namespace BDArmory.Guidances
                 float Fsqr;
                 float FR;
 
+                //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa Guidance - Lalpha: {Lalpha}, c_m: {Lalpha / (ml.vessel.totalMass * ml.vessel.srfSpeed * ml.vessel.srfSpeed)}, D0: {D0}, d_0: {D0 / (ml.vessel.totalMass * ml.vessel.srfSpeed * ml.vessel.srfSpeed)}, eta: {eta}, thrust: {thrust}, TL: {TL}, q: {q}, m^2v^4: {(ml.vessel.totalMass * ml.vessel.totalMass * ml.vessel.srfSpeed * ml.vessel.srfSpeed * ml.vessel.srfSpeed * ml.vessel.srfSpeed)}, R: {R}");
                 // The below derivation doesn't really work, I tried replacing the sin and cos with sinh and cosh, but
                 // looking at the derivation and the diff. eq. it is trying to satisfy, it is clear that the desired
                 // functions are actually sin and cos and not sinh and cosh, since the (F_2)^2 term is positive instead
@@ -851,6 +863,8 @@ namespace BDArmory.Guidances
                     {
                         K1 = -F2sqr * Rsqr / (2f + F2R);
                         K2 = F2sqr * Rsqr / (2f + F2R);
+
+                        if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]:Kappa Guidance, under thrust - F2sqr: {F2sqr}, F2R: {F2R}, eFR: Infinity, enFR: 0");
                     }
                     else
                     {
@@ -879,6 +893,8 @@ namespace BDArmory.Guidances
                     // FR values in Mathf.exp()
                     K1 = FR / (2f - FR);
                     K2 = Fsqr * Rsqr / (FR - 2f);
+
+                    //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa Guidance, gliding - Fsqr: {Fsqr}, FR: {FR}, eFR: Infinity, enFR: 0, K1: {K1}, K2: {K2}");
                 }
                 else if (FR < 0.25f)
                 {
@@ -886,6 +902,7 @@ namespace BDArmory.Guidances
                     // issues, so we just set the values to the limit as FR -> 0
                     K1 = -2;
                     K2 = 6;
+                    //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa Guidance, gliding - Fsqr: {Fsqr}, FR: {FR}, K1: -2, K2: 6");
                 }
                 else
                 {
@@ -895,6 +912,9 @@ namespace BDArmory.Guidances
 
                     K1 = (2f * Fsqr * Rsqr - FR * (eFR - enFR)) / denom;
                     K2 = (Fsqr * Rsqr * (eFR + enFR - 2f)) / denom;
+
+
+                    //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa Guidance, gliding - Fsqr: {Fsqr}, FR: {FR}, eFR: {eFR}, enFR: {enFR}, denom: {denom}, K1: {K1}, K2: {K2}");
                 }
             }
             else
@@ -925,6 +945,8 @@ namespace BDArmory.Guidances
                 if (FR > 16f)
                 {
                     K2 = Fsqr * Rsqr / (FR - 1f);
+
+                    //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa Guidance, {(thrust > D0 ? "under thrust - No Shaping - F2sqr" : "gliding - No Shaping - Fsqr")}: {Fsqr}, {(thrust > D0 ? "F2R" : "FR")}: {FR}, eFR: Infinity, enFR: 0, K1: 0, K2: {K2}");
                 }
                 else if (FR < 0.25f)
                 {
@@ -932,6 +954,7 @@ namespace BDArmory.Guidances
                     // K2 directly to 3, which is what the value converges to (which is the ideal gain for
                     // proportional navigation)
                     K2 = 3f;
+                    //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa Guidance, {(thrust > D0 ? "under thrust - No Shaping - F2sqr" : "gliding - No Shaping - Fsqr")}: {Fsqr}, {(thrust > D0 ? "F2R" : "FR")}: {FR}, K1: 0, K2: 3");
                 }
                 else
                 {
@@ -939,6 +962,8 @@ namespace BDArmory.Guidances
                     float enFR = Mathf.Exp(-FR);
 
                     K2 = (Fsqr * Rsqr * (eFR - enFR)) / (eFR * (FR - 1f) + enFR * (FR + 1f));
+
+                    //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa Guidance, {(thrust > D0 ? "under thrust - No Shaping - F2sqr" : "gliding - No Shaping - Fsqr")}: {Fsqr}, {(thrust > D0 ? "F2R" : "FR")}: {FR}, eFR: {eFR}, enFR: {enFR}, K1: 0, K2: {K2}");
                 }
             }
 
@@ -966,6 +991,7 @@ namespace BDArmory.Guidances
             // Final velocity is shaped by shapingAngle, we want the missile to dive onto the target but we don't want to affect the horizontal components of velocity
             if (shapingAngle == 0f)
             {
+                vF = currVel;
                 accel = (K2 * ttgoInv * ttgoInv) * (adjustedPredictedRelImpactPoint);
                 if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_MISSILES)
                 {
@@ -1027,7 +1053,7 @@ namespace BDArmory.Guidances
 
             // Debug output, useful for tuning
             // NOTE: Think of better way to present these, right now they're just spamming the log, maybe add them to the debug string and display it via the UI?
-            //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa Guidance K1: {K1}, K2: {K2}, accel: {accel}, vF-currVel: {vF-currVel}, posError: {predictedImpactPoint- ml.vessel.CoM - currVel*ttgo}, g: {gLimit}, ttgo: {ttgo}");
+            //if (BDArmorySettings.DEBUG_MISSILES) Debug.Log($"[BDArmory.MissileGuidance]: Kappa Guidance - R: {R}, accel: {accel}, accelVert: {Vector3.Dot(accel, upDirection)}, accelVertVel: {Vector3.Dot(((K1 * ttgoInv) * (vF - currVel)).ProjectOnPlanePreNormalized(velDirection), upDirection)}, vF-currVel: {vF - currVel}, posError: {(predictedImpactPoint - ml.vessel.CoM).ProjectOnPlanePreNormalized(velDirection)}, posErrorUnrolled: {(adjustedPredictedRelImpactPoint - ml.vessel.CoM).ProjectOnPlanePreNormalized(velDirection)}, vertPosError: {Vector3.Dot((predictedImpactPoint - ml.vessel.CoM).ProjectOnPlanePreNormalized(velDirection), upDirection)}, vertPosErrorUnrolled: {Vector3.Dot((adjustedPredictedRelImpactPoint - ml.vessel.CoM).ProjectOnPlanePreNormalized(velDirection), upDirection)}, unrolledAngle: {unrolledAngle}, altDiff: {clampedPredictedImpactAlt - predictedImpactAlt}, missileAltDiff: {clampedPredictedImpactAlt - ml.vessel.altitude - FlightGlobals.currentMainBody.Radius}, vesselVertPos: {Vector3.Dot(ml.vessel.CoM, upDirection)}, g: {gLimit}, ttgo: {ttgo}");
 
             //accel = accel.ProjectOnPlanePreNormalized(velDirection);
             leadTime = Mathf.Min(leadTime, 3f);
@@ -2411,6 +2437,7 @@ namespace BDArmory.Guidances
                 //if (ml.torqueAoALimit.x > 0)
                 //    AoALim = Mathf.Min(maxAoA + Mathf.Min(0.1f * maxAoA, 2f), 1.2f * ml.torqueAoALimit.x * ml.torqueAoALimit.y / (float)airSpeed * BDAMath.Sqrt(ml.torqueAoALimit.z / (float)airDensity));
 
+                float boresightAngle = -1f;
                 Vector3 targetDirection;
                 float targetAngle;
                 if (activeGuidance)
@@ -2427,6 +2454,20 @@ namespace BDArmory.Guidances
                         targetDirection = Vector3.Slerp(velNorm, (10f * targetDirection).ProjectOnPlanePreNormalized(velNorm).normalized, AoALim / 90f);
                     }
 
+                    Vector3 boresightVector;
+                    if (ml.maxOffBoresight < 180f && (boresightAngle = VectorUtils.AnglePreNormalized(targetDirection, boresightVector = (ml.TargetPosition - ml.vessel.CoM).normalized)) > ml.maxOffBoresight)
+                    {
+                        Vector3 maneuverPlaneNormal = (Vector3.Cross(velNorm, targetDirection)).normalized;
+                        float tempBoresight = ml.maxOffBoresight;
+                        // If boresight > 180, we solve for the opposite cone
+                        if (tempBoresight > 90f)
+                        {
+                            tempBoresight = 180f - tempBoresight;
+                            boresightVector = -boresightVector;
+                        }
+
+                        targetDirection = VectorUtils.ConePlaneIntercept(targetDirection, maneuverPlaneNormal, boresightVector, Mathf.Cos(tempBoresight * Mathf.Deg2Rad), false);
+                    }
                 }
                 else
                 {
@@ -2547,7 +2588,7 @@ namespace BDArmory.Guidances
                     finalTorque = aeroTorque;
                 }
 
-                if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_MISSILES) ml.debugString.AppendLine($"achieved g: {(ml.vessel.acceleration.ProjectOnPlanePreNormalized(velNorm).magnitude) * (1f / 9.81f):F2}, lift g: {liftForce / ml.part.mass * (1f / 9.81f):F2}, CL: {liftCurve.Evaluate(AoA):F2}\nAoA: {AoA:F2}, AoALim: {AoALim:F2}, MaxAoA: {maxAoA:F2}\nTargetAngle: {targetAngle:F2}, TurningAngle: {turningAngle:F2}, forward: {forward}, targetDirection: {targetDirection}\nmaxTorque (Aero): {maxTorque:F2} ({maxTorqueAero * dynamicq:F2}), currTorque: {(Vector3.Dot(finalTorque, aeroTorque) > 0 ? "+" : "-")}{finalTorque.magnitude:F2}, aeroTorque: -{aeroTorque.magnitude:F2}\nliftArea: {liftArea}, dragArea: {dragArea}");
+                if (BDArmorySettings.DEBUG_TELEMETRY || BDArmorySettings.DEBUG_MISSILES) ml.debugString.AppendLine($"achieved g: {(ml.vessel.acceleration.ProjectOnPlanePreNormalized(velNorm).magnitude) * (1f / 9.81f):F2}, lift g: {liftForce / ml.part.mass * (1f / 9.81f):F2}, CL: {liftCurve.Evaluate(AoA):F2}\nAoA: {AoA:F2}, AoALim: {AoALim:F2}, MaxAoA: {maxAoA:F2}{(boresightAngle > 0f ? $", Seeker Angle: {boresightAngle:F2}/{ml.maxOffBoresight:F2}" : "")}\nTargetAngle: {targetAngle:F2}, TurningAngle: {turningAngle:F2}, forward: {forward}, targetDirection: {targetDirection}\nmaxTorque (Aero): {maxTorque:F2} ({maxTorqueAero * dynamicq:F2}), currTorque: {(Vector3.Dot(finalTorque, aeroTorque) > 0 ? "+" : "-")}{finalTorque.magnitude:F2}, aeroTorque: -{aeroTorque.magnitude:F2}\nliftArea: {liftArea}, dragArea: {dragArea}");
 
                 finalTorque = ml.transform.InverseTransformDirection(finalTorque).ProjectOnPlanePreNormalized(Vector3.forward);
 

--- a/BDArmory/Utils/VectorUtils.cs
+++ b/BDArmory/Utils/VectorUtils.cs
@@ -718,5 +718,207 @@ namespace BDArmory.Utils
         /// <param name="unit">The unit to round to.</param>
         /// <returns>A new Vector3 rounded to the unit.</returns>
         public static Vector3 Rounded(this Vector3 v, float unit) => v.Round(unit);
+
+        /// <summary>
+        /// Solves for the cone-plane intersect problem, returning the solution closest to "desiredDir".
+        /// </summary>
+        /// <param name="desiredDir">Desired direction.</param>
+        /// <param name="planeNormal">Normalized normal vector of the plane.</param>
+        /// <param name="coneDir">Normalized cone direction vector.</param>
+        /// <param name="coneHalfAngle">Cone half-angle in radians.</param>
+        /// <returns>Solution of the cone-plane intercept problem.</returns>
+        public static Vector3 ConePlaneIntercept(Vector3 desiredDir, Vector3 planeNormal, Vector3 coneDir, float coneHalfAngle, bool forceCone = false)
+        {
+            // This function solves the system of equations in the form:
+            // coneDir dot V = cos(theta)
+            // planeNormal dot V = 0
+            // ||V|| = 1
+
+            // It essentially solves for the intersection of a plane and a cone, both centered at the origin,
+            // where coneDir is the cone's direction vector, and planeNormal is the normal vector of the plane.
+            // Because the solutions are lines, we close the system by enforcing unit-vector results.
+
+            float cosCone = Mathf.Cos(coneHalfAngle);
+
+            float x1 = coneDir.x;
+            float y1 = coneDir.y;
+            float z1 = coneDir.z;
+
+            float x2 = planeNormal.x;
+            float y2 = planeNormal.y;
+            float z2 = planeNormal.z;
+
+            float dot = Vector3.Dot(coneDir, planeNormal);
+
+            // Because the equation solved requires division by the appropriate component of the cross product, we
+            // must check if it isn't 0.
+            float crossx = y1 * z2 - z1 * y2;
+            if (Mathf.Abs(crossx) > Mathf.Epsilon)
+            {
+                // If it is, we can solve for the two x-solutions
+                float newCosCone = calcConePlane(x1, x2, y2, z2, crossx, dot, cosCone, forceCone, out float xsol1, out float xsol2);
+                if (forceCone && newCosCone < 1.5f)
+                {
+                    Vector3 projectedConeDir = new Vector3(
+                        coneDir.x - planeNormal.x * dot,
+                        coneDir.y - planeNormal.y * dot,
+                        coneDir.z - planeNormal.z * dot);
+                    return Vector3.RotateTowards(coneDir, projectedConeDir, coneHalfAngle, 99999f);
+                }
+                // Giving us the two vector solutions
+                calcConePlaneYZ(x1, x2, y1, y2, z1, z2, xsol1, xsol2, crossx, newCosCone, out Vector3 sol1, out Vector3 sol2);
+                // We pick the vector most aligned with breakDirection
+                if (Vector3.Dot(desiredDir, sol1) > Vector3.Dot(desiredDir, sol2))
+                {
+                    return sol1;
+                }
+                else
+                {
+                    return sol2;
+                }
+            }
+
+            // If the solving for the x-component isn't possible due to crossx being 0, we try y
+            float crossy = z1 * x2 - x1 * z2;
+            if (Mathf.Abs(crossy) > Mathf.Epsilon)
+            {
+                float newCosCone = calcConePlane(y1, y2, x2, z2, crossy, dot, cosCone, forceCone, out float ysol1, out float ysol2);
+                if (forceCone && newCosCone < 1.5f)
+                {
+                    Vector3 projectedConeDir = new Vector3(
+                        coneDir.x - planeNormal.x * dot,
+                        coneDir.y - planeNormal.y * dot,
+                        coneDir.z - planeNormal.z * dot);
+                    return Vector3.RotateTowards(coneDir, projectedConeDir, coneHalfAngle, 99999f);
+                }
+                calcConePlaneXZ(x1, x2, y1, y2, z1, z2, ysol1, ysol2, crossy, newCosCone, out Vector3 sol1, out Vector3 sol2);
+                if (Vector3.Dot(desiredDir, sol1) > Vector3.Dot(desiredDir, sol2))
+                {
+                    return sol1;
+                }
+                else
+                {
+                    return sol2;
+                }
+            }
+
+            // And if y is also zero we try z
+            float crossz = x1 * y2 - y1 * x2;
+            if (Mathf.Abs(crossz) > Mathf.Epsilon)
+            {
+                float newCosCone = calcConePlane(z1, z2, x2, y2, crossz, dot, cosCone, forceCone, out float zsol1, out float zsol2);
+                if (forceCone && newCosCone < 1.5f)
+                {
+                    Vector3 projectedConeDir = new Vector3(
+                        coneDir.x - planeNormal.x * dot,
+                        coneDir.y - planeNormal.y * dot,
+                        coneDir.z - planeNormal.z * dot);
+                    return Vector3.RotateTowards(coneDir, projectedConeDir, coneHalfAngle, 99999f);
+                }
+                calcConePlaneXY(x1, x2, y1, y2, z1, z2, zsol1, zsol2, crossz, newCosCone, out Vector3 sol1, out Vector3 sol2);
+                if (Vector3.Dot(desiredDir, sol1) > Vector3.Dot(desiredDir, sol2))
+                {
+                    return sol1;
+                }
+                else
+                {
+                    return sol2;
+                }
+            }
+
+            // If the down and radar vectors are in-line, then we have a planar solution, and we just return breakDirection
+            return desiredDir;
+        }
+
+        /// <summary>
+        /// This solves for the component corresponding to the d1/d2 values (I.E. x1/x2 solves for x) of the cone-plane intersection
+        /// problem. a2 and b2 are the two other components of the normal vector of the plane (I.E. y2, z2 for x1/x2). Due to these
+        /// being added, the order is irrelevant.
+        /// Note that if a solution isn't found, then cosCone is adjusted until there is a single solution.
+        /// </summary>
+        /// <param name="d1">Component of the cone's vector corresponding to the component to be solved for.</param>
+        /// <param name="d2">Component of the plane's normal vector corresponding to the component to be solved for.</param>
+        /// <param name="a2">Other component of the plane's normal vector (I.E. y/z for x).</param>
+        /// <param name="b2">Other component of the plane's normal vector (I.E. y/z for x).</param>
+        /// <param name="crossd">Cross product component in the direction to solve for (cone cross plane).</param>
+        /// <param name="dot">Dot product of the two vectors.</param>
+        /// <param name="cosCone">Cosine of the cone's half-angle.</param>
+        /// <param name="r1">Solution 1 of the problem.</param>
+        /// <param name="r2">Solution 2 of the problem.</param>
+        /// <returns></returns>
+        private static float calcConePlane(float d1, float d2, float a2, float b2, float crossd, float dot, float cosCone, bool forceCone, out float r1, out float r2)
+        {
+            float denominator = (1.0f - dot * dot);
+            float numerator = cosCone * (d1 - d2 * dot);
+            float determinant = numerator * numerator - denominator * (cosCone * cosCone * (a2 * a2 + b2 * b2) - crossd * crossd);
+
+            if (determinant < 0.0f)
+            {
+                if (determinant < -5e-5f)
+                {
+                    if (forceCone)
+                    {
+                        // Set cosCone to an impossible value and return
+                        cosCone = -10f;
+                        r1 = 0f;
+                        r2 = 0f;
+                        return cosCone;
+                    }
+
+                    // Otherwise solve for cosCone required for determinant to be zero
+                    cosCone = BDAMath.Sqrt(numerator * numerator / (denominator * (a2 * a2 + b2 * b2 - crossd * crossd)));
+                    determinant = 0.0f;
+                }
+                else
+                {
+                    determinant = 0.0f;
+                }
+            }
+            else
+                determinant = BDAMath.Sqrt(determinant);
+
+            r1 = (numerator - determinant) / denominator;
+            r2 = (numerator + determinant) / denominator;
+            return cosCone;
+        }
+
+        // Solves for the two other components of the solution given the X-component
+        private static void calcConePlaneYZ(float x1, float x2, float y1, float y2, float z1, float z2, float xsol1, float xsol2, float crossx, float cosCone, out Vector3 sol1, out Vector3 sol2)
+        {
+            crossx = 1.0f / crossx;
+            float ysol1 = (z1 * x2 * xsol1 + z2 * (cosCone - x1 * xsol1)) * crossx;
+            float zsol1 = -(y1 * x2 * xsol1 + y2 * (cosCone - x1 * xsol1)) * crossx;
+            float ysol2 = (z1 * x2 * xsol2 + z2 * (cosCone - x1 * xsol2)) * crossx;
+            float zsol2 = -(y1 * x2 * xsol2 + y2 * (cosCone - x1 * xsol2)) * crossx;
+
+            sol1 = new Vector3(xsol1, ysol1, zsol1);
+            sol2 = new Vector3(xsol2, ysol2, zsol2);
+        }
+
+        // Solves for the two other components of the solution given the Y-component
+        private static void calcConePlaneXZ(float x1, float x2, float y1, float y2, float z1, float z2, float ysol1, float ysol2, float crossy, float cosCone, out Vector3 sol1, out Vector3 sol2)
+        {
+            crossy = 1.0f / crossy;
+            float xsol1 = -(z1 * y2 * ysol1 + z2 * (cosCone - y1 * ysol1)) * crossy;
+            float zsol1 = (x1 * y2 * ysol1 + x2 * (cosCone - y1 * ysol1)) * crossy;
+            float xsol2 = -(z1 * y2 * ysol2 + z2 * (cosCone - y1 * ysol2)) * crossy;
+            float zsol2 = (x1 * y2 * ysol2 + x2 * (cosCone - y1 * ysol2)) * crossy;
+
+            sol1 = new Vector3(xsol1, ysol1, zsol1);
+            sol2 = new Vector3(xsol2, ysol2, zsol2);
+        }
+
+        // Solves for the two other components of the solution given the Z-component
+        private static void calcConePlaneXY(float x1, float x2, float y1, float y2, float z1, float z2, float zsol1, float zsol2, float crossz, float cosCone, out Vector3 sol1, out Vector3 sol2)
+        {
+            crossz = 1.0f / crossz;
+            float xsol1 = (y1 * z2 * zsol1 + y2 * (cosCone - z1 * zsol1)) * crossz;
+            float ysol1 = -(x1 * z2 * zsol1 + x2 * (cosCone - z1 * zsol1)) * crossz;
+            float xsol2 = (y1 * z2 * zsol2 + y2 * (cosCone - z1 * zsol2)) * crossz;
+            float ysol2 = -(x1 * z2 * zsol2 + x2 * (cosCone - z1 * zsol2)) * crossz;
+
+            sol1 = new Vector3(xsol1, ysol1, zsol1);
+            sol2 = new Vector3(xsol2, ysol2, zsol2);
+        }
     }
 }

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -234,6 +234,9 @@ namespace BDArmory.Weapons.Missiles
         [KSPField]
         public float terminalGuidanceDistance = 0.0f;
 
+        [KSPField]
+        public float terminalMaxOffBoresight = -1f;
+
         private bool terminalGuidanceActive;
 
         [KSPField(isPersistant = true, guiActive = true, guiActiveEditor = true, guiName = "#LOC_BDArmory_TerminalGuidance"), UI_Toggle(disabledText = "#LOC_BDArmory_false", enabledText = "#LOC_BDArmory_true")]//Terminal Guidance: false true
@@ -2704,19 +2707,27 @@ namespace BDArmory.Weapons.Missiles
                 // Let the primary and terminal guidance mode worry about toggling this...
                 //TargetAcquired = false;
 
+                float tempMaxOffBoresight = terminalMaxOffBoresight > 0 ? terminalMaxOffBoresight : maxOffBoresight;
+
                 switch (TargetingModeTerminal)
                 {
                     case TargetingModes.Heat:
                         // gets ground heat targets and after locking one, disallows the lock to break to another target
+                        Ray targetRay = new Ray(vessel.CoM, tempTargetPos - vessel.CoM);
+                        Vector3 forward = GetForwardTransform();
+
+                        if (VectorUtils.AnglePreNormalized(targetRay.direction, forward) > tempMaxOffBoresight)
+                        {
+                            break;
+                        }
 
                         if (activeRadarRange < 0 && torpedo)
                         {
-                            heatTarget = BDATargetManager.GetAcousticTarget(SourceVessel, vessel, new Ray(vessel.CoM, tempTargetPos - vessel.CoM), TargetSignatureData.noTarget, lockedSensorFOV * 0.5f, heatThreshold, targetCoM, lockedSensorFOVBias, lockedSensorVelocityBias, lockedSensorVelocityMagnitudeBias, lockedSensorMinAngularVelocity,
-                                FiredByWM, targetVessel, IFF: hasIFF);
+                            heatTarget = BDATargetManager.GetAcousticTarget(SourceVessel, vessel, targetRay, TargetSignatureData.noTarget, lockedSensorFOV * 0.5f, heatThreshold, targetCoM, lockedSensorFOVBias, lockedSensorVelocityBias, lockedSensorVelocityMagnitudeBias, lockedSensorMinAngularVelocity, FiredByWM, targetVessel, IFF: hasIFF);
                         }
                         else
                         {
-                            heatTarget = BDATargetManager.GetHeatTarget(SourceVessel, vessel, new Ray(vessel.CoM, tempTargetPos - vessel.CoM), TargetSignatureData.noTarget, lockedSensorFOV * 0.5f, heatThreshold, frontAspectHeatModifier, uncagedLock, targetCoM, lockedSensorFOVBias, lockedSensorVelocityBias, lockedSensorVelocityMagnitudeBias, lockedSensorMinAngularVelocity, FiredByWM, targetVessel, IFF: hasIFF);
+                            heatTarget = BDATargetManager.GetHeatTarget(SourceVessel, vessel, targetRay, TargetSignatureData.noTarget, lockedSensorFOV * 0.5f, heatThreshold, frontAspectHeatModifier, uncagedLock, targetCoM, lockedSensorFOVBias, lockedSensorVelocityBias, lockedSensorVelocityMagnitudeBias, lockedSensorMinAngularVelocity, FiredByWM, targetVessel, IFF: hasIFF);
                         }
 
                         if (heatTarget.exists && (heatTarget.isDecoy || CheckTargetEngagementEnvelope(heatTarget.targetInfo)))
@@ -2778,7 +2789,7 @@ namespace BDArmory.Weapons.Missiles
                         if (pingRWR) nextRWRPing = Time.time + RadarUtils.ACTIVE_MISSILE_PING_PERSIST_TIME;
 
                         //RadarUtils.UpdateRadarLock(ray, maxOffBoresight, activeRadarMinThresh, ref scannedTargets, 0.4f, true, RadarWarningReceiver.RWRThreatTypes.MissileLock, true);
-                        int numLocked = RadarUtils.RadarUpdateMissileLock(ray, maxOffBoresight, ref scannedTargets, RadarUtils.ACTIVE_MISSILE_PING_PERSIST_TIME, this, pingRWR);
+                        int numLocked = RadarUtils.RadarUpdateMissileLock(ray, tempMaxOffBoresight, ref scannedTargets, RadarUtils.ACTIVE_MISSILE_PING_PERSIST_TIME, this, pingRWR);
                         float sqrThresh = terminalGuidanceDistance * terminalGuidanceDistance * 2.25f; // (terminalGuidanceDistance * 1.5f)^2
 
                         //float smallestAngle = maxOffBoresight;
@@ -2896,6 +2907,7 @@ namespace BDArmory.Weapons.Missiles
                     {
                         seekerTimeout = terminalSeekerTimeout;
                     }
+                    maxOffBoresight = tempMaxOffBoresight;
                     terminalGuidanceActive = true;
                     terminalGuidanceShouldActivate = false;
                     _lockFailTimer = -1; // Reset lockFailTimer
@@ -3824,10 +3836,14 @@ namespace BDArmory.Weapons.Missiles
                         }
                 }
 
-                if (VectorUtils.Angle(aamTarget - vessel.CoM, transform.forward) > maxOffBoresight * 0.75f)
+                /*Vector3 forward = GetForwardTransform();
+                if (VectorUtils.Angle(aamTarget - vessel.CoM, forward) > maxOffBoresight)
                 {
-                    aamTarget = TargetPosition;
-                }
+                    //aamTarget = Vector3.RotateTowards(TargetPosition - vessel.CoM, aamTarget - vessel.CoM, maxOffBoresight * Mathf.Deg2Rad, 99999f) + vessel.CoM;
+                    Vector3 relativeVec = aamTarget - vessel.CoM;
+                    Vector3 maneuverPlaneNormal = (Vector3.Cross(vessel.Velocity(), relativeVec)).normalized;
+                    aamTarget = VectorUtils.ConePlaneIntercept(relativeVec, maneuverPlaneNormal, forward, maxOffBoresight * Mathf.Deg2Rad, false);
+                }*/
 
                 /*//proxy detonation
                 var distThreshold = 0.5f * GetBlastRadius();
@@ -3859,14 +3875,14 @@ namespace BDArmory.Weapons.Missiles
             {
                 if (TargetAcquired)
                 {
-                    //lose lock if seeker reaches gimbal limit
+                    /*//lose lock if seeker reaches gimbal limit
                     float targetViewAngle = VectorUtils.Angle(transform.forward, TargetPosition - vessel.CoM);
 
                     if (targetViewAngle > maxOffBoresight)
                     {
                         if (BDArmorySettings.DEBUG_MISSILES) Debug.Log("[BDArmory.MissileLauncher]: AGM Missile guidance failed - target out of view");
                         guidanceActive = false;
-                    }
+                    }*/
                     CheckMiss();
                 }
                 else
@@ -3902,10 +3918,10 @@ namespace BDArmory.Weapons.Missiles
                 float timeToImpact;
                 SLWTarget = MissileGuidance.GetAirToAirTarget(TargetPosition, TargetVelocity, TargetAcceleration, vessel, out timeToImpact, optimumAirspeed);
                 if (!torpedo) runningDepth = Mathf.Max(timeToImpact / 5, 0.1f) * 10;
-                if (VectorUtils.Angle(SLWTarget - vessel.CoM, transform.forward) > maxOffBoresight * 0.75f)
-                {
-                    SLWTarget = TargetPosition;
-                }
+                //if (VectorUtils.Angle(SLWTarget - vessel.CoM, transform.forward) > maxOffBoresight * 0.75f)
+                //{
+                //    SLWTarget = TargetPosition;
+                //}
                 if (!torpedo) SLWTarget = SLWTarget - targetVessel.Vessel.up * targetVessel.Vessel.radarAltitude;
                 float longitudinalOffset = 0;
                 if (longitudinalOffset == 0) longitudinalOffset = targetVessel.Vessel.GetRadius() * 0.75f * UnityEngine.Random.Range(-1, 1);

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -4853,7 +4853,7 @@ namespace BDArmory.Weapons.Missiles
                             output.AppendLine($"- Lock/Track: {RadarUtils.MISSILE_DEFAULT_LOCKABLE_RCS} m^2 @ {activeRadarRange / 1000} km");
                         output.AppendLine($"- LOAL: {radarLOAL}");
                         if (radarLOAL) output.AppendLine($"  - Radar Search Time: {tempTerminalSeekerTimeout} s");
-                        output.AppendLine($"Max Offboresight: {maxOffBoresight}");
+                        output.AppendLine($"Max Off Boresight: {(terminalMaxOffBoresight > 0 ? terminalMaxOffBoresight : maxOffBoresight)}");
                         output.AppendLine($"Locked FOV: {lockedSensorFOV}");
                     }
 
@@ -4861,7 +4861,7 @@ namespace BDArmory.Weapons.Missiles
                     {
                         output.AppendLine($"Uncaged Lock: {uncagedLock}");
                         output.AppendLine($"Min Heat threshold: {heatThreshold}");
-                        output.AppendLine($"Max Offboresight: {maxOffBoresight}");
+                        output.AppendLine($"Max Off Boresight: {(terminalMaxOffBoresight > 0 ? terminalMaxOffBoresight : maxOffBoresight)}");
                         output.AppendLine($"Locked FOV: {lockedSensorFOV}");
                         output.AppendLine($"Seeker Search Time: {tempTerminalSeekerTimeout} s");
                     }

--- a/BDArmory/Weapons/Missiles/MissileLauncher.cs
+++ b/BDArmory/Weapons/Missiles/MissileLauncher.cs
@@ -4535,7 +4535,13 @@ namespace BDArmory.Weapons.Missiles
             homingModeTerminal = ParseHomingType(terminalHomingType);
 
             if (TargetingMode == TargetingModes.Gps)
+            {
+                if (TargetingModeTerminal != TargetingModes.None)
+                {
+                    terminalMaxOffBoresight = maxOffBoresight;
+                }
                 maxOffBoresight = 180;
+            }
 
             if (!terminalHoming && GuidanceMode == GuidanceModes.AAMLoft)
             {


### PR DESCRIPTION
- Improve missile boresight limiting using cone-plane intersection. The missile will now try to turn on the "maneuver plane" between the velocity vector and the desired turn direction, while respecting the maxOffboresight angle.
- Added "terminalMaxOffBoresight" to MissileLauncher, which replaces the terminal seeker's maxOffboresight capability. Note that "lockedSensorFOV" could get the same treatment (though I think it's not strictly necessary at the moment)