### PR TITLE
Adjust ammo defs

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/Resources/BDAmmo_Universal.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Resources/BDAmmo_Universal.cfg
@@ -1,4 +1,4 @@
-// Warning: The values contained within are valid for the current version of BDA (ksp122). Do not use these configs in earlier versions.
+// Warning: The values contained within are valid for the current version of BDArmory. Do not use these configs in earlier versions.
 
 RESOURCE_DEFINITION
 {

--- a/BDArmory/Distribution/GameData/BDArmory/Resources/BDAmmo_Universal.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Resources/BDAmmo_Universal.cfg
@@ -1,10 +1,10 @@
-// Warning the values contained within are valid  for the current version of BDA (ksp122) do not use these cfgs in earlier versions 
+// Warning: The values contained within are valid for the current version of BDA (ksp122). Do not use these configs in earlier versions.
 
 RESOURCE_DEFINITION
 {
 	name = LaserBolt
 	title = Laser Plasma
-	density = .000168    // 1k 268kg
+	density = 0.000168    // 1k 168kg
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
@@ -14,7 +14,7 @@ RESOURCE_DEFINITION
 {
 	name = 7.62x39Ammo
 	title = 7.62x39 mm Ammo
-	density = .000268    // 1k 268kg
+	density = 0.000268    // 1k 268kg
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
@@ -25,7 +25,7 @@ RESOURCE_DEFINITION
 	name = 7.7x56Ammo
 	title = 7.7x56 mm Ammo
 	abbreviation = 7.7/56
-	density = .000259 //1k 259kg
+	density = 0.000259 //1k 259kg
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
@@ -35,7 +35,7 @@ RESOURCE_DEFINITION
 	name = 7.92x57mmMauser
 	title = 7.92x57mm Mau Ammo
 	abbreviation = 7.92Mau
-	density = .0001     //1k 100kg
+	density = 0.0001     //1k 100kg
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
@@ -54,7 +54,7 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
 	name = 50CalAmmo
-	density = .000116942
+	density = 0.000116942
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
@@ -63,19 +63,19 @@ RESOURCE_DEFINITION
 //20x21Ammo
 RESOURCE_DEFINITION
 {
-name = 20x21Ammo
-title 20x21 mm Ammo
-abbreviation = 20/21
-density = 0.00011 //1k 110kg
-flowMode = STACK_PRIORITY_SEARCH
-transfer = PUMP
-isTweakable = true
+	name = 20x21Ammo
+	title = 20x21 mm Ammo
+	abbreviation = 20/21
+	density = 0.00011 //1k 110kg
+	flowMode = STACK_PRIORITY_SEARCH
+	transfer = PUMP
+	isTweakable = true
 }
 
 RESOURCE_DEFINITION
 {
 	name = 20x102Ammo
-	density = .000259
+	density = 0.000259
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
@@ -86,7 +86,7 @@ RESOURCE_DEFINITION
 	name = 20x163Ammo
 	title = 20x163 mm Ammo
 	abbreviation = 20/163
-	density = .0007 //1k 700kg
+	density = 0.0007 //1k 700kg
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
@@ -205,21 +205,10 @@ RESOURCE_DEFINITION
 }
 RESOURCE_DEFINITION
 {
-name = 57x438Ammo
-title = 57x438 mm Ammo
-abbreviation = 57/438
-density = .005675 
-flowMode = STACK_PRIORITY_SEARCH
-transfer = PUMP
-isTweakable = true
-}
-
-RESOURCE_DEFINITION
-{
-	name = TungstenShell
-	title = Tungsten Shell
-	abbreviation = Tung
-	density = .015968
+	name = 57x438Ammo
+	title = 57x438 mm Ammo
+	abbreviation = 57/438
+	density = 0.005675 
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
@@ -227,25 +216,36 @@ RESOURCE_DEFINITION
 
 RESOURCE_DEFINITION
 {
-name = 75x714Ammo
-title = 75x714 mm Ammo
-abbreviation = 75/714
-density = .00151
-flowMode = STACK_PRIORITY_SEARCH
-transfer = PUMP
-isTweakable = true
+	name = TungstenShell
+	title = Tungsten Shell
+	abbreviation = Tung
+	density = 0.015968
+	flowMode = STACK_PRIORITY_SEARCH
+	transfer = PUMP
+	isTweakable = true
+}
+
+RESOURCE_DEFINITION
+{
+	name = 75x714Ammo
+	title = 75x714 mm Ammo
+	abbreviation = 75/714
+	density = 0.00151
+	flowMode = STACK_PRIORITY_SEARCH
+	transfer = PUMP
+	isTweakable = true
 }
 
 ////76x636Ammo12.5 kg
 RESOURCE_DEFINITION
 {
-name = 76x636Ammo
-title = 76x636mm Ammo
-abbreviation = 76/636
-density = 0.0125
-flowMode = STACK_PRIORITY_SEARCH
-transfer = PUMP
-isTweakable = true
+	name = 76x636Ammo
+	title = 76x636mm Ammo
+	abbreviation = 76/636
+	density = 0.0125
+	flowMode = STACK_PRIORITY_SEARCH
+	transfer = PUMP
+	isTweakable = true
 }
 
 RESOURCE_DEFINITION
@@ -354,7 +354,7 @@ RESOURCE_DEFINITION
 	name = 5/62Shell  // 182 xkm 32.6 860ms
 	title = 5 inch/62 Shell
 	abbreviation = 5" //127
-	density = .03268
+	density = 0.03268
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
@@ -365,7 +365,7 @@ RESOURCE_DEFINITION
 	name = QF5-25Shell //133.35c  184 10km 35 860
 	title = 5inch1/4  Shell
 	abbreviation = 5.25"
-	density = .03568
+	density = 0.03568
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
@@ -466,7 +466,7 @@ RESOURCE_DEFINITION
 {
 	name = M65ShellAmmo
 	title = M65 Shell
-	density = .8522
+	density = 0.8522
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
@@ -529,7 +529,7 @@ RESOURCE_DEFINITION
 	name = ATRocket
 	title = Anti-Tank Rocket
 	abbreviation = ATRa
-	density = .008212 //10 8.2?
+	density = 0.008212 //10 8.2?
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
@@ -539,7 +539,7 @@ RESOURCE_DEFINITION
 	name = Hades122Rocket
 	title = Hades 122mm UG Rocket
 	abbreviation = Had122	
-	density = .0322 //10 322
+	density = 0.0322 //10 322
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
@@ -549,7 +549,7 @@ RESOURCE_DEFINITION
 	name = Hydra70Rocket
 	title = Hydra-70 rockets
 	abbreviation = Hyd70
-	density = .0122
+	density = 0.0122
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
@@ -560,7 +560,7 @@ RESOURCE_DEFINITION
 	name = S-8KOMRocket
 	title = S-8KOM rockets
 	abbreviation = S8
-	density = .0113
+	density = 0.0113
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true
@@ -570,7 +570,7 @@ RESOURCE_DEFINITION
 	name = Rockets
 	title = Rockets
 	abbreviation = Rockets
-	density = .01
+	density = 0.01
 	flowMode = STACK_PRIORITY_SEARCH
 	transfer = PUMP
 	isTweakable = true


### PR DESCRIPTION
Some minor fixes, it essentially just makes BDAmmo_Universal.cfg easier to read [proper formatting] and fixes the 20x21 mm ammo's title.